### PR TITLE
bundle-image: remove stable input; add lockfile to bundle-image

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,25 +15,6 @@
         "type": "github"
       }
     },
-    "nixmodules-stable": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1681237040,
-        "narHash": "sha256-fKB55nXVg5yR5WLaPwO1XVEki1DBZ5I4xap23ANqzIE=",
-        "owner": "replit",
-        "repo": "nixmodules",
-        "rev": "d77c07009d6d0e09eaf7aa011cad530a644eca01",
-        "type": "github"
-      },
-      "original": {
-        "owner": "replit",
-        "repo": "nixmodules",
-        "rev": "d77c07009d6d0e09eaf7aa011cad530a644eca01",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1670276674,
@@ -54,22 +35,6 @@
       "locked": {
         "lastModified": 1670276674,
         "narHash": "sha256-FqZ7b2RpoHQ/jlG6JPcCNmG/DoUPCIvyaropUDFhF3Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1670276674,
-        "narHash": "sha256-FqZ7b2RpoHQ/jlG6JPcCNmG/DoUPCIvyaropUDFhF3Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04",
@@ -85,7 +50,7 @@
     "prybar": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1683237785,
@@ -104,8 +69,7 @@
     },
     "root": {
       "inputs": {
-        "nixmodules-stable": "nixmodules-stable",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "prybar": "prybar"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,9 @@
 {
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=52e3e80afff4b16ccb7c52e9f0f5220552f03d04";
-  inputs.nixmodules-stable.url = "github:replit/nixmodules?rev=d77c07009d6d0e09eaf7aa011cad530a644eca01";
   inputs.prybar.url = "github:replit/prybar?rev=65f486534054665f1b333689417c39acd370d3a5";
 
-  outputs = { self, nixpkgs, nixmodules-stable, prybar, ... }:
+  outputs = { self, nixpkgs, prybar, ... }:
     let
       mkPkgs = system: import nixpkgs {
         inherit system;
@@ -19,7 +18,7 @@
       };
       formatter.x86_64-linux = pkgs.nixpkgs-fmt;
       packages.x86_64-linux = import ./pkgs {
-        inherit pkgs self nixpkgs nixmodules-stable; 
+        inherit pkgs self;
       };
       devShells.x86_64-linux.default = pkgs.mkShell {
         packages = with pkgs; [

--- a/pkgs/bundle-image/default.nix
+++ b/pkgs/bundle-image/default.nix
@@ -1,4 +1,4 @@
-{runCommand, lib, bundle, bundle-stable, registry, registry-stable, revstring, lkl, coreutils, findutils, e2fsprogs, gnutar, gzip, closureInfo } :
+{runCommand, lib, bundle-locked, revstring, lkl, coreutils, findutils, e2fsprogs, gnutar, gzip, closureInfo } :
 
 let
   blockSize = toString (4 * 1024); # ext4fs block size (not block device sector size)
@@ -14,7 +14,9 @@ let
 
   label = "nixmodules-${revstring}";
 
-  diskClosureInfo = closureInfo { rootPaths = [bundle bundle-stable]; };
+  registry = ../../modules.json;
+
+  diskClosureInfo = closureInfo { rootPaths = [bundle-locked registry]; };
 
 in
 
@@ -45,8 +47,7 @@ runCommand label {} ''
 
   xargs -I % cp -a --reflink=auto % $root/nix/store/ < ${diskClosureInfo}/store-paths
 
-  cp -a --reflink=auto ${registry} $root/etc/nixmodules/beta-registry.json
-  cp -a --reflink=auto ${registry-stable} $root/etc/nixmodules/stable-registry.json
+  cp -a --reflink=auto ${registry} $root/etc/nixmodules/modules.json
 
   diskImage=disk.raw
 

--- a/pkgs/bundle-locked/default.nix
+++ b/pkgs/bundle-locked/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, self, revstring, } :
+{ pkgs, revstring, } :
 
 with pkgs.lib;
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nixpkgs, nixmodules-stable, self }:
+{ pkgs, self }:
 
 with pkgs.lib;
 
@@ -15,19 +15,13 @@ rec {
     mapAttrsToList (name: value: { inherit name; path = value;}) modules
   );
 
-  bundle-stable = nixmodules-stable.packages.${pkgs.system}.bundle;
-
-  registry = pkgs.writeTextFile { name = "registry.json"; text = builtins.toJSON modules;};
-
-  registry-stable = nixmodules-stable.packages.${pkgs.system}.registry;
-
   rev = pkgs.writeText "rev" revstring;
 
   rev_long = pkgs.writeText "rev_long" revstring_long;
 
-  bundle-locked = pkgs.callPackage ./bundle-locked { inherit self revstring; };
+  bundle-locked = pkgs.callPackage ./bundle-locked { inherit revstring; };
 
-  bundle-image = pkgs.callPackage ./bundle-image { inherit bundle registry bundle-stable registry-stable revstring; };
+  bundle-image = pkgs.callPackage ./bundle-image { inherit bundle-locked revstring; };
 
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };
 } // modules


### PR DESCRIPTION
Why
===
* If we have lockfiles and aliases, it doesn't seem necessary to also have Stable and Beta registries.
* We want to get the new lockfile in the image

What changed
===
* Removed nixmodules-stable input and everything depending on it
* Add modules.json to bundle-image at path /etc/nixmodules/modules.json

Test plan
===
* `nix build .#bundle-image` worked
* will check to make sure the lockfile is available