### PR TITLE
bundle: add bundle-locked output generated from lockfile

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,179 @@
+{
+  "modules": {
+    "bun-0.5-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/nqwdhvs2n6fv82nkn77rg5wb3g1giwjs-replit-module-bun-0.5-m1.0"
+    },
+    "c-14.0-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/c8v74sbwivlj0mridwsdng883frwccy5-replit-module-c-14.0-m1.0"
+    },
+    "clojure-1.11-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/dsx4w6inr69f6c799qija5nf08q1ds39-replit-module-clojure-1.11-m1.0"
+    },
+    "cpp-14.0-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/065sbbghckzyirbxq239s4y3bcsr2wq2-replit-module-cpp-14.0-m1.0"
+    },
+    "dart-2.18-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/ampynbffmbjckc4xqzndlhbxncdljqfv-replit-module-dart-2.18-m1.0"
+    },
+    "dotnet-7.0-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/nkq2y69kfbbjxrr9dvc385nskqs0cd67-replit-module-dotnet-7.0-m1.0"
+    },
+    "go-1.19-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/g1vrclpr65ynpldn7a6yvjsniaj3fb3r-replit-module-go-1.19-m1.0"
+    },
+    "haskell-9.0-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/7l7mafijx1lrxs85k6vzr3q5xzxi02fb-replit-module-haskell-9.0-m1.0"
+    },
+    "java-22.3-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/v09kxcfkm66bks2lxv5hknxh8i4ijzq9-replit-module-java-22.3-m1.0"
+    },
+    "lua-5.2-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/3g185mb4bzn2g9w0b7shw39x6ybby0g6-replit-module-lua-5.2-m1.0"
+    },
+    "nodejs-14.21-m1.1": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/w07xavsw4n83rc8viwpia0q94vawm7ca-replit-module-nodejs-14.21-m1.1"
+    },
+    "nodejs-16.18-m1.1": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/f86gwahsy4xkksxy7dx8nmnkc59pjxbs-replit-module-nodejs-16.18-m1.1"
+    },
+    "nodejs-18.12-m1.1": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/snnaxxr6c6q816y4wvwcdifcf3ccd6al-replit-module-nodejs-18.12-m1.1"
+    },
+    "nodejs-19.1-m1.1": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/4x8rdnv3vr4fifql701w0ivzakhrq41d-replit-module-nodejs-19.1-m1.1"
+    },
+    "php-8.1-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/z9x4avlw2s0cmaqglbzb3ymb7cgv7hm4-replit-module-php-8.1-m1.0"
+    },
+    "python-3.10-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/jbnx31bxgv328fbsvdj8896frwlpbwlj-replit-module-python-3.10-m1.0"
+    },
+    "qbasic-0.0-m1.1": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/rpb9dg8c8cwiszfxa1xhw7z06yh59vn3-replit-module-qbasic-0.0-m1.1"
+    },
+    "r-4.2-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/c7wcs687dkxvfak0dr2gnb5ll69bv6yf-replit-module-r-4.2-m1.0"
+    },
+    "ruby-3.1-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/rxmyz9gv677v06jz64pqs7a9g2ppw0mj-replit-module-ruby-3.1-m1.0"
+    },
+    "rust-1.64-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/v2wq17m6chbxgv4vk2r4p4bqjp5r80vn-replit-module-rust-1.64-m1.0"
+    },
+    "swift-5.6-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/nva192a313k246j5a787x00hpljbwxxx-replit-module-swift-5.6-m1.0"
+    },
+    "web-3.0-m1.0": {
+      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
+      "created": "2023-05-09T07:10:11-07:00",
+      "path": "/nix/store/37kafc7qxhji91175lgccmn2yx1dzw9m-replit-module-web-3.0-m1.0"
+    }
+  },
+  "aliases": {
+    "bun": "bun-0.5-m1.0",
+    "bun-0.5": "bun-0.5-m1.0",
+    "bun-0.5-m1": "bun-0.5-m1.0",
+    "c": "c-14.0-m1.0",
+    "c-14.0": "c-14.0-m1.0",
+    "c-14.0-m1": "c-14.0-m1.0",
+    "clojure": "clojure-1.11-m1.0",
+    "clojure-1.11": "clojure-1.11-m1.0",
+    "clojure-1.11-m1": "clojure-1.11-m1.0",
+    "cpp": "cpp-14.0-m1.0",
+    "cpp-14.0": "cpp-14.0-m1.0",
+    "cpp-14.0-m1": "cpp-14.0-m1.0",
+    "dart": "dart-2.18-m1.0",
+    "dart-2.18": "dart-2.18-m1.0",
+    "dart-2.18-m1": "dart-2.18-m1.0",
+    "dotnet": "dotnet-7.0-m1.0",
+    "dotnet-7.0": "dotnet-7.0-m1.0",
+    "dotnet-7.0-m1": "dotnet-7.0-m1.0",
+    "go": "go-1.19-m1.0",
+    "go-1.19": "go-1.19-m1.0",
+    "go-1.19-m1": "go-1.19-m1.0",
+    "haskell": "haskell-9.0-m1.0",
+    "haskell-9.0": "haskell-9.0-m1.0",
+    "haskell-9.0-m1": "haskell-9.0-m1.0",
+    "java": "java-22.3-m1.0",
+    "java-22.3": "java-22.3-m1.0",
+    "java-22.3-m1": "java-22.3-m1.0",
+    "lua": "lua-5.2-m1.0",
+    "lua-5.2": "lua-5.2-m1.0",
+    "lua-5.2-m1": "lua-5.2-m1.0",
+    "nodejs": "nodejs-19.1-m1.1",
+    "nodejs-14.21": "nodejs-14.21-m1.1",
+    "nodejs-14.21-m1": "nodejs-14.21-m1.1",
+    "nodejs-16.18": "nodejs-16.18-m1.1",
+    "nodejs-16.18-m1": "nodejs-16.18-m1.1",
+    "nodejs-18.12": "nodejs-18.12-m1.1",
+    "nodejs-18.12-m1": "nodejs-18.12-m1.1",
+    "nodejs-19.1": "nodejs-19.1-m1.1",
+    "nodejs-19.1-m1": "nodejs-19.1-m1.1",
+    "php": "php-8.1-m1.0",
+    "php-8.1": "php-8.1-m1.0",
+    "php-8.1-m1": "php-8.1-m1.0",
+    "python": "python-3.10-m1.0",
+    "python-3.10": "python-3.10-m1.0",
+    "python-3.10-m1": "python-3.10-m1.0",
+    "qbasic": "qbasic-0.0-m1.1",
+    "qbasic-0.0": "qbasic-0.0-m1.1",
+    "qbasic-0.0-m1": "qbasic-0.0-m1.1",
+    "r": "r-4.2-m1.0",
+    "r-4.2": "r-4.2-m1.0",
+    "r-4.2-m1": "r-4.2-m1.0",
+    "ruby": "ruby-3.1-m1.0",
+    "ruby-3.1": "ruby-3.1-m1.0",
+    "ruby-3.1-m1": "ruby-3.1-m1.0",
+    "rust": "rust-1.64-m1.0",
+    "rust-1.64": "rust-1.64-m1.0",
+    "rust-1.64-m1": "rust-1.64-m1.0",
+    "swift": "swift-5.6-m1.0",
+    "swift-5.6": "swift-5.6-m1.0",
+    "swift-5.6-m1": "swift-5.6-m1.0",
+    "web": "web-3.0-m1.0",
+    "web-3.0": "web-3.0-m1.0",
+    "web-3.0-m1": "web-3.0-m1.0"
+  }
+}

--- a/pkgs/bundle-locked/default.nix
+++ b/pkgs/bundle-locked/default.nix
@@ -1,0 +1,29 @@
+{ pkgs, self, revstring, } :
+
+with pkgs.lib;
+
+let
+
+  modulesLocks = (builtins.fromJSON (builtins.readFile ../../modules.json)).modules;
+
+  commits = unique (catAttrs "commit" (builtins.attrValues modulesLocks));
+
+  flakes = builtins.listToAttrs (
+    map (commit: {
+      name = commit;
+      value = builtins.getFlake "github:replit/nixmodules/${commit}";
+    }) commits);
+
+  modules = builtins.mapAttrs (name: module:
+    let
+      m = (flakes.${module.commit}).modules.${name};
+    in
+      # verify the outpath matches what the lockfile expects
+      assert m.outPath == module.path;
+      m) modulesLocks;
+
+in
+
+pkgs.linkFarm "nixmodules-bundle-${revstring}" (
+    mapAttrsToList (name: value: { inherit name; path = value;}) modules
+)

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,6 +25,8 @@ rec {
 
   rev_long = pkgs.writeText "rev_long" revstring_long;
 
+  bundle-locked = pkgs.callPackage ./bundle-locked { inherit self revstring; };
+
   bundle-image = pkgs.callPackage ./bundle-image { inherit bundle registry bundle-stable registry-stable revstring; };
 
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };


### PR DESCRIPTION
Why
===
* Being able to do the building in Nix makes it easier to integrate with other tools.

What changed
===
* Added a new output bundle-locked, which is the bundle generated from the lockfile