### PR TITLE
Th pylsp wrapper

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -79,6 +79,10 @@
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/wkq2q9m9k5khgxldy28qi3mfvx8cl9bg-replit-module-python-3.10"
   },
+  "python-3.10:v2-20230607-f97d5f7": {
+    "commit": "f97d5f7b66810efcd80305aeb9e6425cdc97ae6d",
+    "path": "/nix/store/fzi279mar0y56d8zzkwwsg53dlgls8h3-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"


### PR DESCRIPTION
Why
===

If you use the Python Nix module, and then use poetry to install ujson, it breaks pylsp because it requires ujson as well, and `.pythonlibs` being in `PYTHONPATH` affects it and causes it not to be able to find stdc++.so

**Note: this fix depends on https://github.com/replit/repl-it-web/pull/32128**

What changed
============

1. use a wrapper for pylsp to freeze `PYTHONPATH` for it
2. add lsp configuration for jedi to add `.pythonlibs` to its path. see https://github.com/python-lsp/python-lsp-server/blob/develop/CONFIGURATION.md

Test plan
=========

The following test is to be performed after nixmodules disk goes into Canary and https://github.com/replit/repl-it-web/pull/32128 gets merged.

1. make blank repl
2. use module tool to add the python module
3. `poetry init` and step through the prompt to get project inited
5. `poetry add requests`
4. `poetry add ujson`
6. in `main.py` write
```
import requests
requests.get()
```
7. hover over word "get" and see hover help
8. `poetry add ujson`
9. `kill 1`
10. refresh browser
11. hover over word "get" and still see hover help

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
