### PR TITLE
Use fenix for Rust module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1687847100,
+        "narHash": "sha256-iFz5DVesvyb14C/dmjO7BYXKYd/djeLT8lZhf/U62xQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b89bebe1bde8a83f65ae39838e25f1148d1e4a0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -27,22 +48,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1686089707,
-        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -84,9 +89,26 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687774320,
+        "narHash": "sha256-eHWa7h0kDejwk4jnWfQdcjxql59af7B4g3m4ywtKvqs=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "8769cd24bcb742d33b2deeb010342ab8e41eb103",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,5 +1,4 @@
 { pkgs ? import <nixpkgs> { }
-, pkgs-unstable ? import <nixpkgs-unstable> { }
 , configPath
 }:
 (pkgs.lib.evalModules {
@@ -8,7 +7,7 @@
     (import ./module-definition.nix)
   ];
   specialArgs = {
-    inherit pkgs pkgs-unstable;
+    inherit pkgs;
     modulesPath = builtins.toString ./.;
   };
 }).config.replit.buildModule

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,8 +1,7 @@
-{ pkgs, pkgs-unstable }:
+{ pkgs }:
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-unstable;
   };
 
   modulesList = [

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -1,6 +1,5 @@
-{ pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 let
-  pkgs = pkgs-unstable;
   cargoRun = pkgs.writeScriptBin "cargo_run" ''
     if [ ! -f "$HOME/$REPL_SLUG/Cargo.toml" ]; then
       NAME=$(echo $REPL_SLUG | sed -r 's/([a-z0-9])([A-Z])/\1_\2/g'| tr '[:upper:]' '[:lower:]')

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -1,20 +1,22 @@
 { pkgs, lib, ... }:
 let
+  toolchain = pkgs.fenix.stable;
+
   cargoRun = pkgs.writeScriptBin "cargo_run" ''
     if [ ! -f "$HOME/$REPL_SLUG/Cargo.toml" ]; then
       NAME=$(echo $REPL_SLUG | sed -r 's/([a-z0-9])([A-Z])/\1_\2/g'| tr '[:upper:]' '[:lower:]')
-      ${pkgs.cargo}/bin/cargo init --name=$NAME
+      ${toolchain.cargo}/bin/cargo init --name=$NAME
     fi
 
-    ${pkgs.cargo}/bin/cargo run
+    ${toolchain.cargo}/bin/cargo run
   '';
-  rust-version = lib.versions.majorMinor pkgs.rustc.version;
+  rust-version = lib.versions.majorMinor toolchain.rustc.version;
 in
 {
   id = "rust-${rust-version}";
   name = "Rust Tools";
 
-  packages = with pkgs; [
+  packages = with toolchain; [
     cargo
     clang
     rustc
@@ -34,14 +36,14 @@ in
     name = "rust-analyzer";
     language = "rust";
 
-    start = "${pkgs.rust-analyzer}/bin/rust-analyzer";
+    start = "${toolchain.rust-analyzer}/bin/rust-analyzer";
   };
 
   replit.formatters.cargo-fmt = {
     name = "cargo fmt";
     language = "rust";
 
-    start = "${pkgs.cargo}/bin/cargo fmt";
+    start = "${toolchain.cargo}/bin/cargo fmt";
     stdin = false;
   };
 
@@ -49,7 +51,7 @@ in
     name = "rustfmt";
     language = "rust";
 
-    start = "${pkgs.rustfmt}/bin/rustfmt $file";
+    start = "${toolchain.rustfmt}/bin/rustfmt $file";
     stdin = false;
   };
 


### PR DESCRIPTION
Why
===

[fenix](https://github.com/nix-community/fenix) has a lot of benefits:
- we can easily define multiple rust-toolchain versions (but why, when rustc is backwards-compatible?)
  - we may want to expose a module that uses rust nightly?
- we gain access to all components in `profile = "complete"`
  - this is big because of `miri`
- we can use new versions of the rust toolchain without needing to update `nixpkgs` (or `fenix`!)
- [devenv](https://github.com/cachix/devenv) uses it so we know it'll remain actively maintained

What changed
============

- got rid of `inputs.nixpkgs-unstable` since the rust module was the only one using it
- changed rust module to use `fenix`

Test plan
=========

- tmpltester works with latest version of the rust module

Rollout
=======

- [x] This is fully backward and forward compatible

once tmpltester passes, we can make another deploy of the nixmodules disk that has the auto-upgrade map to the latest rust version. i'd like to make this an auto-upgrade :)
