### PR TITLE
bundle-image-tarball: fix directory structure

### DIFF
--- a/pkgs/bundle-image-tarball/default.nix
+++ b/pkgs/bundle-image-tarball/default.nix
@@ -7,5 +7,5 @@ in
 runCommand label {} ''
   echo "making tarball..."
   mkdir -p $out
-  tar --use-compress-program=${pigz}/bin/pigz -Scf $out/disk.raw.tar.gz ${bundle-image}/disk.raw
+  tar --use-compress-program=${pigz}/bin/pigz -Scf $out/disk.raw.tar.gz -C ${bundle-image} disk.raw
 ''


### PR DESCRIPTION
Why
===
* The tarball should just contain disk.raw at the top level, but instead it had /nix/store/...disk.raw

What changed
===
* Strip off that path

Test plan
===
* Built it and extracted the tarball to confirm it is just the disk.raw file