### PR TITLE
Added libs needed by pygame; added user bin dir to PATH

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -215,6 +215,10 @@
     "commit": "eb29cca1bc856c48a88bdd41ef7b4a18286f58c4",
     "path": "/nix/store/hm14rxnkjv7ikrsi5c9yw56qsbdbcvnz-replit-module-python-3.10"
   },
+  "python-3.10:v12-20230712-7266cd2": {
+    "commit": "7266cd2c087353e75787d3f5f141eb961b71162f",
+    "path": "/nix/store/1hmdmhfjv2513nk75g2aw63776gvjcjd-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -49,15 +49,15 @@ let
     inherit pkgs python pypkgs;
   };
 
-  python-ld-library-path = pkgs.lib.makeLibraryPath [
+  python-ld-library-path = pkgs.lib.makeLibraryPath ([
     # Needed for pandas / numpy
     pkgs.stdenv.cc.cc.lib
     pkgs.zlib
-    # Needed for pygame
     pkgs.glib
     # Needed for matplotlib
     pkgs.xorg.libX11
-  ];
+    # Needed for pygame
+  ] ++ (with pkgs.xorg; [ libXext libXinerama libXcursor libXrandr libXi libXxf86vm ]));
 
   python3-wrapper = pkgs.stdenvNoCC.mkDerivation {
     name = "python3-wrapper";
@@ -185,5 +185,6 @@ in
       POETRY_CONFIG_DIR = poetry-config.outPath;
       POETRY_VIRTUALENVS_CREATE = "0";
       PYTHONUSERBASE = userbase;
+      PATH = "${userbase}/bin";
     };
 }

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -38,6 +38,7 @@ let
     "python-3.10:v8-20230629-218abef" = { to = "python-3.10:v9-20230706-ccb32c4"; auto = true; };
     "python-3.10:v9-20230706-ccb32c4" = { to = "python-3.10:v10-20230711-6807d41"; auto = true; };
     "python-3.10:v10-20230711-6807d41" = { to = "python-3.10:v11-20230711-eb29cca"; auto = true; };
+    "python-3.10:v11-20230711-eb29cca" = { to = "python-3.10:v12-20230712-7266cd2"; auto = true; };
 
     "pyright-extended:v1-20230707-0c33b22" = { to = "pyright-extended:v2-20230711-eb29cca"; auto = true; };
 


### PR DESCRIPTION
Why
===

1. running a pygame program from the python module isn't opening a display port. The pygame template has some additional libs we didn't include
2. If you install a lib that has a binary, like `poetry add gunicorn`, the binary is installed into $REPL_HOME/.pythonlibs/bin but that is not visible to PATH

What changed
============

1. add libs for pygame
2. added $REPL_HOME/.pythonlibs/bin to PATH

Test plan
=========

1. run the program in https://replit.com/@replit/Pygame-Beta and see the Output displaying graphics
2. install `gunicorn` and be able to run it in the shell