### PR TITLE
Allow building by module ID in top level

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,4 +28,4 @@ rec {
   bundle-image = pkgs.callPackage ./bundle-image { inherit bundle registry bundle-stable registry-stable revstring; };
 
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };
-}
+} // modules


### PR DESCRIPTION
# Why?

Want to build a module via ID from remote like:

```
nix profile install github:replit/nixmodules#"'nodejs-18.12-m1.1'"
```

## Change

Added each module by its full ID as a attribute of packages.