### PR TITLE
Make the default squash disk small

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -71,6 +71,7 @@ rec {
   };
 
   bundle-squashfs = bundle-squashfs-fn {
+    moduleIds = [ "python-3.10" "nodejs-18" ];
     inherit upgrade-maps;
   };
 


### PR DESCRIPTION
Why
===

Make the squash disk for dev small so that devs can dev quicker.

What changed
============

`nix build .#bundle-squashfs` will only include node-18 and python-3.10.