### PR TITLE
[ci] try using Magic Nix Cache

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,5 +9,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v20
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - run: scripts/ci_check.sh


### PR DESCRIPTION
Why
===
* We don't want to have it build everything every time
* https://github.com/DeterminateSystems/magic-nix-cache-action

What changed
===
* Use Determinate Systems installer and magic nix cache in CI workflow

Test plan
===
* CI passes

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
