### PR TITLE
[python] fewer libraries for pandas / numpy

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -223,6 +223,10 @@
     "commit": "4ba5dba393f9a1dde13b73b94a58b344ca0cc9ac",
     "path": "/nix/store/sip8bp1wzdfyrx4j8ws9dpkczx2wf0b7-replit-module-python-3.10"
   },
+  "python-3.10:v14-20230713-b6f899f": {
+    "commit": "b6f899fbadc6aff267d7470a7aa5e640158058d8",
+    "path": "/nix/store/mc47d2nbcj241y3m8264i3glqr6fqidl-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -39,6 +39,20 @@ let
     destination = "/conf.toml";
   };
 
+  cppLibs = pkgs.stdenvNoCC.mkDerivation {
+    name = "cpplibs";
+    dontUnpack = true;
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib
+      cp ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++* $out/lib
+
+      runHook postInstall
+    '';
+  };
+
   prybar-python = pkgs.prybar.prybar-python310;
 
   stderred = pkgs.callPackage ../../stderred { };
@@ -51,7 +65,7 @@ let
 
   python-ld-library-path = pkgs.lib.makeLibraryPath ([
     # Needed for pandas / numpy
-    pkgs.stdenv.cc.cc.lib
+    cppLibs
     pkgs.zlib
     pkgs.glib
     # Needed for matplotlib


### PR DESCRIPTION
Why
===
* We encountered an issue where a downloaded binary used libgcc_s.so from the stdenv.cc.cc.lib when the binary was called from a Python program. Numpy doesn't need all the libraries in stdenv.cc.cc.lib.

What changed
===
* Be more explicit about what binaries we need for numpy/pandas

Test plan
===
* Confirm we import numpy and pandas
* Confirm something using C++ parts of numpy works:

```
import numpy

arr = numpy.array([3, 2, 0, 1])

print(numpy.sort(arr, kind='heapsort'))
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
