### PR TITLE
fix package json runner

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -487,6 +487,10 @@
     "commit": "82a14e9392a6379c9558269f56a1d00deb731789",
     "path": "/nix/store/954jfxrmx2ak1hskq9hk2diwql1w5ds5-replit-module-bun-1.0"
   },
+  "bun-1.0:v5-20230921-cc7a2dd": {
+    "commit": "cc7a2ddd7b32a46569023d76fe3944f25beffc94",
+    "path": "/nix/store/k5pg3mxa92cxg1pviqvpyqfp0sm6g36v-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"

--- a/pkgs/modules/run-package-json/default.nix
+++ b/pkgs/modules/run-package-json/default.nix
@@ -5,17 +5,21 @@
 let
   bun = pkgs-unstable.callPackage ../../bun { };
 
-  script = pkgs-unstable.writeScript "package-json-runner" ''
+  script = pkgs-unstable.writeScriptBin "package-json-runner" ''
     #!${bun}/bin/bun
-    
+
     ${builtins.readFile ./script.js}
   '';
 in
 
 {
+  packages = [
+    script
+  ];
+
   replit.runners."package.json" = {
     name = "package.json";
-    start = "${script} --run-script ${runFileScript} --run-package-json-script ${runPackageJsonScript}";
+    start = "${script}/bin/package-json-runner --run-script ${runFileScript} --run-package-json-script ${runPackageJsonScript}";
     optionalFileParam = true;
   };
 }

--- a/pkgs/modules/run-package-json/default.nix
+++ b/pkgs/modules/run-package-json/default.nix
@@ -1,12 +1,10 @@
 { runPackageJsonScript, runFileScript }:
 
-{ config, lib, pkgs-unstable, ... }:
+{ config, lib, pkgs, ... }:
 
 let
-  bun = pkgs-unstable.callPackage ../../bun { };
-
-  script = pkgs-unstable.writeScriptBin "package-json-runner" ''
-    #!${bun}/bin/bun
+  script = pkgs.writeScriptBin "package-json-runner" ''
+    #! ${pkgs.nodejs}/bin/node
 
     ${builtins.readFile ./script.js}
   '';

--- a/pkgs/modules/run-package-json/script.js
+++ b/pkgs/modules/run-package-json/script.js
@@ -1,6 +1,6 @@
-const fs = require("node:fs");
-const path = require("node:path");
-const { spawn } = require("node:child_process");
+const fs = require("fs");
+const path = require("path");
+const { spawn, exec } = require("child_process");
 
 const args = process.argv.slice(1);
 
@@ -67,9 +67,8 @@ if (hasScripts && packageJson.scripts["replit-dev"]) {
 
 console.info(`+ ${cmd}`);
 
-spawn('sh', ['-c', cmd], {
-	stdio: 'inherit',
-	cwd: process.cwd(),
-	detached: true,
-	shell: false,
-}).unref();
+exec(cmd, {
+  cwd: process.cwd(),
+  stdio: 'inherit',
+  shell: false,
+})

--- a/pkgs/modules/run-package-json/script.js
+++ b/pkgs/modules/run-package-json/script.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const { spawn, exec } = require("child_process");
+const { exec } = require("child_process");
 
 const args = process.argv.slice(1);
 

--- a/pkgs/modules/run-package-json/script.js
+++ b/pkgs/modules/run-package-json/script.js
@@ -50,26 +50,25 @@ const hasScripts = Boolean(packageJson.scripts);
 let cmd = null;
 if (hasScripts && packageJson.scripts["replit-dev"]) {
   checkPackageJsonScript();
-  cmd = `${runPackageJsonScript} replit-dev`;
+  cmd = [runPackageJsonScript, 'replit-dev'];
 } else if (hasScripts && packageJson.scripts["dev"]) {
   checkPackageJsonScript();
-  cmd = `${runPackageJsonScript} dev`;
+  cmd = [runPackageJsonScript, 'dev'];
 } else if (packageJson["main"]) {
   checkRunScript();
-  cmd = `${runScript} ${packageJson["main"]}`;
+  cmd = [runScript, packageJson["main"]];
 } else if (process.env.file) {
   checkRunScript();
-  cmd = `${runScript} ${process.env.file}`;
+  cmd = [runScript, process.env.file];
 } else {
   console.error("Nothing to run.");
   process.exit(1);
 }
 
-console.info(`+ ${cmd}`);
+console.info(`+ ${cmd.join(' ')}`);
 
-spawn('sh', ['-c', cmd], {
+spawn(cmd[0], cmd.slice(1).join(' '), {
 	stdio: 'inherit',
 	cwd: process.cwd(),
-	detached: true,
 	shell: false,
-}).unref();
+})

--- a/pkgs/modules/run-package-json/script.js
+++ b/pkgs/modules/run-package-json/script.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
-const path = require("path");
-const { exec } = require("child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
 
 const args = process.argv.slice(1);
 
@@ -67,8 +67,9 @@ if (hasScripts && packageJson.scripts["replit-dev"]) {
 
 console.info(`+ ${cmd}`);
 
-exec(cmd, {
-  cwd: process.cwd(),
-  stdio: 'inherit',
-  shell: false,
-})
+spawn('sh', ['-c', cmd], {
+	stdio: 'inherit',
+	cwd: process.cwd(),
+	detached: true,
+	shell: false,
+}).unref();

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -41,6 +41,20 @@ let
         - the `entrypoint` defined in `.replit`
       '';
     };
+    "bun-1.0:v3-20230915-80b0f23" = {
+      to = "bun-1.0:v5-20230921-cc7a2dd";
+      auto = true;
+      changelog = ''# `package.json` runner
+        The runner for bun module has changed for increased flexibility and conformance to standards.
+
+        The new precedence is:
+        - the `replit-dev` script defined in `package.json`
+        - the `dev` script defined in `package.json`
+        - the `main` file defined in `package.json`
+        - the `entrypoint` defined in `.replit`
+      '';
+    };
+
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
     "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };


### PR DESCRIPTION
Why
===

looks like bun tried to `ls /nix/store` since the package-json-runner script was a direct child of that dir

also, the Stop button wasn't working

What changed
============

- use `writeScriptBin` instead of `writeScript` for the package-json-runner script
- use `exec` instead of `spawn` to launch the command

Test plan
=========

- open bun repl
- `strace -s512 -fostrace.txt package-json-runner --run-script exit --run-package-json-script exit` doesn't yield an `openat(..., "/nix/store/", ...)` in `strace.txt`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
