### PR TITLE
[python] add escape hatch for LD_LIBRARY_PATH

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -259,6 +259,10 @@
     "commit": "9932e6ad065e5c5c418204b33509f9ac0eb05bd9",
     "path": "/nix/store/n162cnl1pjz2a1l1gx7j6zpxxbw10daz-replit-module-python-3.10"
   },
+  "python-3.10:v20-20230824-f46249a": {
+    "commit": "f46249a0c04d1c2aad26c837d68d736de2b6bcf8",
+    "path": "/nix/store/g9ip8421pf99fy2nbw26bc2bv45rw2gk-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -50,6 +50,7 @@ let
     "python-3.10:v16-20230726-64244b3" = { to = "python-3.10:v17-20230803-f57c5cc"; auto = true; };
     "python-3.10:v17-20230803-f57c5cc" = { to = "python-3.10:v18-20230807-322e88b"; auto = true; };
     "python-3.10:v18-20230807-322e88b" = { to = "python-3.10:v19-20230816-9932e6a"; auto = true; };
+    "python-3.10:v19-20230816-9932e6a" = { to = "python-3.10:v20-20230824-f46249a"; auto = true; };
 
     "pyright-extended:v1-20230707-0c33b22" = { to = "pyright-extended:v2-20230711-eb29cca"; auto = true; };
     "pyright-extended:v2-20230711-eb29cca" = { to = "pyright-extended:v3-20230712-4ba5dba"; auto = true; };


### PR DESCRIPTION
Why
===
* Currently there is no way for the end user to add dynamic libraries to the Python environment

What changed
===
* Introduce PYTHON_LD_LIBRARY_PATH (an env var we had in older Replit Python templates). If this variable is set in the environment, use it for Python's LD_LIBRARY_PATH and ignore the default settings. If someone uses the escape hatch, they have to go all the way.
* Make a pythonWrapper helper function that allows us to keep all the wrappers consistent

Test plan
===
* Ran all the wrapped binaries. Tested that LD_LIBRARY_PATH is what I expect.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
