### PR TITLE
update bun package version

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -15,6 +15,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/7kphn968bd4hxal2pfsr1kwvz3kmqdnx-replit-module-bun-0.6"
   },
+  "bun-0.6:v4-20230721-719ce58": {
+    "commit": "719ce588110378538018aa64c77f604840af7296",
+    "path": "/nix/store/d8yrnalpkvqclyl66fx7vsg4yxaw2c8a-replit-module-bun-0.6"
+  },
   "c-clang14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7x92nggc7kng9g1bqpmphak1xhjg55ng-replit-module-c-clang14"

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -7,12 +7,12 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  version = "0.6.7";
+  version = "0.6.14";
   pname = "bun";
 
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    sha256 = "bX3gV3wR2ZJabP6LXT4Tg3T+061aghktXD2YOrQfmWo=";
+    sha256 = "5iU+1FevTjjzo/qN0zjIoCQflbWCmdfMXkx+6BOEEcc=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Why
===

bun 1.0 is coming out soon, we'll wanna drum up hype

What changed
============

- update bun module to 0.7.14
- change runner to attempt using `package.json` first

Test plan
=========

- install this bun module in a Bun template repl
- `bun --version` should print `0.7.14`
- run button still works
- change `package.json#main` to be `src/index.ts`
- run button fails

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
