### PR TITLE
Removed commit from output

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,178 +1,90 @@
 {
-  "bun-0.5:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/asz1nzgcgnxh9nl9b1f9k08v6zwf9j6x-replit-module-bun-0.5"
+  "bun-0.5:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/l08f5vl1af9rpzd7kvr0l5gx9v7y8p12-replit-module-bun-0.5"
   },
-  "bun-0.5:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/0dr0jmc0x3ywf43587gjpxgijrvrhc01-replit-module-bun-0.5"
+  "c-clang14:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/7x92nggc7kng9g1bqpmphak1xhjg55ng-replit-module-c-clang14"
   },
-  "c-clang14:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/cva88mb2v7rq3glh18kif8x8dkpdnf33-replit-module-c-clang14"
+  "clojure-1.11:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/giqq76fl3yphzsm6rkl1qxqh4mszknpl-replit-module-clojure-1.11"
   },
-  "c-clang14:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/q38k5vw9p476hkriiyq07hlbrcwnkw7v-replit-module-c-clang14"
+  "cpp-clang14:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/8iv4czda6j5nfhxs80ci625hj91ffpbn-replit-module-cpp-clang14"
   },
-  "clojure-1.11:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/w1ln5f6bgf0dfaqa07fmlix228ypy1zs-replit-module-clojure-1.11"
+  "dart-2.18:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/mhl58f8y3z6jv0javkmx28y5h9aacw39-replit-module-dart-2.18"
   },
-  "clojure-1.11:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/qc7smpb0m1sikaggkljqfcrcz7w6f2wg-replit-module-clojure-1.11"
+  "dotnet-7.0:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/06mjna44a7w9bby6r121a7i9a5027qqn-replit-module-dotnet-7.0"
   },
-  "cpp-clang14:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/n43jbl85644jc19iiyq38na135x1x0qm-replit-module-cpp-clang14"
+  "go-1.19:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/y1gb1k8bkyd9jqxi4r1g9qibcqn3c6dm-replit-module-go-1.19"
   },
-  "cpp-clang14:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/l2jc2s595j9l5gfqp6ch99b7z0gyaybq-replit-module-cpp-clang14"
+  "haskell-ghc9.0:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/ayihz2zdzc2vsv6l437srdynqrk8xvny-replit-module-haskell-ghc9.0"
   },
-  "dart-2.18:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/cmq17vxaavc0wd57p8rdsclkddj9ax62-replit-module-dart-2.18"
+  "java-graalvm22.3:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/7zjcdf4z9d0dhwg13cs3xb1rj248m8ri-replit-module-java-graalvm22.3"
   },
-  "dart-2.18:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/x1s31iibn5a999b6xx496asca7zh7w2z-replit-module-dart-2.18"
+  "lua-5.2:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/d6a5wl9pyla9si60plaxzmhqggywkcxy-replit-module-lua-5.2"
   },
-  "dotnet-7.0:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/79cfd8y0by9d1fvikrsb7jx8bnpw88qc-replit-module-dotnet-7.0"
+  "nodejs-14:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/96mjfxlm21916i1x99apm8lkwkr16dfd-replit-module-nodejs-14"
   },
-  "dotnet-7.0:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/37r1xniwdyip3rvczvx3xd3i375dqhpc-replit-module-dotnet-7.0"
+  "nodejs-16:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/nyxn9zpxqbkb8vicq51zb3pkxkbj7jw9-replit-module-nodejs-16"
   },
-  "go-1.19:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/2dl4myyagnpycp61q7kgv854xywf6j2f-replit-module-go-1.19"
+  "nodejs-18:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/m7ij5hyk1gh83vyy5rxqzwvfzib9z269-replit-module-nodejs-18"
   },
-  "go-1.19:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/i9fq9jm8prsh8v25kx9jrp8a5jcxdb9j-replit-module-go-1.19"
+  "nodejs-19:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
   },
-  "haskell-ghc9.0:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/8m5sp5fym00v5q1fp0gb9ms3ysgx1pzr-replit-module-haskell-ghc9.0"
+  "php-8.1:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/rb9vj0jxx7cbmk29j5ncjr3ipl1nmrxw-replit-module-php-8.1"
   },
-  "haskell-ghc9.0:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/yy60kg7ny76r6h4lh5pjq9hhqjsq2f82-replit-module-haskell-ghc9.0"
+  "python-3.10:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/wkq2q9m9k5khgxldy28qi3mfvx8cl9bg-replit-module-python-3.10"
   },
-  "java-graalvm22.3:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/2r9zdxai3c1qqz0cyyzg2vyjppw64psb-replit-module-java-graalvm22.3"
+  "qbasic:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
   },
-  "java-graalvm22.3:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/j5y9gi4qxw63x9ykrph140vjdv2sv4mw-replit-module-java-graalvm22.3"
+  "r-4.2:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/ymdx5g837nll9qg5nv6plxm561fif9y1-replit-module-r-4.2"
   },
-  "lua-5.2:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/lzzhr24bsgya8kqzc8m3wba1d6w732yp-replit-module-lua-5.2"
+  "ruby-3.1:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/xac2nbz5f2vczvvq1nphfassipk2wwv2-replit-module-ruby-3.1"
   },
-  "lua-5.2:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/13bpc5k1h8n2wddvgzg998dmn4g6gmw5-replit-module-lua-5.2"
+  "rust-1.69:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/xkp307fdmgwn8dnbqadzlrb8fr0bvkx4-replit-module-rust-1.69"
   },
-  "nodejs-14:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/c19iy6gnara9frq1s4vd9mhp2bwsm9n6-replit-module-nodejs-14"
+  "swift-5.6:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/gxqkjmzin0ip7441rjay7kj7lkgrmmmf-replit-module-swift-5.6"
   },
-  "nodejs-14:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/x6ljhmqgqwsqal5wsw5frh0r52an1md8-replit-module-nodejs-14"
-  },
-  "nodejs-16:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/c44aiv4ybphqw2f6j379ckhrgkgnwbkw-replit-module-nodejs-16"
-  },
-  "nodejs-16:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/ylmcm1c43hn85270rsfm2vracdvf2p0p-replit-module-nodejs-16"
-  },
-  "nodejs-18:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/i4hs39zq227ain5xx6ndswy0k7hhg3za-replit-module-nodejs-18"
-  },
-  "nodejs-18:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/ky2pprlz9wpghqc5gws9r86b5f4yzz2d-replit-module-nodejs-18"
-  },
-  "nodejs-19:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/fwv20kqy881jk40v4q1m8nd23sy9k2l8-replit-module-nodejs-19"
-  },
-  "nodejs-19:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/dbv7jv22zlipxmacna0apbrsjy2r70cd-replit-module-nodejs-19"
-  },
-  "php-8.1:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/haz7qmz4chljdvdnkzg6zvyrab461mgc-replit-module-php-8.1"
-  },
-  "php-8.1:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/cz5ydaysa1b5aqk2vgs64n9nv3qwv39a-replit-module-php-8.1"
-  },
-  "python-3.10:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/3rq9jv8x1h2z7hn52cd4vndb95an2nyl-replit-module-python-3.10"
-  },
-  "python-3.10:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/2m50pxv2m13qwmr85rqi2mf8hbcwdar3-replit-module-python-3.10"
-  },
-  "qbasic:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/rzh8576fq8ylq3awpc8p71yi7z8djl29-replit-module-qbasic"
-  },
-  "qbasic:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/d7fgppdf382fmrshbca7iaaii1sf2snb-replit-module-qbasic"
-  },
-  "r-4.2:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/xa1p9bpbddsb19nc9jyy05sb7vp9f7fm-replit-module-r-4.2"
-  },
-  "r-4.2:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/x3mfmsq40a8mjjgsch74rlqa07micm0q-replit-module-r-4.2"
-  },
-  "ruby-3.1:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/8vzgiw1fa1lxrf9s06y7w8rdm7xp5sw3-replit-module-ruby-3.1"
-  },
-  "ruby-3.1:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/w0fs14ghabvr67hi1nv96yzq1ljxzkwz-replit-module-ruby-3.1"
-  },
-  "rust-1.64:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/canmk2sm8nbcyhscgwwyga82cvlpfiyl-replit-module-rust-1.64"
-  },
-  "swift-5.6:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/8zwy89617rkgrmmrc792dcfa6p42m47j-replit-module-swift-5.6"
-  },
-  "swift-5.6:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/vwcb3s0zr5ibzp74fah3slw749fgayfw-replit-module-swift-5.6"
-  },
-  "web:v1-20230522-94a8f12": {
-    "commit": "94a8f12da8d04565c302689dadcdddc1f812386f",
-    "path": "/nix/store/nmhwvwqf0n6wfw9l669cms6rxcjaki52-replit-module-web"
-  },
-  "web:v2-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/9pz63cx8qcbkf61pck93cv00ggnxfpi9-replit-module-web"
-  },
-  "rust-1.69:v1-20230523-b8111f7": {
-    "commit": "b8111f7594185eae037d95166cf8b6349a9d9c5e",
-    "path": "/nix/store/f872chwgfs743gr4v3n6h5f2w7imkjld-replit-module-rust-1.69"
+  "web:v1-20230525-868e31d": {
+    "commit": "868e31de1aec5b235764c591ad2682e160b06e51",
+    "path": "/nix/store/7lhwlqy8nmrmc27n68ia16q6bn27cwk5-replit-module-web"
   }
 }

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, self, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -570,7 +570,6 @@ in
 
         moduleJSON = {
           id = config.id;
-          commit = self.rev or "dirty";
           name = config.name;
           description = config.description;
           env = {

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -8,9 +8,9 @@ mapping = {
   #"nodejs-16:v1-20230522-49470df" = { to = "nodejs-16:v2-20230522-4c01fa0"; auto = true; changelog = "improved your experience"; };
   #"nodejs-14:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 14 is deprecated. Upgrade to 18!"; };
   #"nodejs-16:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 16 is deprecated. Upgrade to 18!"; };
-  "go" = { to = "go-1.19:v2-20230523-b8111f7"; };
-  "rust" = { to = "rust-1.69:v1-20230523-b8111f7"; };
-  "swift" = { to = "swift-5.6:v2-20230523-b8111f7"; };
+  "go" = { to = "go-1.19:v1-20230525-868e31d"; };
+  "rust" = { to = "rust-1.69:v1-20230525-868e31d"; };
+  "swift" = { to = "swift-5.6:v1-20230525-868e31d"; };
 };
 
 present-entries = entries: mapAttrs (mod: entry: 


### PR DESCRIPTION
# Why?

This was making the module outpaths change whenever the repo became dirty, which is confusing. I thought I needed this for frontend to detect a module as me automatically upgraded, but don't need this anymore.

## Changes

1. removed the field
2. clean-slate the module.json once again to reduce churn (we will stop this practice once we deploy for the 1st time and/or have CI in place)