### PR TITLE
[WS-967] Update prettier start command

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -159,6 +159,10 @@
     "commit": "8d7bacfd650a9419c5a22372e81b05c8334716ad",
     "path": "/nix/store/avi0wg5i5q356fxqgnyc32w52agzw70f-replit-module-nodejs-18"
   },
+  "nodejs-18:v8-20230907-87be05d": {
+    "commit": "87be05dfc7d57cceff2c71898a23f16da33d1dfd",
+    "path": "/nix/store/s33j5i04xh289d7hz98hgbfhnixxbi58-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -186,6 +190,10 @@
   "nodejs-20:v4-20230905-8d7bacf": {
     "commit": "8d7bacfd650a9419c5a22372e81b05c8334716ad",
     "path": "/nix/store/xjv5b5c2qsvw4zlvlw3m5kcwl0p56b5v-replit-module-nodejs-20"
+  },
+  "nodejs-20:v5-20230907-87be05d": {
+    "commit": "87be05dfc7d57cceff2c71898a23f16da33d1dfd",
+    "path": "/nix/store/f9f4zzgr2clzsq84fgbps153yp4h1phk-replit-module-nodejs-20"
   },
   "php-8.1:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -100,7 +100,9 @@ in
       name = "Prettier";
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ];
-      start = "${prettier}/bin/prettier --stdin-filepath $file";
+      start = {
+        args = [ "${prettier}/bin/prettier" "--stdin-filepath" "$file" ];
+      };
       stdin = true;
     };
 


### PR DESCRIPTION
Why
===


When the start command is a string, it gets modified into `sh -c <command>`. See https://github.com/replit/goval/pull/10626#discussion_r1317457548

We don't actually want `sh -c`, because we need to pipe the output from stdin, so let's pass the start command in a different format.

What changed
============



Use an array of args for start command

Test plan
=========


Tested this end to end using `custom-nixmodules-disk`, loaded it in local conman, and was able to run prettier in local repl-it-web

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
