### PR TITLE
Make moduleit exit with 1 if nix-build fails

### DIFF
--- a/pkgs/moduleit/moduleit.sh
+++ b/pkgs/moduleit/moduleit.sh
@@ -25,6 +25,11 @@ fi
 echo "nix-build ${args[@]}"
 nix-build "${args[@]}"
 
+if [ $? -ne 0 ]
+then
+  exit 1
+fi
+
 if [ -L "${OUTPUT_FILE}" ]; then
   # If output link was provided,
   # materialize the output as an actual file containing the JSON config


### PR DESCRIPTION
Why
===

When moduleit fails due to nix-build, it still returns exit code 0. Causing Nix modules to emit a .res file without an error.

Context: https://replit.slack.com/archives/C03KS2B221W/p1690387564427729

What changed
============

If nix-build fails, moduleit returns exit code 1.

Test plan
=========

Try compiling the nix files in https://replit.com/join/xgtafsfodg-coltonatreplit with moduleit. It should fail and `echo $?` should give 1