### PR TITLE
Poetry wrapper

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -83,6 +83,10 @@
     "commit": "f97d5f7b66810efcd80305aeb9e6425cdc97ae6d",
     "path": "/nix/store/fzi279mar0y56d8zzkwwsg53dlgls8h3-replit-module-python-3.10"
   },
+  "python-3.10:v3-20230608-8cad1d8": {
+    "commit": "8cad1d8823176a2767e4153b436420f3dcee87ac",
+    "path": "/nix/store/lg7ind2gs5djklrh95w081rc3zh6sgss-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -91,6 +91,17 @@ let
     '';
   };
 
+  poetry-wrapper = pkgs.stdenvNoCC.mkDerivation {
+    name = "poetry-wrapper";
+    buildInputs = [ pkgs.makeWrapper ];
+
+    buildCommand = ''
+      mkdir -p $out/bin
+      makeWrapper ${poetry}/bin/poetry $out/bin/poetry \
+        --unset PYTHONPATH
+    '';
+  };
+
 in
 {
   id = "python-${community-version}";
@@ -99,7 +110,7 @@ in
   packages = [
     python3-wrapper
     pip
-    poetry
+    poetry-wrapper
     run-prybar
     pylsp-wrapper
   ];


### PR DESCRIPTION
Why
===

Turns out that even though we put poetry in its own venv it's still not isolated enough. Bug:

1. make blank repl
2. install python 3.10 module
3. `poetry init` walk through prompts
4. `poetry add urllib3`
5. `poetry pyyaml` fails due to

```
'HTTPResponse' object has no attribute 'strict'
```

Unsetting `PYTHONPATH` fixes it.

What changed
============

Added poetry-wrapper to freeze `PYTHONPATH` for poetry.

Test plan
=========

Re-test the bug and it should be able to install pyyaml.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ x] This is fully backward and forward compatible
