### PR TITLE
Pin pip version with a tag

### DIFF
--- a/pkgs/pip/default.nix
+++ b/pkgs/pip/default.nix
@@ -7,7 +7,7 @@ pypkgs.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "replit";
     repo = pname;
-    rev = "main";
+    rev = "21.2.dev0";
     sha256 = "sha256-k4RnK9TnvfJlxpihdHFg3JmYtNDC4KY+f41VwJ+e+1A=";
     name = "${pname}-${version}-source";
   };


### PR DESCRIPTION
Why
===

ci was [failing](https://github.com/replit/nixmodules/actions/runs/6252687183/job/16976470675?pr=109) due to  updates in [pip repo](https://github.com/replit/pip/commits/main).

What changed
============

Pinned to specific tag.