### PR TITLE
pyright-extended: 2.0.1 -> 2.0.3 

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -247,6 +247,10 @@
     "commit": "f57c5cc1d8a9393b18f28bdb5e49214e6804bd9e",
     "path": "/nix/store/fv2xdkgsvcxyb3zkmk0vn5cqrcry1vhc-replit-module-python-3.10"
   },
+  "python-3.10:v18-20230807-322e88b": {
+    "commit": "322e88bc93d0bd99994822232e87ab3ec383fe76",
+    "path": "/nix/store/bncbm7nx30h0vg9vj76wd03gn0f1016m-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -314,6 +318,10 @@
   "pyright-extended:v4-20230717-2dadc92": {
     "commit": "2dadc923fd0e86eedf75b8693c32864a91800093",
     "path": "/nix/store/1d3768kwnppkphcriffq8w4aa8c2cric-replit-module-pyright-extended"
+  },
+  "pyright-extended:v5-20230807-322e88b": {
+    "commit": "322e88bc93d0bd99994822232e87ab3ec383fe76",
+    "path": "/nix/store/i9n4y2r4s99m2fzv8k46lvd52ixy95k9-replit-module-pyright-extended"
   },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",

--- a/pkgs/pyright-extended/default.nix
+++ b/pkgs/pyright-extended/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 let
-  version = "2.0.1";
+  version = "2.0.3";
 in
 pkgs.stdenvNoCC.mkDerivation rec {
   pname = "pyright-extended";
@@ -8,7 +8,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
 
   src = pkgs.fetchurl {
     url = "https://registry.npmjs.org/@replit/pyright-extended/-/pyright-extended-${version}.tgz";
-    hash = "sha256-Z6KrDIXAJHsZgBmV09czN/Pc9usnNReQxSz3w9S2vGs=";
+    hash = "sha256-ROuFPc1XFslqGlFjkOl0xDqYdPzWWeJs67KUHHP10DQ=";
   };
 
   binPath = lib.makeBinPath [

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -43,10 +43,13 @@ let
     "python-3.10:v13-20230712-4ba5dba" = { to = "python-3.10:v14-20230713-b6f899f"; auto = true; };
     "python-3.10:v14-20230713-b6f899f" = { to = "python-3.10:v15-20230717-2dadc92"; auto = true; };
     "python-3.10:v15-20230717-2dadc92" = { to = "python-3.10:v16-20230726-64244b3"; auto = true; };
+    "python-3.10:v16-20230726-64244b3" = { to = "python-3.10:v17-20230803-f57c5cc"; auto = true; };
+    "python-3.10:v17-20230803-f57c5cc" = { to = "python-3.10:v18-20230807-322e88b"; auto = true; };
 
     "pyright-extended:v1-20230707-0c33b22" = { to = "pyright-extended:v2-20230711-eb29cca"; auto = true; };
     "pyright-extended:v2-20230711-eb29cca" = { to = "pyright-extended:v3-20230712-4ba5dba"; auto = true; };
     "pyright-extended:v3-20230712-4ba5dba" = { to = "pyright-extended:v4-20230717-2dadc92"; auto = true; };
+    "pyright-extended:v4-20230717-2dadc92" = { to = "pyright-extended:v5-20230807-322e88b"; auto = true; };
 
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
 


### PR DESCRIPTION
Why
===
* updated version

What changed
===
* bumped version

Test plan
===
* cli showed sensible output for
```
/nix/store/6yxbmlpflvp76msczz459dwjpycdakmp-pyright-extended-2.0.3/bin/langserver.index.js --stdio
```

Rollout
=======
_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
