### PR TITLE
Fix module it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
       modules = import ./pkgs/modules {
         inherit pkgs;
         inherit pkgs-unstable;
-        inherit self;
       };
     };
 }

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,7 +1,6 @@
 { pkgs ? import <nixpkgs> { }
 , pkgs-unstable ? import <nixpkgs-unstable> { }
 , configPath
-, self
 }:
 (pkgs.lib.evalModules {
   modules = [
@@ -9,7 +8,7 @@
     (import ./module-definition.nix)
   ];
   specialArgs = {
-    inherit pkgs pkgs-unstable self;
+    inherit pkgs pkgs-unstable;
     modulesPath = builtins.toString ./.;
   };
 }).config.replit.buildModule

--- a/pkgs/moduleit/example.nix
+++ b/pkgs/moduleit/example.nix
@@ -15,7 +15,6 @@ in
 {
   id = "nodejs";
   name = "Node.js";
-  version = "1.2";
 
   packages = [
     pkgs.nodejs-14_x

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,9 +1,8 @@
-{ pkgs, pkgs-unstable, self }:
+{ pkgs, pkgs-unstable }:
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
     inherit pkgs-unstable;
-    inherit self;
   };
   
   modulesList = [

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -2,20 +2,30 @@
 set -exuo pipefail
 
 NIX_FLAGS="--extra-experimental-features nix-command --extra-experimental-features flakes --extra-experimental-features discard-references"
+
 echo "Evaluate modules derivations"
 nix eval $NIX_FLAGS .#modules --json
+
 echo "Build upgrade maps"
 nix build $NIX_FLAGS .#upgrade-maps
 cat result/auto-upgrade.json
 cat result/recommend-upgrade.json
+
 echo "Build active modules"
 nix build $NIX_FLAGS .#active-modules
 cat result
 nix develop $NIX_FLAGS
+
 echo "Verify modules.json"
 python scripts/lock_modules.py -v
 python scripts/check_modules.py
+
 echo "Verify upgrade maps"
 python scripts/check_upgrade_maps.py
+
 echo "Build new/updated modules"
 python scripts/build_changed_modules.py origin/main
+
+echo "Build moduleit example"
+cd pkgs/moduleit
+./moduleit.sh example.nix


### PR DESCRIPTION
#Why?

I broke moduleit by adding a self parameter to `entrypoint.nix` wo adding it to the moduleit.sh script. But it turns out we don't need this param anyway.

## Changes

1. Removed the param.
2. Fixed example.nix