### PR TITLE
Node.js major version only

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -50,26 +50,6 @@
       "created": "2023-05-09T07:10:11-07:00",
       "path": "/nix/store/3g185mb4bzn2g9w0b7shw39x6ybby0g6-replit-module-lua-5.2-m1.0"
     },
-    "nodejs-14.21-m1.1": {
-      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
-      "created": "2023-05-09T07:10:11-07:00",
-      "path": "/nix/store/w07xavsw4n83rc8viwpia0q94vawm7ca-replit-module-nodejs-14.21-m1.1"
-    },
-    "nodejs-16.18-m1.1": {
-      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
-      "created": "2023-05-09T07:10:11-07:00",
-      "path": "/nix/store/f86gwahsy4xkksxy7dx8nmnkc59pjxbs-replit-module-nodejs-16.18-m1.1"
-    },
-    "nodejs-18.12-m1.1": {
-      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
-      "created": "2023-05-09T07:10:11-07:00",
-      "path": "/nix/store/snnaxxr6c6q816y4wvwcdifcf3ccd6al-replit-module-nodejs-18.12-m1.1"
-    },
-    "nodejs-19.1-m1.1": {
-      "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
-      "created": "2023-05-09T07:10:11-07:00",
-      "path": "/nix/store/4x8rdnv3vr4fifql701w0ivzakhrq41d-replit-module-nodejs-19.1-m1.1"
-    },
     "php-8.1-m1.0": {
       "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
       "created": "2023-05-09T07:10:11-07:00",
@@ -142,15 +122,6 @@
     "lua": "lua-5.2-m1.0",
     "lua-5.2": "lua-5.2-m1.0",
     "lua-5.2-m1": "lua-5.2-m1.0",
-    "nodejs": "nodejs-19.1-m1.1",
-    "nodejs-14.21": "nodejs-14.21-m1.1",
-    "nodejs-14.21-m1": "nodejs-14.21-m1.1",
-    "nodejs-16.18": "nodejs-16.18-m1.1",
-    "nodejs-16.18-m1": "nodejs-16.18-m1.1",
-    "nodejs-18.12": "nodejs-18.12-m1.1",
-    "nodejs-18.12-m1": "nodejs-18.12-m1.1",
-    "nodejs-19.1": "nodejs-19.1-m1.1",
-    "nodejs-19.1-m1": "nodejs-19.1-m1.1",
     "php": "php-8.1-m1.0",
     "php-8.1": "php-8.1-m1.0",
     "php-8.1-m1": "php-8.1-m1.0",

--- a/modules.json
+++ b/modules.json
@@ -89,6 +89,26 @@
       "commit": "806dc5beea43fab9a44b8f9b9f800726733dfc5a",
       "created": "2023-05-09T07:10:11-07:00",
       "path": "/nix/store/37kafc7qxhji91175lgccmn2yx1dzw9m-replit-module-web-3.0-m1.0"
+    },
+    "nodejs-14-m1.1": {
+      "commit": "8c6632757435958d53fec1dac7aefc3c25a976f5",
+      "created": "2023-05-10T14:42:44-04:00",
+      "path": "/nix/store/ka73l28kbi58dhzj88sfndmz8ck4a83a-replit-module-nodejs-14-m1.1"
+    },
+    "nodejs-16-m1.1": {
+      "commit": "8c6632757435958d53fec1dac7aefc3c25a976f5",
+      "created": "2023-05-10T14:42:44-04:00",
+      "path": "/nix/store/7i46wk2m5452m4kfprjk1dmrin995511-replit-module-nodejs-16-m1.1"
+    },
+    "nodejs-18-m1.1": {
+      "commit": "8c6632757435958d53fec1dac7aefc3c25a976f5",
+      "created": "2023-05-10T14:42:44-04:00",
+      "path": "/nix/store/4q1k1fwzv2jdcag0xzp477cwd4694519-replit-module-nodejs-18-m1.1"
+    },
+    "nodejs-19-m1.1": {
+      "commit": "8c6632757435958d53fec1dac7aefc3c25a976f5",
+      "created": "2023-05-10T14:42:44-04:00",
+      "path": "/nix/store/wm87b2x7lyfs9v9m6ndksdr9w6hrs1x9-replit-module-nodejs-19-m1.1"
     }
   },
   "aliases": {
@@ -145,6 +165,15 @@
     "swift-5.6-m1": "swift-5.6-m1.0",
     "web": "web-3.0-m1.0",
     "web-3.0": "web-3.0-m1.0",
-    "web-3.0-m1": "web-3.0-m1.0"
+    "web-3.0-m1": "web-3.0-m1.0",
+    "nodejs": "nodejs-19-m1.1",
+    "nodejs-14": "nodejs-14-m1.1",
+    "nodejs-14-m1": "nodejs-14-m1.1",
+    "nodejs-16": "nodejs-16-m1.1",
+    "nodejs-16-m1": "nodejs-16-m1.1",
+    "nodejs-18": "nodejs-18-m1.1",
+    "nodejs-18-m1": "nodejs-18-m1.1",
+    "nodejs-19": "nodejs-19-m1.1",
+    "nodejs-19-m1": "nodejs-19-m1.1"
   }
 }

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -3,7 +3,7 @@
 
 let
 
-  community-version = lib.versions.majorMinor nodejs.version;
+  community-version = lib.versions.major nodejs.version;
 
   nodepkgs = pkgs.nodePackages.override {
     inherit nodejs;


### PR DESCRIPTION
# Why?

Node.js use the major version only as their current active release lines. Matching this allows us to better track their security releases. More: https://replit.com/@util/Design-docs#goval/nixmodules_versions.md under Runtimes Security Fixes

## Change

1. Removed pre-existing node-js modules
2. changed community-version declaration to use major version
3. re-ran `python scripts/lock_modules.py`