### PR TITLE
[WS-967] Add prettier to node nixmodules

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -151,6 +151,10 @@
     "commit": "6807d41cf5b2d4672b10cfaee99abb2c55af5010",
     "path": "/nix/store/22bmyr6mq7j7vk23nwyg548b7pvrbmvl-replit-module-nodejs-18"
   },
+  "nodejs-18:v7-20230905-8d7bacf": {
+    "commit": "8d7bacfd650a9419c5a22372e81b05c8334716ad",
+    "path": "/nix/store/avi0wg5i5q356fxqgnyc32w52agzw70f-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -174,6 +178,10 @@
   "nodejs-20:v3-20230711-6807d41": {
     "commit": "6807d41cf5b2d4672b10cfaee99abb2c55af5010",
     "path": "/nix/store/fa7w38dg5il8f2ggydj9lhypj9za123h-replit-module-nodejs-20"
+  },
+  "nodejs-20:v4-20230905-8d7bacf": {
+    "commit": "8d7bacfd650a9419c5a22372e81b05c8334716ad",
+    "path": "/nix/store/xjv5b5c2qsvw4zlvlw3m5kcwl0p56b5v-replit-module-nodejs-20"
   },
   "php-8.1:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -15,6 +15,8 @@ let
     ${prybar}/bin/prybar-nodejs -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i ''$1
   '';
 
+  prettier = nodepkgs.prettier;
+
 in
 
 {
@@ -28,6 +30,7 @@ in
 
   packages = [
     nodejs
+    prettier
   ];
 
   replit = {
@@ -91,6 +94,14 @@ in
           type = "pwa-node";
         };
       };
+    };
+
+    formatters.prettier = {
+      name = "Prettier";
+      language = "javascript";
+      extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ];
+      start = "${prettier}/bin/prettier --stdin-filepath $file";
+      stdin = true;
     };
 
     packagers.upmNodejs = {


### PR DESCRIPTION
Why
===

https://linear.app/replit/issue/WS-967/add-prettier-to-jsts-nixmodules

Trying to support prettier as a more built-in experience in js/ts repls. The idea here is:
* Add it to nix modules
* Expose it as a `formatters` through toolchain config
* Allow user to select it as their formatter (or use lsp formatter, etc)


What changed
============

* Following Toby's high level steps here to add prettier and expose through `formatters` field
* Ran `python scripts/lock_modules.py`

Test plan
=========

I'm not sure how to test this. If there's a way to point a local replit web at this so I can confirm prettier is infact installed, that sounds good. But I might need some help figuring out how to do that.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
