### PR TITLE
[python] poetry: add setuptools to PYTHONPATH

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -179,6 +179,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/5lhy377r0n9cjawvw13dfis678fx50sl-replit-module-python-3.10"
   },
+  "python-3.10:v8-20230629-218abef": {
+    "commit": "218abef66eef0192a64b8e1f86ec9fcc05860818",
+    "path": "/nix/store/lgg2wxc7myl9swdqhr176ma70f8sj6vv-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -103,7 +103,7 @@ let
     buildCommand = ''
       mkdir -p $out/bin
       makeWrapper ${poetry}/bin/poetry $out/bin/poetry \
-        --unset PYTHONPATH
+        --set PYTHONPATH "${pypkgs.setuptools}/${python.sitePackages}"
     '';
   };
 

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -26,6 +26,8 @@ let
     "nodejs-19:v1-20230525-c48c43c" = { to = "nodejs-19:v2-20230605-9621162"; auto = true; };
 
     "python-3.10:v5-20230613-622effa" = { to = "python-3.10:v6-20230614-6eb09f7"; auto = true; };
+    "python-3.10:v6-20230614-6eb09f7" = { to = "python-3.10:v7-20230623-0b7a606"; auto = true; };
+    "python-3.10:v7-20230623-0b7a606" = { to = "python-3.10:v8-20230629-218abef"; auto = true; };
 
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
 


### PR DESCRIPTION
Why
===
* When I tried to install `streamlit` I got:

```
--> poetry add 'streamlit 1.24.0'

Updating dependencies
Resolving dependencies...

Writing lock file

Package operations: 2 installs, 0 updates, 0 removals

  • Installing validators (0.20.0)

  EnvCommandError

  Command ['pip', 'install', '--no-deps', 'https://files.pythonhosted.org/packages/95/14/ed0af6865d378cfc3c504aed0d278a890cbefb2f1934bf2dbe92ecf9d6b1/validators-0.20.0.tar.gz#sha256=24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a'] errored with the following return code 1, and output: 
  Looking in indexes: https://package-proxy.replit.com/pypi/simple/
  Collecting https://files.pythonhosted.org/packages/95/14/ed0af6865d378cfc3c504aed0d278a890cbefb2f1934bf2dbe92ecf9d6b1/validators-0.20.0.tar.gz#sha256=24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a
    Using cached validators-0.20.0.tar.gz (30 kB)
      ERROR: Command errored out with exit status 1:
       command: /nix/store/zdba9frlxj2ba8ca095win3nphsiiqhb-python3-3.10.8/bin/python3.10 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-k4rbph53/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-k4rbph53/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-wz_cj51q
           cwd: /tmp/pip-req-build-k4rbph53/
      Complete output (3 lines):
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
      ModuleNotFoundError: No module named 'setuptools'
      ----------------------------------------
  WARNING: Discarding https://files.pythonhosted.org/packages/95/14/ed0af6865d378cfc3c504aed0d278a890cbefb2f1934bf2dbe92ecf9d6b1/validators-0.20.0.tar.gz#sha256=24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  

  at /nix/store/298sf6p0k8yxlircd825nd9xya63mkcp-poetry-in-venv/env/lib/python3.10/site-packages/poetry/utils/env.py:1197 in _run
      1193│                 output = subprocess.check_output(
      1194│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1195│                 )
      1196│         except CalledProcessError as e:
    → 1197│             raise EnvCommandError(e, input=input_)
      1198│ 
      1199│         return decode(output)
      1200│ 
      1201│     def execute(self, bin, *args, **kwargs):


Failed to add packages, reverting the pyproject.toml file to its original content.
exit status 1
```

What changed
============
* Add setuptools to the poetry PYTHONPATH

Test plan
=========
* Using these nixmodules locally, I was able to install streamlit. 

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
