### PR TITLE
feat: add nix module with nixd language server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,6 +56,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -121,6 +139,27 @@
         "type": "github"
       }
     },
+    "nixd": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693052712,
+        "narHash": "sha256-7wrP6s4OEuR7BUasy76n7j+c09rp7wyOq7YVYviXw9s=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "f88accc8a8231efdae900ff6a14cb6301a73cff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1687466461,
@@ -133,6 +172,24 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -177,6 +234,7 @@
     "root": {
       "inputs": {
         "java-language-server": "java-language-server",
+        "nixd": "nixd",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar",

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,8 @@
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nixd.url = "github:nix-community/nixd";
+  inputs.nixd.inputs.nixpkgs.follows = "nixpkgs";
   inputs.prybar.url = "github:replit/prybar";
   inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
   inputs.java-language-server.url = "github:replit/java-language-server";
@@ -9,11 +11,11 @@
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
   inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
-        overlays = [ self.overlays.default prybar.overlays.default java-language-server.overlays.default ]; # ++ import ;
+        overlays = [ self.overlays.default prybar.overlays.default java-language-server.overlays.default nixd.overlays.default ]; # ++ import ;
         # replbox has an unfree license
         config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
           "@replit/replbox"

--- a/modules.json
+++ b/modules.json
@@ -454,5 +454,9 @@
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
+  },
+  "nix:v1-20230906-ff49114": {
+    "commit": "ff491143e779453de50b979dc7dd35ac0f2ef40a",
+    "path": "/nix/store/4lhzsk1lq4hirb9fp6hv43w56cq88lpi-replit-module-nix"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -40,6 +40,7 @@ let
     (mkModule ./haskell)
     (mkModule ./java)
     (mkModule ./lua)
+    (mkModule ./nix)
     (mkModule ./php)
     (mkModule ./qbasic)
     (mkModule ./R)

--- a/pkgs/modules/nix/default.nix
+++ b/pkgs/modules/nix/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }: {
+  id = "nix";
+  name = "Nix";
+
+  replit.languageServers.nixd = {
+    name = "nixd";
+    language = "nix";
+    start = "${pkgs.nixd}/bin/nixd";
+    extensions = [ ".nix" ];
+
+    configuration = {
+      options.enable = false;
+    };
+  };
+}


### PR DESCRIPTION
Why
===

We don't currently have a language server running for Nix files which can make it feel like you're flying blind. Instead, we can leverage [`nixd`](https://github.com/nix-community/nixd) to provide a rich experience and potentially options completion in the future.

What changed
============

We now pull in `nixd` via flake input and a new `nix` module was added that configures the language server for Nix files.

Test plan
=========

Help! What is a good way for me to test that this works?

Rollout
=======

I don't believe this will introduce any incompatibilities. Should be good to roll out once confirmed working and any feedback is addressed.

- [x] This is fully backward and forward compatible
