### PR TITLE
Add NIX_FLAGS to ci

### DIFF
--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -15,6 +15,8 @@ global_job_config:
   secrets:
     - name: gcp-goval
   env_vars:
+    - name: NIX_FLAGS
+      value: "--extra-experimental-features nix-command --extra-experimental-features flakes --extra-experimental-features discard-references"
     - name: SEMAPHORE_CACHE_BACKEND
       value: "gcs"
     - name: SEMAPHORE_CACHE_GCS_BUCKET


### PR DESCRIPTION
Why
===

CI build failed with 

![image](https://github.com/replit/nixmodules/assets/54303/80e2c032-1e11-49f2-8694-74ab7e42d22e)

What changed
============

Added `NIX_FLAGS` which is referenced in the script already. Don't know why I removed this :(

Test plan
=========

Try the build.
