### PR TITLE
update nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1686089707,
-        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "lastModified": 1690083312,
+        "narHash": "sha256-I3egwgNXavad1eIjWu1kYyi0u73di/sMmlnQIuzQASk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "rev": "af8cd5ded7735ca1df1a1174864daab75feeb64a",
         "type": "github"
       },
       "original": {

--- a/modules.json
+++ b/modules.json
@@ -267,6 +267,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/k0bzn31kqx4z9r0m8gk00bxdal4dx7vc-replit-module-rust-1.69"
   },
+  "rust-1.70:v1-20230724-17660e5": {
+    "commit": "17660e54868baaacb9765ae06c5527678f2e3a0b",
+    "path": "/nix/store/6qngvxv1pbz590xiqzmasaqidcwa56k4-replit-module-rust-1.70"
+  },
   "swift-5.6:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/gxqkjmzin0ip7441rjay7kj7lkgrmmmf-replit-module-swift-5.6"


### PR DESCRIPTION
Why
===

i'm doing stuff that needs latest nixpkgs-unstable upstack

What changed
============

updated nixpkgs-unstable input

Test plan
=========

- use rust 1.70 module
- `rustc --version` prints 1.70
- profit

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
