### PR TITLE
[bundle] ensure bundle-image and bundle-image-tarball have no dependencies

### DIFF
--- a/pkgs/bundle-image-tarball/builder.sh
+++ b/pkgs/bundle-image-tarball/builder.sh
@@ -1,0 +1,9 @@
+. .attrs.sh
+
+PATH="${env[PATH]}"
+out="${outputs[out]}"
+bundleImage="${env[bundle-image]}"
+
+echo "making tarball..."
+mkdir -p "$out"
+tar --use-compress-program=pigz -Scf $out/disk.raw.tar.gz -C ${bundleImage} disk.raw

--- a/pkgs/bundle-image-tarball/default.nix
+++ b/pkgs/bundle-image-tarball/default.nix
@@ -1,11 +1,18 @@
-{runCommand, lib, revstring, bundle-image, pigz }:
+{system, bash, lib, bundle-image, revstring, coreutils, gnutar, pigz} :
 
-let
-  label = "nixmodules-${revstring}";
-in
-
-runCommand label {} ''
-  echo "making tarball..."
-  mkdir -p $out
-  tar --use-compress-program=${pigz}/bin/pigz -Scf $out/disk.raw.tar.gz -C ${bundle-image} disk.raw
-''
+derivation {
+  name = "nixmodules-${revstring}";
+  builder = "${bash}/bin/bash";
+  args = [ ./builder.sh ];
+  inherit system;
+  __structuredAttrs = true;
+  unsafeDiscardReferences.out = true;
+  env = {
+    PATH = lib.makeBinPath [
+      coreutils
+      gnutar
+      pigz
+    ];
+    inherit bundle-image;
+  };
+}

--- a/pkgs/bundle-image/builder.sh
+++ b/pkgs/bundle-image/builder.sh
@@ -1,0 +1,72 @@
+. .attrs.sh
+
+PATH="${env[PATH]}"
+out="${outputs[out]}"
+
+gibibyte=$(( 1024 * 1024 * 1024))
+# Approximative percentage of reserved space in an ext4 fs over 512MiB.
+# 0.05208587646484375
+#  × 1000, integer part: 52
+compute_fudge() {
+    echo $(( $1 * 52 / 1000 ))
+}
+
+# Given lines of numbers, adds them together
+sum_lines() {
+    local acc=0
+    while read -r number; do
+        acc=$((acc+number))
+    done
+    echo "$acc"
+}
+
+mkdir "$out"
+
+root="$PWD/root"
+mkdir -p "$root/nix/store" "$root/etc/nixmodules"
+
+xargs -I % cp -a --reflink=auto % "$root/nix/store/" < "${env[diskClosureInfo]}"/store-paths
+
+cp -a --reflink=auto "${env[registry]}" "$root/etc/nixmodules/modules.json"
+
+diskImage=disk.raw
+
+# Compute required space in filesystem blocks
+diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "${env[blockSize]}" | cut -f1 | sum_lines)
+
+# Each inode takes space!
+numInodes=$(find . | wc -l)
+# Convert to bytes, inodes take two blocks each!
+diskUsage=$(( (diskUsage + 2 * numInodes) * env[blockSize] ))
+# Then increase the required space to account for the reserved blocks.
+fudge=$(compute_fudge $diskUsage)
+requiredFilesystemSpace=$(( diskUsage + fudge ))
+
+diskSize=$(( requiredFilesystemSpace ))
+
+# Round up to the nearest gibibyte.
+if (( diskSize % gibibyte )); then
+    diskSize=$(( ( diskSize / gibibyte + 1) * gibibyte ))
+fi
+
+truncate -s "$diskSize" "$diskImage"
+
+printf "Automatic disk size...\n"
+printf "  Closure space use: %d bytes\n" "$diskUsage"
+printf "  fudge: %d bytes\n" "$fudge"
+printf "  Filesystem size needed: %d bytes\n" "$requiredFilesystemSpace"
+printf "  Disk image size: %d bytes\n" "$diskSize"
+
+echo "making filesystem..."
+
+mkfs.ext4 -b "${env[blockSize]}" -F -L "${env[label]}" "$diskImage"
+
+echo "copying to image..."
+cptofs -p \
+       -t ext4 \
+       -i "$diskImage" \
+       "$root"/* / ||
+    (echo >&2 "ERROR: cptofs failed. diskSize might be too small for closure."; exit 1)
+
+echo "moving image to out..."
+mv "$diskImage" "$out/disk.raw"

--- a/pkgs/bundle-image/default.nix
+++ b/pkgs/bundle-image/default.nix
@@ -1,92 +1,29 @@
-{runCommand, lib, bundle-locked, revstring, lkl, coreutils, findutils, e2fsprogs, gnutar, gzip, closureInfo } :
+{system, bash, lib, bundle-locked, revstring, lkl, coreutils, findutils, e2fsprogs, closureInfo}:
 
 let
-  blockSize = toString (4 * 1024); # ext4fs block size (not block device sector size)
-
-  binPath = lib.makeBinPath [
-    coreutils
-    findutils
-    lkl
-    e2fsprogs
-    gnutar
-    gzip
-  ];
 
   label = "nixmodules-${revstring}";
 
   registry = ../../modules.json;
 
-  diskClosureInfo = closureInfo { rootPaths = [bundle-locked registry]; };
-
 in
 
-runCommand label {} ''
-  export PATH=${binPath}
-
-  gibibyte=$(( 1024 * 1024 * 1024))
-  # Approximative percentage of reserved space in an ext4 fs over 512MiB.
-  # 0.05208587646484375
-  #  × 1000, integer part: 52
-  compute_fudge() {
-    echo $(( $1 * 52 / 1000 ))
-  }
-
-  # Given lines of numbers, adds them together
-  sum_lines() {
-    local acc=0
-    while read -r number; do
-      acc=$((acc+number))
-    done
-    echo "$acc"
-  }
-
-  mkdir $out
-
-  root="$PWD/root"
-  mkdir -p $root/nix/store $root/etc/nixmodules
-
-  xargs -I % cp -a --reflink=auto % $root/nix/store/ < ${diskClosureInfo}/store-paths
-
-  cp -a --reflink=auto ${registry} $root/etc/nixmodules/modules.json
-
-  diskImage=disk.raw
-
-  # Compute required space in filesystem blocks
-  diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "${blockSize}" | cut -f1 | sum_lines)
-  # Each inode takes space!
-  numInodes=$(find . | wc -l)
-  # Convert to bytes, inodes take two blocks each!
-  diskUsage=$(( (diskUsage + 2 * numInodes) * ${blockSize} ))
-  # Then increase the required space to account for the reserved blocks.
-  fudge=$(compute_fudge $diskUsage)
-  requiredFilesystemSpace=$(( diskUsage + fudge ))
-
-  diskSize=$(( requiredFilesystemSpace ))
-
-  # Round up to the nearest gibibyte.
-  if (( diskSize % gibibyte )); then
-  diskSize=$(( ( diskSize / gibibyte + 1) * gibibyte ))
-  fi
-
-  truncate -s "$diskSize" $diskImage
-
-  printf "Automatic disk size...\n"
-  printf "  Closure space use: %d bytes\n" $diskUsage
-  printf "  fudge: %d bytes\n" $fudge
-  printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
-  printf "  Disk image size: %d bytes\n" $diskSize
-
-  echo "making filesystem..."
-
-  mkfs.ext4 -b ${blockSize} -F -L ${label} $diskImage
-
-  echo "copying to image..."
-  cptofs -p \
-         -t ext4 \
-         -i $diskImage \
-         $root/* / ||
-    (echo >&2 "ERROR: cptofs failed. diskSize might be too small for closure."; exit 1)
-
-  echo "moving image to out..."
-  mv $diskImage $out/disk.raw
-''
+derivation {
+  name = label;
+  builder = "${bash}/bin/bash";
+  args = [ ./builder.sh ];
+  inherit system;
+  __structuredAttrs = true;
+  unsafeDiscardReferences.out = true;
+  env = {
+    inherit label registry;
+    PATH = lib.makeBinPath [
+      coreutils
+      findutils
+      lkl
+      e2fsprogs
+    ];
+    blockSize = toString (4 * 1024); # ext4fs block size (not block device sector size)
+    diskClosureInfo = closureInfo { rootPaths = [bundle-locked registry]; };
+  };
+}


### PR DESCRIPTION
Why
===
* Nix was scanning the bundle image/tarball and finding references which you could see by running

nix path-info -rsSh .#bundle-image

these references ended up in the runtime closure, which means they could not be garbage collected without also collecting the image itself.

What changed
===
* Use the experimental feature unsafeDiscardReferences enabled under experimental flag discard-references to tell Nix that really these derivations has no references in the end.

Test plan
===
* Confirmed nix build works for both image and tarball
* Confirmed they do not have references