### PR TITLE
Fix Python DAP

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -111,6 +111,10 @@
     "commit": "8cad1d8823176a2767e4153b436420f3dcee87ac",
     "path": "/nix/store/lg7ind2gs5djklrh95w081rc3zh6sgss-replit-module-python-3.10"
   },
+  "python-3.10:v4-20230613-295cf88": {
+    "commit": "295cf880234725ffe42797467f68f34d8276e5b1",
+    "path": "/nix/store/yvjg4jsgm7hfb8rlcii6hrgvdyc9qyzh-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/dapPython/default.nix
+++ b/pkgs/dapPython/default.nix
@@ -1,20 +1,20 @@
-{ stdenv, coreutils }:
+{ pkgs, python, pypkgs }:
 
-stdenv.mkDerivation rec {
+pypkgs.buildPythonPackage rec {
   pname = "replit-python-dap-wrapper";
   version = "1.0.0";
 
-  phases = "installPhase";
+  src = ./.;
 
-  # TODO: this has an implicit dependency on python and the pydebug package.
+  propagatedBuildInputs = with pypkgs; [
+    debugpy
+  ];
 
-  buildInputs = [ coreutils ];
-
-  installPhase = ''
+  postInstall = ''
     mkdir -p $out/bin
-
+    
     cat<<EOF > $out/bin/dap-python
-    #!${coreutils}/bin/env python3
+    #!${python}/bin/python3
     """A small wrapper around debugpy's cli.
 
     This wrapper is roughly equivalent to:

--- a/pkgs/dapPython/setup.py
+++ b/pkgs/dapPython/setup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup(
+        name="replit-python-dap-wrapper"
+    )

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -45,7 +45,9 @@ let
 
   debugpy = pypkgs.debugpy;
 
-  dapPython = pkgs.callPackage ../../dapPython { };
+  dapPython = pkgs.callPackage ../../dapPython {
+    inherit pkgs python pypkgs;
+  };
 
   python-lsp-server = pkgs.callPackage ../../python-lsp-server {
     inherit pypkgs;
@@ -133,7 +135,9 @@ in
   replit.debuggers.dapPython = {
     name = "DAP Python";
     language = "python3";
-    start = "${dapPython}/bin/dap-python $file";
+    start = {
+      args = [ "${dapPython}/bin/dap-python" "$file" ];
+    };
     fileParam = true;
     transport = "localhost:0";
     integratedAdapter = {


### PR DESCRIPTION
Why
===

Python DAP wasn't working in Repls. Reasons:

1. Due to the DAP process needing to read from a special pipe from fd 3, we can not use `sh` to run it. To prevent that , we need to provide the commands as an argument array, instead of a string command (which will be run by sh)
2. The DAP process wouldn't work without debugpy being installed

This accompanies https://github.com/replit/goval/pull/9550

What changed
============

1. Rewrote start command as an object with an args array
2. Embedded debugpy as a dependency of dap-python

Test plan
=========

After this is deployed to canary and https://github.com/replit/goval/pull/9550 is deployed to pid1

1. create blank repl
2. install the new python module v4
3. make a `main.py` with
```python
sum = 0

for i in range(10):
    sum += i

print(sum)
```
4. set a breakpoint
5. use the debugger tool, start a debugging session and see the code pause in the breakpoint
6. click step and look at variables

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
