### PR TITLE
Fix prybar

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,33 +67,19 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1670276674,
-        "narHash": "sha256-FqZ7b2RpoHQ/jlG6JPcCNmG/DoUPCIvyaropUDFhF3Q=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "prybar": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1683297029,
-        "narHash": "sha256-CzzkHL+CtKO0e8r8TuJnRPln7SGc6R2Ke1HhwD9ptKU=",
+        "lastModified": 1689082687,
+        "narHash": "sha256-R1/l3hNsDxE3/2UVl7/5Llb9POlYG81DRpjprGq4+gw=",
         "owner": "replit",
         "repo": "prybar",
-        "rev": "22c750d920f53cb5450062e9c3a6421296941b84",
+        "rev": "fe84b6d426ecf88a845e6cde0f0dfaf3787e18b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.prybar.url = "github:replit/prybar";
+  inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
   inputs.java-language-server.url = "github:replit/java-language-server";
   inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/modules.json
+++ b/modules.json
@@ -135,6 +135,10 @@
     "commit": "ccb32c46b2fac1df7fd7eb30814a915a2312c0c4",
     "path": "/nix/store/3ay4x2j31b3aa9px5snfjpvj5xdrigd3-replit-module-nodejs-18"
   },
+  "nodejs-18:v6-20230711-6807d41": {
+    "commit": "6807d41cf5b2d4672b10cfaee99abb2c55af5010",
+    "path": "/nix/store/22bmyr6mq7j7vk23nwyg548b7pvrbmvl-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -154,6 +158,10 @@
   "nodejs-20:v2-20230706-ccb32c4": {
     "commit": "ccb32c46b2fac1df7fd7eb30814a915a2312c0c4",
     "path": "/nix/store/dvnc2dc97mlwrvi5hbv7pabw8wfm16jw-replit-module-nodejs-20"
+  },
+  "nodejs-20:v3-20230711-6807d41": {
+    "commit": "6807d41cf5b2d4672b10cfaee99abb2c55af5010",
+    "path": "/nix/store/fa7w38dg5il8f2ggydj9lhypj9za123h-replit-module-nodejs-20"
   },
   "php-8.1:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -198,6 +206,10 @@
   "python-3.10:v9-20230706-ccb32c4": {
     "commit": "ccb32c46b2fac1df7fd7eb30814a915a2312c0c4",
     "path": "/nix/store/l532z6ffflhqdkacrd0ldmkhp4hnrsdk-replit-module-python-3.10"
+  },
+  "python-3.10:v10-20230711-6807d41": {
+    "commit": "6807d41cf5b2d4672b10cfaee99abb2c55af5010",
+    "path": "/nix/store/fqx93fc7g2xf3p1xm46an56p6fp7fwm1-replit-module-python-3.10"
   },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",


### PR DESCRIPTION
Why
===

This prybar error:

```
$ /nix/store/98aif6s30m0l7d045x0q4hhhww8gl19q-run-prybar/bin/run-prybar main.py
/nix/store/7f2abdl02kmzra17bvc89nwh5pn3fdrg-prybar-python310-0.0.0-22c750d/bin/prybar-python310: /nix/store/4nlgxhb09sdr51nc9hdm8az5b08vzkgx-glibc-2.35-163/lib/libc.so.6: version `GLIBC_ABI_DT_RELR' not found (required by /nix/store/dg8mpqqykmw9c7l0bgzzb5znkymlbfjw-glibc-2.37-8/lib/libdl.so.2)
```

Pull in this prybar update https://github.com/replit/prybar/pull/110 to fix it

What changed
============

Added follows clause to nixpkg of prybar to make sure we use the same nixpkgs for prybar as rest of nixmodules. Updated prybar sha (hardcoded sha will be removed after prybar pr is merged and before merging this pr).

Test plan
=========

Running Prybar should not fail.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
