### PR TITLE
fix nixpkgs-unstable reference

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,17 +33,18 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1684464849,
-        "narHash": "sha256-f8th/GWE9M2hePTMZc0YyFboigt9AG/ioEcyHcdFK2I=",
-        "owner": "NixOS",
+        "lastModified": 1684911969,
+        "narHash": "sha256-j2tz1P2rA3d1WYHk8+1WbYDIJO33BqW1EfQSvi+/O8s=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b969a89c3e84a121c9b3af2e4ef277cd822b988a",
+        "rev": "87f9156865ab09e3bde39aadb4131ae364ae704e",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "nixos",
         "ref": "nixpkgs-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=52e3e80afff4b16ccb7c52e9f0f5220552f03d04";
-  inputs.nixpkgs-unstable.url = "nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.prybar.url = "github:replit/prybar?rev=65f486534054665f1b333689417c39acd370d3a5";
 
   outputs = { self, nixpkgs, nixpkgs-unstable, prybar, ... }:


### PR DESCRIPTION
Why
===
* when calling `nix flake update github:replit/nixmodules` we got

error:
       … while updating the lock file of flake 'github:replit/nixmodules/436efc3e4ad3fbff090e68748e1d0e499140b43c'

       error: cannot write modified lock file of flake 'github:replit/nixmodules' (use '--no-write-lock-file' to ignore)

What changed
===
* use the github: type url instead

Test plan
===
* I tried running nix flake update on this commit and it worked