### PR TITLE
Updated rust to 1.69; added nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,16 +33,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1684385584,
-        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
+        "lastModified": 1684464849,
+        "narHash": "sha256-f8th/GWE9M2hePTMZc0YyFboigt9AG/ioEcyHcdFK2I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
+        "rev": "b969a89c3e84a121c9b3af2e4ef277cd822b988a",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -31,6 +31,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1684385584,
+        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1670276674,
@@ -70,6 +85,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,10 @@
 {
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=52e3e80afff4b16ccb7c52e9f0f5220552f03d04";
+  inputs.nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
   inputs.prybar.url = "github:replit/prybar?rev=65f486534054665f1b333689417c39acd370d3a5";
 
-  outputs = { self, nixpkgs, prybar, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, ... }:
     let
       mkPkgs = system: import nixpkgs {
         inherit system;
@@ -11,6 +12,11 @@
       };
 
       pkgs = mkPkgs "x86_64-linux";
+
+      pkgs-unstable = import nixpkgs-unstable {
+        system = "x86_64-linux";
+        overlays = [ self.overlays.default prybar.overlays.default ]; # ++ import ;
+      };
     in
     {
       overlays.default = final: prev: {
@@ -34,6 +40,7 @@
       };
       modules = import ./pkgs/modules {
         inherit pkgs;
+        inherit pkgs-unstable;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=52e3e80afff4b16ccb7c52e9f0f5220552f03d04";
-  inputs.nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs-unstable.url = "nixpkgs/nixpkgs-unstable";
   inputs.prybar.url = "github:replit/prybar?rev=65f486534054665f1b333689417c39acd370d3a5";
 
   outputs = { self, nixpkgs, nixpkgs-unstable, prybar, ... }:

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { }
+, pkgs-unstable ? import <nixpkgs-unstable> { }
 , configPath
-, pkgs-unstable
 }:
 (pkgs.lib.evalModules {
   modules = [

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,5 +1,6 @@
 { pkgs ? import <nixpkgs> { }
 , configPath
+, pkgs-unstable
 }:
 (pkgs.lib.evalModules {
   modules = [
@@ -8,6 +9,7 @@
   ];
   specialArgs = {
     inherit pkgs;
+    inherit pkgs-unstable;
     modulesPath = builtins.toString ./.;
   };
 }).config.replit.buildModule

--- a/pkgs/moduleit/example.nix
+++ b/pkgs/moduleit/example.nix
@@ -13,7 +13,8 @@ let
 in
 
 {
-  name = "nodejs";
+  id = "nodejs";
+  name = "Node.js";
   version = "1.2";
 
   packages = [

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,7 +1,8 @@
-{ pkgs }:
+{ pkgs, pkgs-unstable }:
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
+    inherit pkgs-unstable;
   };
   
   modulesList = [

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -1,5 +1,6 @@
-{ pkgs, lib, ... }:
+{ pkgs-unstable, lib, ... }:
 let
+  pkgs = pkgs-unstable;
   cargoRun = pkgs.writeScriptBin "cargo_run" ''
     if [ ! -f "$HOME/$REPL_SLUG/Cargo.toml" ]; then
       NAME=$(echo $REPL_SLUG | sed -r 's/([a-z0-9])([A-Z])/\1_\2/g'| tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
# Why?

Upgrade rust to get their new registry updating scheme that will be fast.

# Changes

1. added nixpkgs-unstable as input
2. rust uses things from the unstable channel

# Testing

* `nix build .#bundle`
* `ls result` and see rust at the new version

Disk usage didn't seem to go up much:

```
nix build .#bundle-image
$ ls -l result/disk.raw 
-r--r--r-- 1 toby toby 22548578304 Dec 31  1969 result/disk.raw
```