### PR TITLE
fix prybar invocation for python 3.8

### DIFF
--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -75,11 +75,6 @@ let
     '';
   };
 
-  prybar-python =
-    if pythonVersion == "3.8"
-    then pkgs.prybar.prybar-python3
-    else pkgs.prybar.prybar-python310;
-
   stderred = pkgs.callPackage ../../stderred { };
 
   dapPython = pkgs.callPackage ../../dapPython {
@@ -139,8 +134,10 @@ let
 
   python3-wrapper = pythonWrapper { bin = "${python}/bin/python3"; name = "python3"; aliases = [ "python" "python${pythonVersion}" ]; };
 
+  prybar-python-version = if pythonVersion == "3.8" then "3" else "310";
+
   run-prybar-bin = pkgs.writeShellScriptBin "run-prybar" ''
-    ${stderred}/bin/stderred -- ${prybar-python}/bin/prybar-python310 -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i ''$1
+    ${stderred}/bin/stderred -- ${pkgs.prybar."prybar-python${prybar-python-version}"}/bin/prybar-python${prybar-python-version} -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i ''$1
   '';
 
   run-prybar = pythonWrapper { bin = "${run-prybar-bin}/bin/run-prybar"; name = "run-prybar"; };


### PR DESCRIPTION
Why
===

run button with python 3.8 module doesn't work

What changed
============

fixed the bin path for python prybar for python 3.8 module

Test plan
=========

run button works with python 3.8 module

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
