### PR TITLE
Update prodvana_deploy.sh

### DIFF
--- a/scripts/prodvana_deploy.sh
+++ b/scripts/prodvana_deploy.sh
@@ -32,4 +32,4 @@ curl -X POST \
     -H "Authorization: $SHIP_IT_BOT_AUTH" \
     -H "content-type: application/json" \
     -d @payload.json \
-    https://ship-it-bot.replit.com/deploy/$APPLICATION_NAME/$SERVICE_NAME
+    $DEPLOY_URL/deploy/$APPLICATION_NAME/$SERVICE_NAME


### PR DESCRIPTION

Why
===

Let's move the endpoint to a secret so we don't expose it on public repos

What changed
============

Move the CD endpoint to a secret handled in semaphore 


Test plan
=========

CI stills handles the deploy to the bot

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [X] This is fully backward and forward compatible
