### PR TITLE
Add ts extensions for nodejs LSP

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -43,17 +43,33 @@
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/96mjfxlm21916i1x99apm8lkwkr16dfd-replit-module-nodejs-14"
   },
+  "nodejs-14:v2-20230605-9621162": {
+    "commit": "9621162b15c82a23c5a1bae4f9f0750369a113c3",
+    "path": "/nix/store/bk2pmb38w1q2kphf660y8higspnlj4ld-replit-module-nodejs-14"
+  },
   "nodejs-16:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/nyxn9zpxqbkb8vicq51zb3pkxkbj7jw9-replit-module-nodejs-16"
+  },
+  "nodejs-16:v2-20230605-9621162": {
+    "commit": "9621162b15c82a23c5a1bae4f9f0750369a113c3",
+    "path": "/nix/store/a7m10dcjvp9p7my4ljchbkx9s0ghlq0q-replit-module-nodejs-16"
   },
   "nodejs-18:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/m7ij5hyk1gh83vyy5rxqzwvfzib9z269-replit-module-nodejs-18"
   },
+  "nodejs-18:v2-20230605-9621162": {
+    "commit": "9621162b15c82a23c5a1bae4f9f0750369a113c3",
+    "path": "/nix/store/v6z52pi9r1zypcrm5hdnq1h0vbm6yi0g-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
+  },
+  "nodejs-19:v2-20230605-9621162": {
+    "commit": "9621162b15c82a23c5a1bae4f9f0750369a113c3",
+    "path": "/nix/store/9j9klqjgidi37fpqfqm3mxmj95053vfi-replit-module-nodejs-19"
   },
   "php-8.1:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -32,6 +32,8 @@ in
 
   replit = {
 
+    languageServers.typescript-language-server.extensions = [".js" ".jsx" ".ts" ".tsx" ".json"];
+
     runners.nodeJS = {
       name = "Node.js";
       language = "javascript";
@@ -99,6 +101,12 @@ in
         guessImports = true;
         enabledForHosting = false;
       };
+    };
+
+    env = {
+      XDG_CONFIG_HOME = "$REPL_HOME/.config";
+      npm_config_prefix = "$REPL_HOME/.config/npm/node_global";
+      PATH = "$REPL_HOME/.config/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
     };
 
   };


### PR DESCRIPTION
# Why?

1. Node.js module LSP does not support .ts files.
2. Setup environment variables same as https://replit.com/@replit/Nodejs to allow global installs, etc.

## Change

1. Added extensions override for typescript language server.
2. Added env var setup.