### PR TITLE
added optionFileParam attribute to runners

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -127,6 +127,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/r9k0fgr2yw22yizxrhjj1fs65pm7x0hj-replit-module-nodejs-18"
   },
+  "nodejs-18:v5-20230706-ccb32c4": {
+    "commit": "ccb32c46b2fac1df7fd7eb30814a915a2312c0c4",
+    "path": "/nix/store/3ay4x2j31b3aa9px5snfjpvj5xdrigd3-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -142,6 +146,10 @@
   "nodejs-20:v1-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/1w9kq8ydq31ab7cvwddy7xal760dpi18-replit-module-nodejs-20"
+  },
+  "nodejs-20:v2-20230706-ccb32c4": {
+    "commit": "ccb32c46b2fac1df7fd7eb30814a915a2312c0c4",
+    "path": "/nix/store/dvnc2dc97mlwrvi5hbv7pabw8wfm16jw-replit-module-nodejs-20"
   },
   "php-8.1:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -182,6 +190,10 @@
   "python-3.10:v8-20230629-218abef": {
     "commit": "218abef66eef0192a64b8e1f86ec9fcc05860818",
     "path": "/nix/store/lgg2wxc7myl9swdqhr176ma70f8sj6vv-replit-module-python-3.10"
+  },
+  "python-3.10:v9-20230706-ccb32c4": {
+    "commit": "ccb32c46b2fac1df7fd7eb30814a915a2312c0c4",
+    "path": "/nix/store/l532z6ffflhqdkacrd0ldmkhp4hnrsdk-replit-module-python-3.10"
   },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -46,7 +46,7 @@ in
       language = "javascript";
       start = "${run-prybar}/bin/run-prybar $file";
       interpreter = true;
-      fileParam = true;
+      optionalFileParam = true;
     };
 
     debuggers.nodeDAP = {

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -129,7 +129,7 @@ in
 
   replit.runners.python-prybar = {
     name = "Prybar for Python ${community-version}";
-    fileParam = true;
+    optionalFileParam = true;
     language = "python3";
     start = "${run-prybar}/bin/run-prybar $file";
     interpreter = true;


### PR DESCRIPTION
Why
===

Prompted by https://replit.slack.com/archives/C03KS2B221W/p1687220639216759, we need to preserve the existing interpreter behavior. One of the behaviors that was broken with Nix modules is when you initially open a repl with an interpreter setup with prybar, you can use the "Console" pane to enter code in the language of the repl before even hitting the run button for the first time.

Plan:

1. allow a runner to optionally take a file param with the `optionalFileParam` attribute. Only one of `optionalFileParam` and `fileParam` should be set to true
2. in pid1, an optionalFileParam runner can be run without a fileParam and will be utilized at initialization time of the interp2 service via `p.freshInterp("", p, nil)`
3. the front end will use new attribute to match files to run configs

What changed
============

1. Added `optionalFileParam` to the runner options
2. In order to not propagate a change to all modules, I wrote a `stripAttrsWithDefaultValues` function that will strip out attributes from an attribute set if its value is the same as the expected default value, in this case we only use it with `optionalFileParam`. Didn't want to use it with everything, because that would again trigger changes to all modules.
3. assertion to make sure a runner does not have both `optionalFileParam` and `fileParam` set to true
4. Updated Node.js modules with `optionalFileParam` = true

Test plan
=========

1. `cd pkgs/moduleit`
2. change example.nix to have a `optionalFileParam` set and building `./moduleit.sh example.nix`
3. try having `optionalFileParam` and `fileParam` true, building should fail

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
