### PR TITLE
Added set of all oci bundles

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -96,6 +96,20 @@ rec {
 
   custom-bundle-phony-ocis = mkPhonyOCIs { moduleIds = [ "nodejs-18" ]; };
 
+  all-phony-oci-bundles = mapAttrs
+    (moduleId: module:
+      let
+        flake = builtins.getFlake "github:replit/nixmodules/${module.commit}";
+        shortModuleId = elemAt (strings.splitString ":" moduleId) 0;
+      in
+      mkPhonyOCI {
+        inherit moduleId;
+        module = flake.modules.${shortModuleId};
+      })
+    all-modules;
+
   bundle-phony-ocis = mkPhonyOCIs { };
+
+  inherit all-modules;
 
 } // modules


### PR DESCRIPTION
Why
===

The nixmodules_oci.sh script builds an OCI for every historical module (there are ~110 currently). This is very time and disk space consuming. We can check with the docker repository to be able to only build the ones that do not already exist.

What changed
============

1. Added a mapping module ID -> OCI derivation for every historical module ID
2. Added a way to get all historical modules for scripting purposes

Test plan
=========

1. `nix eval .#all-modules --json |jq`
2. `nix build .#'all-phony-oci-bundles."nodejs-18:v10-20230914-1095880"'`
