### PR TITLE
Removed community versions

### DIFF
--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -481,11 +481,6 @@ in
       default = "";
     };
 
-    community-version = mkOption {
-      type = types.str;
-      description = "The version of the language or framework provided by this module.";
-    };
-
     version = mkOption {
       type = types.str;
       description = "Version of the module";
@@ -588,7 +583,6 @@ in
           id = config.id;
           name = config.name;
           description = config.description;
-          community-version = config.community-version;
           version = config.version;
           env = {
             PATH = lib.makeBinPath config.packages;
@@ -602,6 +596,6 @@ in
         };
 
       in
-      pkgs.writeText "replit-module-${config.id}-${config.community-version}-m${config.version}" (builtins.toJSON moduleJSON);
+      pkgs.writeText "replit-module-${config.id}-v${config.version}" (builtins.toJSON moduleJSON);
   };
 }

--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -1,7 +1,9 @@
-{ pkgs, lib, ... }: {
-  id = "r";
+{ pkgs, lib, ... }: 
+let r-version = lib.versions.majorMinor pkgs.R.version;
+in
+{
+  id = "r-${r-version}";
   name = "R Tools";
-  community-version = lib.versions.majorMinor pkgs.R.version;
   version = "1.0";
 
   replit.runners.r = {

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -4,12 +4,13 @@ let
   bun = pkgs.callPackage ../../bun { };
 
   extensions = [ ".js" ".ts" ];
+
+  community-version = lib.versions.majorMinor bun.version;
 in
 
 {
-  id = "bun";
+  id = "bun-${community-version}";
   name = "Bun Tools";
-  community-version = lib.versions.majorMinor bun.version;
   version = "1.0";
 
   imports = [

--- a/pkgs/modules/c/default.nix
+++ b/pkgs/modules/c/default.nix
@@ -9,11 +9,12 @@ let
   };
   dap-cpp = pkgs.callPackage ../../dap-cpp { };
   dap-cpp-messages = import ../../dap-cpp/messages.nix;
+
+  clang-version = lib.versions.majorMinor clang.version;
 in
 {
-  id = "c";
+  id = "c-clang${clang-version}";
   name = "C Tools (with Clang)";
-  community-version = lib.versions.majorMinor clang.version;
   version = "1.0";
 
   packages = [

--- a/pkgs/modules/clojure/default.nix
+++ b/pkgs/modules/clojure/default.nix
@@ -1,7 +1,9 @@
-{ pkgs, lib, ... }: {
-  id = "clojure";
+{ pkgs, lib, ... }: 
+let clojure-version = lib.versions.majorMinor pkgs.clojure.version;
+in
+{
+  id = "clojure-${clojure-version}";
   name = "Clojure Tools";
-  community-version = lib.versions.majorMinor pkgs.clojure.version;
   version = "1.0";
 
   replit.runners.clojure = {

--- a/pkgs/modules/cpp/default.nix
+++ b/pkgs/modules/cpp/default.nix
@@ -7,11 +7,12 @@ let
   };
   dap-cpp = pkgs.callPackage ../../dap-cpp { };
   dap-cpp-messages = import ../../dap-cpp/messages.nix;
+
+  clang-version = lib.versions.major clang.version;
 in
 {
-  id = "cpp";
+  id = "cpp-clang${clang-version}";
   name = "C++ Tools (with Clang)";
-  community-version = lib.versions.majorMinor clang.version;
   version = "1.0";
 
   packages = [

--- a/pkgs/modules/dart/default.nix
+++ b/pkgs/modules/dart/default.nix
@@ -1,7 +1,8 @@
-{ pkgs, lib, ... }: {
-  id = "dart";
+{ pkgs, lib, ... }:
+let dart-version = lib.versions.majorMinor pkgs.dart.version;
+in {
+  id = "dart-${dart-version}";
   name = "Dart Tools";
-  community-version = lib.versions.majorMinor pkgs.dart.version;
   version = "1.0";
 
   packages = [

--- a/pkgs/modules/dotnet/default.nix
+++ b/pkgs/modules/dotnet/default.nix
@@ -4,12 +4,13 @@ let
   dotnet = pkgs.dotnet-sdk_7;
 
   extensions = [ ".cs" ".csproj" ".fs" ".fsproj" ];
+
+  dotnet-version = lib.versions.majorMinor dotnet.version;
 in
 
 {
-  id = "dotnet";
+  id = "dotnet-${dotnet-version}";
   name = ".NET 7 Tools";
-  community-version = lib.versions.majorMinor dotnet.version;
   version = "1.0";
 
   packages = [

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -3,9 +3,8 @@ let
   goversion = lib.versions.majorMinor pkgs.go.version;
 in
 {
-  id = "go";
+  id = "go-${goversion}";
   name = "Go Tools";
-  community-version = goversion;
   version = "1.0";
 
   packages = with pkgs; [

--- a/pkgs/modules/haskell/default.nix
+++ b/pkgs/modules/haskell/default.nix
@@ -1,7 +1,10 @@
-{ pkgs, lib, ... }: {
-  id = "haskell";
+{ pkgs, lib, ... }: 
+let 
+  ghc-version = lib.versions.majorMinor pkgs.ghc.version;
+in
+{
+  id = "haskell-ghc${ghc-version}";
   name = "Haskell Tools";
-  community-version = lib.versions.majorMinor pkgs.ghc.version;
   version = "1.0";
 
   packages = with pkgs; [

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -3,6 +3,8 @@
 let
   graalvm = pkgs.graalvm17-ce;
 
+  graalvm-version = lib.versions.majorMinor graalvm.version;
+
   graal-compile-command = "${pkgs.graalvm17-ce}/bin/javac -classpath .:target/dependency/* -d . $(find . -type f -name '*.java')";
 
   jdt-language-server = pkgs.callPackage ../../jdt-language-server { };
@@ -11,12 +13,12 @@ let
     inherit jdt-language-server;
     jdk = pkgs.graalvm11-ce;
   };
+
 in
 
 {
-  id = "java";
+  id = "java-graalvm${graalvm-version}";
   name = "Java Tools (with Graal VM)";
-  community-version = lib.versions.majorMinor graalvm.version;
   version = "1.0";
 
   packages = [

--- a/pkgs/modules/lua/default.nix
+++ b/pkgs/modules/lua/default.nix
@@ -1,7 +1,9 @@
-{ pkgs, lib, ... }: {
-  id = "lua";
+{ pkgs, lib, ... }: 
+let lua-version = lib.versions.majorMinor pkgs.lua.version;
+in
+{
+  id = "lua-${lua-version}";
   name = "Lua Tools";
-  community-version = lib.versions.majorMinor pkgs.lua.version;
   version = "1.0";
 
   packages = with pkgs; [

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -18,9 +18,8 @@ let
 in
 
 {
-  id = "nodejs";
-  name = "Node.js Tools";
-  inherit community-version;
+  id = "nodejs-${community-version}";
+  name = "Node.js ${community-version} Tools";
   version = "1.1";
   imports = [
     (import ../typescript-language-server {

--- a/pkgs/modules/php/default.nix
+++ b/pkgs/modules/php/default.nix
@@ -1,10 +1,10 @@
 { pkgs, lib, ... }:
 let phpactor = pkgs.callPackage ../../phpactor { };
+php-version = lib.versions.majorMinor pkgs.php.version;
 in
 {
-  id = "php";
+  id = "php-${php-version}";
   name = "PHP Tools";
-  community-version = lib.versions.majorMinor pkgs.php.version;
   version = "1.0";
 
   packages = with pkgs; [

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -80,9 +80,8 @@ let
 
 in
 {
-  id = "python";
-  name = "Python Tools";
-  inherit community-version;
+  id = "python-${community-version}";
+  name = "Python ${community-version} Tools";
   version = "1.0";
 
   packages = [
@@ -101,7 +100,7 @@ in
   };
 
   replit.runners.python-prybar = {
-    name = "Prybar for Python 3.10";
+    name = "Prybar for Python ${community-version}";
     fileParam = true;
     language = "python3";
     start = "${run-prybar}/bin/run-prybar $file";

--- a/pkgs/modules/qbasic/default.nix
+++ b/pkgs/modules/qbasic/default.nix
@@ -12,7 +12,6 @@ in
 {
   id = "qbasic";
   name = "QBASIC Tools (with Replbox)";
-  community-version = lib.versions.majorMinor replbox.version;
   version = "1.1";
 
   replit.runners.replbox-qbasic = {

--- a/pkgs/modules/ruby/default.nix
+++ b/pkgs/modules/ruby/default.nix
@@ -3,12 +3,12 @@
 let
   ruby = pkgs.ruby_3_1;
   rubyPackages = pkgs.rubyPackages_3_1;
+  ruby-version = lib.versions.majorMinor "${ruby.version}";
 in
 
 {
-  id = "ruby";
+  id = "ruby-${ruby-version}";
   name = "Ruby Tools";
-  community-version = lib.versions.majorMinor "${ruby.version}";
   version = "1.0";
 
   packages = [

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -8,12 +8,11 @@ let
 
     ${pkgs.cargo}/bin/cargo run
   '';
-  community-version = lib.versions.majorMinor pkgs.rustc.version;
+  rust-version = lib.versions.majorMinor pkgs.rustc.version;
 in
 {
-  id = "rust";
+  id = "rust-${rust-version}";
   name = "Rust Tools";
-  inherit community-version;
   version = "1.0";
 
   packages = with pkgs; [

--- a/pkgs/modules/swift/default.nix
+++ b/pkgs/modules/swift/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  community-version = lib.versions.majorMinor pkgs.swift.version;
+  swift-version = lib.versions.majorMinor pkgs.swift.version;
 
   swiftc-wrapper = pkgs.stdenv.mkDerivation {
     name = "swiftc-wrapper";
@@ -16,9 +16,8 @@ let
   };
 in
 {
-  id = "swift";
+  id = "swift-${swift-version}";
   name = "Swift Tools";
-  inherit community-version;
   version = "1.0";
 
   packages = with pkgs; [

--- a/pkgs/modules/web/default.nix
+++ b/pkgs/modules/web/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }: {
   id = "web";
   name = "Web Tools";
-  community-version = "3.0";
   version = "1.0";
 
   imports = [


### PR DESCRIPTION
## Why?

From our discussions we decided that community versions should not be a formal thing baked into the module system.

## Changes

1. Removed community-version field in module definitions
2. update all modules versioning scheme. Most of them embed the "community version" into their ID. some do not have one.
3. Instead of `m` prefix to a module version, I switched it to `v`