### PR TITLE
SvelteKit

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -310,5 +310,9 @@
   "pyright-extended:v4-20230717-2dadc92": {
     "commit": "2dadc923fd0e86eedf75b8693c32864a91800093",
     "path": "/nix/store/1d3768kwnppkphcriffq8w4aa8c2cric-replit-module-pyright-extended"
+  },
+  "svelte-kit-node-20:v1-20230724-46059dd": {
+    "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
+    "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -11,12 +11,14 @@ let
       pypkgs = pkgs.python310Packages;
     }))
     (mkModule ./pyright-extended)
+
     (mkModule (import ./nodejs {
       nodejs = pkgs.nodejs-18_x;
     }))
     (mkModule (import ./nodejs {
       nodejs = pkgs.nodejs_20;
     }))
+
     (mkModule ./go)
     (mkModule ./rust)
     (mkModule ./swift)
@@ -33,6 +35,7 @@ let
     (mkModule ./qbasic)
     (mkModule ./R)
     (mkModule ./ruby)
+    (mkModule ./svelte-kit)
     (mkModule ./web)
   ];
 

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -1,0 +1,41 @@
+{ pkgs-unstable, ... }:
+
+{
+  id = "svelte-kit-node-20";
+  name = "SvelteKit with Node.js 20 Tools";
+  imports = [
+    (import ../typescript-language-server {
+      nodepkgs = pkgs-unstable.nodePackages;
+    })
+  ];
+
+  packages = with pkgs-unstable; [
+    nodejs
+  ];
+
+  replit = {
+    runners.dev-server = {
+      name = "package.json dev script";
+      language = "svelte";
+      extensions = [
+        ".svelte"
+        ".js"
+        ".ts"
+      ];
+
+      start = "${pkgs-unstable.nodejs}/bin/npm run dev";
+    };
+
+    languageServers.typescript-language-server.extensions = [
+      ".ts"
+      ".js"
+    ];
+
+    languageServers.svelte-language-server = {
+      name = "Svelte Language Server";
+      language = "svelte";
+      extensions = [ ".svelte" ".js" ".ts" ];
+      start = "${pkgs-unstable.nodePackages.svelte-language-server}/bin/svelteserver --stdio";
+    };
+  };
+}


### PR DESCRIPTION
Why
===

A really popular (and getting more popular) frontend framework.

What changed
============

- added svelte-language-server to the nodejs module

Test plan
=========

- open a `.svelte` file
- type `<svelte:he` and notice completion for `<svelte:head`
- profit

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
