### PR TITLE
More CI checks

### DIFF
--- a/scripts/build_changed_modules.py
+++ b/scripts/build_changed_modules.py
@@ -1,0 +1,54 @@
+# This script test builds the updated modules for a pull request branch.
+
+import json
+import os
+import subprocess
+import argparse
+
+module_registry_file = 'modules.json'
+
+def get_modules():
+  if not os.path.isfile(module_registry_file):
+    return {}
+  f = open(module_registry_file, 'r')
+  modules = json.load(f)
+  f.close()
+  return modules
+
+def build_module(module_id):
+  args = ['nix', 'build', '.#modules."%s"' % module_id]
+  print(" ".join(args))
+  subprocess.run(args)
+
+def get_upstream_modules(branch):
+  args = ['git', 'show', '%s:modules.json' % branch]
+  print(" ".join(args))
+  output = subprocess.check_output(args)
+  return json.loads(str(output, 'UTF-8'))
+
+def main():
+  parser = argparse.ArgumentParser(
+    prog='build_changed_modules',
+    description='builds the modules that were changed from an upstream branch',
+  )
+
+  parser.add_argument('upstream_branch')
+
+  args = parser.parse_args()
+
+  upstream_modules = get_upstream_modules(args.upstream_branch)
+  upstream_ids = set(upstream_modules.keys())
+  current_modules = get_modules()
+  current_ids = set(current_modules.keys())
+  new_modules = current_ids - upstream_ids
+  for module_registry_id in new_modules:
+    module_id, _ = module_registry_id.split(':')
+    build_module(module_id)
+    # verify output is same as entry
+    actual_path = os.readlink('result')
+    referenced_path = current_modules[module_registry_id]['path']
+    assert actual_path == referenced_path, 'output path for %s does not match: %s vs %s' % (module_registry_id, actual_path, referenced_path)
+    print('%s ok' % module_registry_id)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -1,0 +1,54 @@
+# This script checks module.json for:
+#
+# 1. all commits references exist in the linear history of the current branch
+# 2. there are no duplicate numeric versions for the same module ID, say `go-1.19-v1-20230412-9uegy7e` 
+#    and `go-1.19-v1-20230501-cceo023`
+
+import subprocess
+import os
+import json
+
+module_registry_file = 'modules.json'
+
+def commit_exists(commit):
+  try:
+    output = subprocess.check_output(['git', 'show', '-s', '--format=format:%H', commit])
+    return str(output, 'UTF-8') == commit
+  except:
+    return False
+
+def get_commits(modules):
+  commits = set()
+  for entry in modules.values():
+    commits.add(entry['commit'])
+  return commits
+
+def check_commits_exist(modules):
+  for commit in get_commits(modules):
+    assert commit_exists(commit), 'Commit %s does not exist!' % commit
+
+def get_modules():
+  if not os.path.isfile(module_registry_file):
+    return {}
+  f = open(module_registry_file, 'r')
+  modules = json.load(f)
+  f.close()
+  return modules
+
+def check_no_duplicate_numeric_versions(modules):
+  uniques = {}
+  for key in modules.keys():
+    module_id, tag = key.split(':')
+    version, _, _ = tag.split('-')
+    short_key = "%s:%s" % (module_id, version)
+    if short_key in uniques:
+      raise Exception("%s has duplicate numeric versions: %s and %s" % (module_id, key, uniques[short_key]))
+    uniques[short_key] = key
+
+def main():
+  modules = get_modules()
+  check_commits_exist(modules)
+  check_no_duplicate_numeric_versions(modules)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -14,5 +14,8 @@ cat result
 nix develop $NIX_FLAGS
 echo "Verify modules.json"
 python scripts/lock_modules.py -v
+python scripts/check_modules.py
 echo "Verify upgrade maps"
 python scripts/check_upgrade_maps.py
+echo "Build new/updated modules"
+python scripts/build_changed_modules.py origin/main

--- a/scripts/lock_modules.py
+++ b/scripts/lock_modules.py
@@ -128,28 +128,6 @@ def update_module_registry(module_registry):
       print('%s added' % registry_id)
     changed = True
   return changed
-
-def commit_exists(commit):
-  try:
-    output = subprocess.check_output(['git', 'show', '-s', '--format=format:%H', commit])
-    return str(output, 'UTF-8') == commit
-  except:
-    return False
-
-def get_commits():
-  if not os.path.isfile(module_registry_file):
-    return {}
-  f = open(module_registry_file, 'r')
-  modules = json.load(f)
-  f.close()
-  commits = set()
-  for entry in modules.values():
-    commits.add(entry['commit'])
-  return commits
-
-def check_commits_exist():
-  for commit in get_commits():
-    assert commit_exists(commit), 'Commit %s does not exist!' % commit
   
 def main():
   parser = argparse.ArgumentParser(
@@ -172,8 +150,6 @@ def main():
   if args.verify and changed:
     print('%s is not up to date!!' % module_registry_file)
     exit(1)
-  if args.verify:
-    check_commits_exist()
 
   if changed:
     save_module_registry(module_registry)


### PR DESCRIPTION
# Why?

Want CI check to actually test build the newly updated modules, but not everything because I am worried that'll take it over our disk usage limit.
Add a check to guard against hand-merging of modules.json where multiple entries have the same numeric version.

## Changes

1. moved commit verification logic out of `lock_modules.py` into `check_modules.py` to reduce responsibility of the former
2. added numeric version duplicate check to `check_modules.py`
3. added `build_changed_modules.py` script to build modules/versions that were added vs main
4. call the new checks in `ci_check.sh`