### PR TITLE
bundle-squashfs: add output

### DIFF
--- a/pkgs/bundle-squashfs/builder.sh
+++ b/pkgs/bundle-squashfs/builder.sh
@@ -1,0 +1,17 @@
+set -eou pipefail
+. .attrs.sh
+
+PATH="${env[PATH]}"
+out="${outputs[out]}"
+
+mkdir "$out"
+
+root="$PWD/root"
+mkdir -p "$root/nix/store" "$root/etc/nixmodules"
+
+xargs -I % cp -a --reflink=auto % "$root/nix/store/" < "${env[diskClosureInfo]}"/store-paths
+
+cp -a --reflink=auto "${env[registry]}" "$root/etc/nixmodules/modules.json"
+
+echo "making squashfs..."
+mksquashfs "$root" "$out/disk.sqsh"

--- a/pkgs/bundle-squashfs/default.nix
+++ b/pkgs/bundle-squashfs/default.nix
@@ -1,0 +1,28 @@
+{system, bash, lib, bundle-locked, revstring, coreutils, findutils, closureInfo, squashfsTools}:
+
+let
+
+  label = "nixmodules-${revstring}";
+
+  registry = ../../modules.json;
+
+in
+
+derivation {
+  name = label;
+  builder = "${bash}/bin/bash";
+  args = [ ./builder.sh ];
+  inherit system;
+  __structuredAttrs = true;
+  unsafeDiscardReferences.out = true;
+  outputs = [ "out" ];
+  env = {
+    inherit label registry;
+    PATH = lib.makeBinPath [
+      coreutils
+      findutils
+      squashfsTools
+    ];
+    diskClosureInfo = closureInfo { rootPaths = [bundle-locked registry]; };
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -24,4 +24,6 @@ rec {
   bundle-image = pkgs.callPackage ./bundle-image { inherit bundle-locked revstring; };
 
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };
+
+  bundle-squashfs = pkgs.callPackage ./bundle-squashfs { inherit bundle-locked revstring; };
 } // modules


### PR DESCRIPTION
Why
===
* For local and CI, it is useful to have a small squashfs drive

What changed
==
* Added bundle-squashfs output

Test plan
===
* nix build .#bundle-squashfs works
* when mounting it, it looks like it has the correct files