### PR TITLE
[oci image] update ztoc-rs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678987480,
-        "narHash": "sha256-DIr9S+4UTDjg2LKjEgBhByv0SSrdol0PsUroJFND1wI=",
+        "lastModified": 1692732389,
+        "narHash": "sha256-32ODTGZ5Mgj9zoTerSbzVUFRnvDTvCeIGwxmDsf2DTU=",
         "owner": "replit",
         "repo": "ztoc-rs",
-        "rev": "389266216adec144a9ae21c7f4c765990d2e2cf5",
+        "rev": "a170dec3756c013c365340273052286aa7b6a38a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Why
===
* Conner and I found a bug where ztoc-rs was not generating the same span format as soci-snapshotter's own tool. Fixed in https://github.com/replit/ztoc-rs/pull/1

What changed
===
* Update ztoc-rs to pull in bugfix

Test plan
===
* Already tested that this new oci image ztoc does not cause soci-snapshotter to crash in the same scenario it did before. Ran a custom soci-snapshotter at a debug log level and confirmed it pulled all the spans from each of the nixmodules images.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
