### PR TITLE
php: remove v1 module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -215,10 +215,6 @@
     "commit": "1095880875b051ac1690ea27bc76803db516f800",
     "path": "/nix/store/dkf8rlcnvhax5387y6hp65ncqak6irfw-replit-module-nodejs-20"
   },
-  "php-8.1:v1-20230525-c48c43c": {
-    "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
-    "path": "/nix/store/rb9vj0jxx7cbmk29j5ncjr3ipl1nmrxw-replit-module-php-8.1"
-  },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/1y67njsbspbq0dd6g4jry4b3sjs9h28l-replit-module-php-8.1"

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -51,6 +51,8 @@ let
     "nodejs-20:v5-20230907-87be05d" = { to = "nodejs-20:v6-20230908-bb1b9fd"; auto = true; };
     "nodejs-20:v6-20230908-bb1b9fd" = { to = "nodejs-20:v7-20230914-1095880"; auto = true; };
 
+    "php-8.1:v1-20230525-c48c43c" = { to = "php-8.1:v2-20230623-0b7a606"; auto = true; };
+
     "python-3.8:v1-20230829-e1c0916" = { to = "python-3.8:v2-20230907-3d66d15"; auto = true; };
     "python-3.8:v2-20230907-3d66d15" = { to = "python-3.8:v3-20230914-1095880"; auto = true; };
 


### PR DESCRIPTION
Why
===
* Hydra cannot built it because the fixed-output-derivation is not reproducible

What changed
===
* Removed php-8.1:v1 from module lock file
* Added missing upgrade map for php from v1 to v2

Test plan
===
* CI passes
* Add the old PHP nixmodule string and confirm it still installs the v2
* Check hydra builds to see if this is no longer a problem

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
