### PR TITLE
Wrap pip

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -239,6 +239,10 @@
     "commit": "2dadc923fd0e86eedf75b8693c32864a91800093",
     "path": "/nix/store/pjgicxaqah5y75s85r4d56h4yikqakd9-replit-module-python-3.10"
   },
+  "python-3.10:v16-20230726-64244b3": {
+    "commit": "64244b3b2897e11a62f63107af95367aee244ef2",
+    "path": "/nix/store/i1saik2bhi0wyaq78cgl044qhy1jy7gr-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -23,6 +23,18 @@ let
     '';
   };
 
+  pip-wrapper = pkgs.stdenvNoCC.mkDerivation {
+    name = "pip-wrapper";
+    buildInputs = [ pkgs.makeWrapper ];
+
+    buildCommand = ''
+      mkdir -p $out/bin
+      makeWrapper ${pip}/bin/pip $out/bin/pip \
+        --set LD_LIBRARY_PATH "${python-ld-library-path}" \
+        --prefix PYTHONPATH : "${pypkgs.setuptools}/${python.sitePackages}"
+    '';
+  };
+
   poetry = pkgs.callPackage ../../poetry {
     inherit python;
     inherit pypkgs;
@@ -115,7 +127,7 @@ in
 
   packages = [
     python3-wrapper
-    pip
+    pip-wrapper
     poetry-wrapper
     run-prybar
   ];
@@ -194,7 +206,7 @@ in
   replit.env =
     let userbase = "$REPL_HOME/${pylibs-dir}";
     in {
-      PYTHONPATH = "${userbase}/${python.sitePackages}";
+      PYTHONPATH = "${python}/lib/python${community-version}:${userbase}/${python.sitePackages}";
       PIP_CONFIG_FILE = pip-config.outPath;
       POETRY_CONFIG_DIR = poetry-config.outPath;
       POETRY_VIRTUALENVS_CREATE = "0";

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -42,6 +42,7 @@ let
     "python-3.10:v12-20230712-7266cd2" = { to = "python-3.10:v13-20230712-4ba5dba"; auto = true; };
     "python-3.10:v13-20230712-4ba5dba" = { to = "python-3.10:v14-20230713-b6f899f"; auto = true; };
     "python-3.10:v14-20230713-b6f899f" = { to = "python-3.10:v15-20230717-2dadc92"; auto = true; };
+    "python-3.10:v15-20230717-2dadc92" = { to = "python-3.10:v16-20230726-64244b3"; auto = true; };
 
     "pyright-extended:v1-20230707-0c33b22" = { to = "pyright-extended:v2-20230711-eb29cca"; auto = true; };
     "pyright-extended:v2-20230711-eb29cca" = { to = "pyright-extended:v3-20230712-4ba5dba"; auto = true; };


### PR DESCRIPTION
Why
===

When running pip to install a package (not poetry), if the package (example: sentence-transformers) runs post install code that depends on setuptools, it breaks because setuptools is not available. 

```
  Downloading https://package-proxy.replit.com/pypi/packages/6d/84/bba42b8266508ae5d80e2e1c1356e64543a50dfb5d6fe9cc23461532b980/sentence-transformers-0.1.0.tar.gz (35 kB)
    ERROR: Command errored out with exit status 1:
     command: /nix/store/lwzzgbnj41d657lpxczk6l5f7d5zcnj1-python3-3.10.11/bin/python3.10 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-nxdqu7u4/sentence-transformers_517f6b7fc7af4738be0aa4470c05d2cf/setup.py'"'"'; __file__='"'"'/tmp/pip-install-nxdqu7u4/sentence-transformers_517f6b7fc7af4738be0aa4470c05d2cf/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-vha7jjxb
         cwd: /tmp/pip-install-nxdqu7u4/sentence-transformers_517f6b7fc7af4738be0aa4470c05d2cf/
    Complete output (3 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'
    ----------------------------------------
```

What changed
============

Added pip wrapper that specifies a PYTHONPATH and LD_LIBRARY_PATH similar to the python wrapper, prybar wrapper and poetry wrapper.

Test plan
=========

You should be able to `pip install sentence-transformers`
