### PR TITLE
Update bun

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -102,5 +102,9 @@
   "web:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7lhwlqy8nmrmc27n68ia16q6bn27cwk5-replit-module-web"
+  },
+  "bun-0.6:v1-20230607-15011da": {
+    "commit": "15011da597d303361babfa8823d9223145498e0d",
+    "path": "/nix/store/1vrlhhzyjkizcqkjycb6x4a0g7vw0imq-replit-module-bun-0.6"
   }
 }

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -1,23 +1,18 @@
 { lib
 , stdenvNoCC
-, callPackage
 , fetchurl
 , autoPatchelfHook
 , unzip
 , openssl
-, writeShellScript
-, curl
-, jq
-, common-updater-scripts
 }:
 
-stdenvNoCC.mkDerivation {
-  version = "0.5.9";
+stdenvNoCC.mkDerivation rec {
+  version = "0.6.7";
   pname = "bun";
 
   src = fetchurl {
-    url = "https://github.com/oven-sh/bun/releases/download/bun-v0.5.9/bun-linux-x64.zip";
-    sha256 = "vwxkydYJdnb8MBUAfywpXdaahsuw5IvnXeoUmilzruE=";
+    url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
+    sha256 = "bX3gV3wR2ZJabP6LXT4Tg3T+061aghktXD2YOrQfmWo=";
   };
 
   strictDeps = true;

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -11,7 +11,9 @@ let
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
     "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
+
     "bun" = { to = "bun-0.5:v1-20230525-c48c43c"; auto = true; };
+    "bun-0.5:v1-20230525-c48c43c" = { to = "bun-0.6:v1-20230607-15011da"; auto = true; };
   };
 
   present-entries = entries: mapAttrs


### PR DESCRIPTION
Why
===

There were [8 releases of bun in 2 weeks](https://bun.sh/blog/bun-v0.6.7) starting with 0.6.0 on May 16th. Seems this has died down a bit, so updating the module here. Some features I'm excited about:
- *bun*dler
- perf boosts
- node api catchup
- test suite improvements
- bug fixes

What changed
============

- Added `bun-0.6` module
- Added auto-upgrade to the latest version in the upgrade map
  - There weren't any announced breaking changes, so this auto-upgrade shouldn't negatively impact any Repls

Test plan
=========

`bun --version` prints the right version

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
