### PR TITLE
add gcloud module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -334,5 +334,9 @@
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
+  },
+  "gcloud:v1-20230815-e6e4431": {
+    "commit": "e6e4431a8f1d71ec0664ce97828bede1608dcfd1",
+    "path": "/nix/store/q67zzk6y4zzw7k6nc2plql97z1yv7xwx-replit-module-gcloud"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -26,6 +26,7 @@ let
     (mkModule ./c)
     (mkModule ./cpp)
     (mkModule ./dart)
+    (mkModule ./gcloud)
     (mkModule ./clojure)
     (mkModule ./dotnet)
     (mkModule ./haskell)

--- a/pkgs/modules/gcloud/default.nix
+++ b/pkgs/modules/gcloud/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  id = "gcloud";
+  name = "Google Cloud Tools";
+  packages = [
+    pkgs.google-cloud-sdk
+  ];
+}


### PR DESCRIPTION
Why
===
* We'd like to make it very easy to install Google Cloud tools

What changed
===
* Add module that installs google-cloud-sdk

Test plan
===
* builds fine locally, can run binaries from result

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
