### PR TITLE
Upgrade poetry to 1.5.1

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -243,6 +243,10 @@
     "commit": "64244b3b2897e11a62f63107af95367aee244ef2",
     "path": "/nix/store/i1saik2bhi0wyaq78cgl044qhy1jy7gr-replit-module-python-3.10"
   },
+  "python-3.10:v17-20230803-f57c5cc": {
+    "commit": "f57c5cc1d8a9393b18f28bdb5e49214e6804bd9e",
+    "path": "/nix/store/fv2xdkgsvcxyb3zkmk0vn5cqrcry1vhc-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -209,7 +209,14 @@ in
       PYTHONPATH = "${python}/lib/python${community-version}:${userbase}/${python.sitePackages}";
       PIP_CONFIG_FILE = pip-config.outPath;
       POETRY_CONFIG_DIR = poetry-config.outPath;
+      POETRY_CACHE_DIR = "$REPL_HOME/.cache/pypoetry";
       POETRY_VIRTUALENVS_CREATE = "0";
+      POETRY_INSTALLER_MODERN_INSTALLATION = "0";
+      POETRY_PIP_USE_PIP_CACHE = "1";
+      POETRY_PIP_NO_ISOLATE = "1";
+      POETRY_PIP_NO_PREFIX = "1";
+      POETRY_PIP_FROM_PATH = "1";
+      POETRY_USE_USER_SITE = "1";
       PYTHONUSERBASE = userbase;
       PATH = "${userbase}/bin";
     };

--- a/pkgs/poetry/default.nix
+++ b/pkgs/poetry/default.nix
@@ -3,11 +3,11 @@ let
 
   myPoetry = pkgs.stdenv.mkDerivation {
     name = "poetry-in-venv";
-    version = "1.1.13";
+    version = "1.5.1";
 
     src = builtins.fetchTarball {
-      url = https://storage.googleapis.com/poetry-bundles/poetry-1.1.14-bundle.tgz;
-      sha256 = "sha256:0qg41d4gvlmsfzqz8vsh4spzxvky9y750jp1h67v5ips1xzalq4w";
+      url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.1-bundle.tgz;
+      sha256 = "sha256:1qh1w1dr2wvqla4cdxcgvl9xipcyk31mapivcp66v92mkvpayygk";
     };
 
     buildInputs = [ pypkgs.pip ];


### PR DESCRIPTION
Why
===

Upgrade to the latest stable 1.5 line of poetry. We still have [customizations](https://github.com/replit/poetry) but they are current to the [upstream line](https://github.com/python-poetry/poetry/tree/1.5).

What changed
============

Updated poetry version and added new customization flags.