### PR TITLE
phony OCI image bundle

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,61 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678190193,
+        "narHash": "sha256-nuiUyTTjzMVfeRZInX81mBrWk26/2AgjZs/cdjX1oIk=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "292b3a8437125f015adbd32efd6bcdbbd95303f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "ztoc-rs",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1678152261,
+        "narHash": "sha256-cPRDxwygVMleiSEGELrvAiq9vYAN4c3KK/K4UEO13vU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5291dd0aa7a52d607fc952763ef60714e4c881d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -7,6 +63,36 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -93,7 +179,58 @@
         "java-language-server": "java-language-server",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "prybar": "prybar"
+        "prybar": "prybar",
+        "ztoc-rs": "ztoc-rs"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "ztoc-rs",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "ztoc-rs",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677812689,
+        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "ztoc-rs": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1678987480,
+        "narHash": "sha256-DIr9S+4UTDjg2LKjEgBhByv0SSrdol0PsUroJFND1wI=",
+        "owner": "replit",
+        "repo": "ztoc-rs",
+        "rev": "389266216adec144a9ae21c7f4c765990d2e2cf5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "replit",
+        "repo": "ztoc-rs",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,8 @@
   inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
   inputs.java-language-server.url = "github:replit/java-language-server";
   inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.ztoc-rs.url = "github:replit/ztoc-rs";
+  inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, ... }:
     let

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,6 +13,17 @@ let
     inherit revstring;
   };
 
+  mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
+
+  mkPhonyOCIs = { moduleIds ? null }: pkgs.callPackage ./mk-phony-ocis {
+    inherit mkPhonyOCI;
+    modulesLocks = import ./filter-modules-locks {
+      inherit pkgs;
+      inherit moduleIds;
+    };
+    inherit revstring;
+  };
+
   bundle-squashfs-fn = { moduleIds ? null, upgrade-maps }:
     let
       modulesLocks = import ./filter-modules-locks {
@@ -82,5 +93,9 @@ rec {
     moduleIds = [ "python-3.10" "nodejs-18" ];
     inherit upgrade-maps;
   };
+
+  custom-bundle-phony-ocis = mkPhonyOCIs { moduleIds = [ "nodejs-18" ]; };
+
+  bundle-phony-ocis = mkPhonyOCIs { };
 
 } // modules

--- a/pkgs/mk-phony-oci/builder.sh
+++ b/pkgs/mk-phony-oci/builder.sh
@@ -1,0 +1,81 @@
+set -eou pipefail
+. .attrs.sh
+
+PATH="${env[PATH]}"
+out="${outputs[out]}"
+mkdir $out
+
+mkdir image
+echo '{"imageLayoutVersion": "1.0.0"}' > ${out}/oci-layout
+
+tar -Pcpf ${out}/layer.tar --hard-dereference --sort=name --mtime="1970-01-01T00:00:01Z" \
+  --owner=0 --group=0 --verbatim-files-from --files-from "${env[diskClosureInfo]}"/store-paths
+
+DIFFID=$(sha256sum ${out}/layer.tar | cut -f -1 -d ' ')
+pigz ${out}/layer.tar
+LAYER_DIGEST=$(sha256sum ${out}/layer.tar.gz | cut -f -1 -d ' ')
+cat ${out}/layer.tar.gz | ztoc > ${out}/ztoc
+ZTOC_DIGEST=$(sha256sum ${out}/ztoc | cut -f -1 -d ' ')
+
+LAYER_SIZE=$(stat --printf='%s' ${out}/layer.tar.gz)
+ZTOC_SIZE=$(stat --printf='%s' ${out}/ztoc)
+
+mkdir -p ${out}/blobs/sha256/
+mv ${out}/layer.tar.gz "${out}/blobs/sha256/${LAYER_DIGEST}"
+mv ${out}/ztoc "${out}/blobs/sha256/${ZTOC_DIGEST}"
+
+## Phony Image
+
+echo '{}' > ${out}/config.json
+CONFIG_DIGEST=$(sha256sum ${out}/config.json | cut -f -1 -d ' ')
+CONFIG_SIZE=$(stat --printf='%s' ${out}/config.json)
+mv "${out}/config.json" "${out}/blobs/sha256/${CONFIG_DIGEST}"
+
+cat <<EOF > ${out}/manifest.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.example+type",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:${CONFIG_DIGEST}",
+    "size": ${CONFIG_SIZE}
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:${LAYER_DIGEST}",
+      "size": ${LAYER_SIZE},
+      "annotations": {
+        "com.replit.diffid": "${DIFFID}"
+      }
+    },
+    {
+      "mediaType": "application/octet-stream",
+      "digest": "sha256:${ZTOC_DIGEST}",
+      "size": ${ZTOC_SIZE}
+    }
+  ]
+}
+EOF
+MANIFEST_DIGEST=$(sha256sum ${out}/manifest.json | cut -f -1 -d ' ')
+MANIFEST_SIZE=$(stat --printf='%s' ${out}/manifest.json)
+mv "${out}/manifest.json" "${out}/blobs/sha256/${MANIFEST_DIGEST}"
+
+cat <<EOF > ${out}/index.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "artifactType": "application/vnd.example+type",
+      "digest": "sha256:${MANIFEST_DIGEST}",
+      "size": ${MANIFEST_SIZE},
+      "annotations": {
+        "org.opencontainers.image.ref.name": "${env[MODULE_ID]}"
+      }
+    }
+  ]
+}
+EOF

--- a/pkgs/mk-phony-oci/default.nix
+++ b/pkgs/mk-phony-oci/default.nix
@@ -1,0 +1,34 @@
+{ system
+, bash
+, lib
+, coreutils
+, closureInfo
+, gnutar
+, pigz
+, ztoc-rs
+}:
+
+{ module, moduleId }:
+let
+  sanitizedModuleId = builtins.replaceStrings [ ":" ] [ "_" ] moduleId;
+in
+derivation {
+  name = "oci-image-${sanitizedModuleId}";
+  builder = "${bash}/bin/bash";
+  args = [ ./builder.sh ];
+  inherit system;
+  __structuredAttrs = true;
+  unsafeDiscardReferences.out = true;
+  outputs = [ "out" ];
+  env = {
+    MODULE_ID = moduleId;
+    PATH = lib.makeBinPath [
+      coreutils
+      coreutils
+      gnutar
+      pigz
+      ztoc-rs
+    ];
+    diskClosureInfo = closureInfo { rootPaths = [ module ]; };
+  };
+}

--- a/pkgs/mk-phony-ocis/default.nix
+++ b/pkgs/mk-phony-ocis/default.nix
@@ -1,0 +1,35 @@
+{ pkgs
+, revstring
+, modulesLocks
+, mkPhonyOCI
+}:
+
+with pkgs.lib;
+
+let
+  commits = unique (catAttrs "commit" (builtins.attrValues modulesLocks));
+
+  flakes = builtins.listToAttrs (
+    map
+      (commit: {
+        name = commit;
+        value = builtins.getFlake "github:replit/nixmodules/${commit}";
+      })
+      commits);
+
+  phonyOCIs = builtins.mapAttrs
+    (name: module:
+      let
+        module-id = elemAt (strings.splitString ":" name) 0;
+        m = (flakes.${module.commit}).modules.${module-id};
+      in
+      # verify the outpath matches what the lockfile expects
+      assert m.outPath == module.path;
+      mkPhonyOCI { module = m; moduleId = name; })
+    modulesLocks;
+
+in
+
+pkgs.linkFarm "nixmodules-phonyOCI-${revstring}" (
+  mapAttrsToList (name: value: { inherit name; path = value; }) phonyOCIs
+)


### PR DESCRIPTION
Why
===
* We'd like to be able to quickly build containers that depend on nixmodules.

What changed
===
* Add new bundle-phony-ocis package output that makes a phony OCI image for each nixmodule. The OCI images contain a layer that is the /nix/store paths of the module, and a ZTOC blob for that layer. These modules cna be uploaded to a Registry.

Test plan
===
* built `nix build .#bundle-phony-ocis` output looks reasonable
* can push output to Registry

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
