### PR TITLE
add pyright-extended LSP module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -246,5 +246,9 @@
   "web:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/53vn26l79zj17g28xlfki4d3j3ra7nbi-replit-module-web"
+  },
+  "pyright-extended:v1-20230707-0c33b22": {
+    "commit": "0c33b229d159ded681992f2220e273540b6708b7",
+    "path": "/nix/store/naqna9imw62bi543fnlpg8r7rd79bf2b-replit-module-pyright-extended"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -10,6 +10,7 @@ let
       python = pkgs.python310Full;
       pypkgs = pkgs.python310Packages;
     }))
+    (mkModule ./pyright-extended)
     (mkModule (import ./nodejs {
       nodejs = pkgs.nodejs-18_x;
     }))

--- a/pkgs/modules/pyright-extended/default.nix
+++ b/pkgs/modules/pyright-extended/default.nix
@@ -1,0 +1,50 @@
+{ pkgs, lib, ... }:
+let
+  version = "1.1.317";
+
+  pyright-extended = pkgs.stdenvNoCC.mkDerivation rec {
+    pname = "pyright-extended";
+    inherit version;
+
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/@replit/pyright-extended/-/pyright-extended-${version}.tgz";
+      hash = "sha256-I/NAp7EjX0a4jzXWczUyOPC8ZFYZibPQLH5vHb9ixZU=";
+    };
+
+    binPath = lib.makeBinPath [
+      pkgs.ruff
+      pkgs.yapf
+      pkgs.nodejs_18
+    ];
+
+    nativeBuildInputs = [
+      pkgs.makeWrapper
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib
+      cp -r . $out/lib
+      mkdir -p $out/bin
+      makeWrapper "$out/lib/index.js" "$out/bin/index.js" \
+        --prefix PATH : "${binPath}"
+      makeWrapper "$out/lib/langserver.index.js" "$out/bin/langserver.index.js" \
+        --prefix PATH : "${binPath}"
+      runHook postInstall
+    '';
+  };
+
+in
+{
+  id = "pyright-extended";
+  name = "pyright-extended LSP";
+
+  replit.languageServers.python-lsp-server = {
+    name = "pyright-extended";
+    language = "python3";
+    start = "${pyright-extended}/bin/langserver.index.js --stdio";
+  };
+}


### PR DESCRIPTION
Why
===
* We'd like to try this new LSP we made

What changed
===
* Added new pyright-extended module, which only delivers an LSP.

Test plan
===
* Tried it out locally

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
