### PR TITLE
Attempt to fix the nix flake update error again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,8 +42,8 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "87f9156865ab09e3bde39aadb4131ae364ae704e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=52e3e80afff4b16ccb7c52e9f0f5220552f03d04";
-  inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs?rev=87f9156865ab09e3bde39aadb4131ae364ae704e";
   inputs.prybar.url = "github:replit/prybar?rev=65f486534054665f1b333689417c39acd370d3a5";
 
   outputs = { self, nixpkgs, nixpkgs-unstable, prybar, ... }:


### PR DESCRIPTION
# Why

Still getting this error:
```
$ nix flake update  github:replit/nixmodules/f798299b1e3ecf2b864f562ec7ea19970a217745
error:
       … while updating the lock file of flake 'github:replit/nixmodules/f798299b1e3ecf2b864f562ec7ea19970a217745'

       error: cannot write modified lock file of flake 'github:replit/nixmodules/f798299b1e3ecf2b864f562ec7ea19970a217745' (use '--no-write-lock-file' to ignore)
```

# Change

Hardcode specific rev in flake.nix