### PR TITLE
Prybar is back: but no interp

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,7 +19,7 @@
     "crane": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "ztoc-rs",
           "nixpkgs"
@@ -76,6 +76,21 @@
     },
     "flake-utils": {
       "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1676283394,
         "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
@@ -89,7 +104,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1676283394,
         "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
@@ -195,12 +210,34 @@
         "type": "github"
       }
     },
+    "prybar": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1694708807,
+        "narHash": "sha256-Fb8L0Sl5kP9mDJMaAjt5igruA/fpa34KHuHUhy8wraI=",
+        "owner": "replit",
+        "repo": "prybar",
+        "rev": "59b47997a2e2d121679315efcc35f33b157182e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "replit",
+        "repo": "prybar",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "java-language-server": "java-language-server",
         "nixd": "nixd",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "prybar": "prybar",
         "ztoc-rs": "ztoc-rs"
       }
     },
@@ -235,7 +272,7 @@
       "inputs": {
         "advisory-db": "advisory-db",
         "crane": "crane",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -4,16 +4,18 @@
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.nixd.url = "github:nix-community/nixd";
   inputs.nixd.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.prybar.url = "github:replit/prybar";
+  inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
   inputs.java-language-server.url = "github:replit/java-language-server";
   inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs";
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
   inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, java-language-server, nixd, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
-        overlays = [ self.overlays.default java-language-server.overlays.default nixd.overlays.default ]; # ++ import ;
+        overlays = [ self.overlays.default prybar.overlays.default java-language-server.overlays.default nixd.overlays.default ]; # ++ import ;
         # replbox has an unfree license
         config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
           "@replit/replbox"

--- a/modules.json
+++ b/modules.json
@@ -494,5 +494,9 @@
   "nix:v1-20230906-ff49114": {
     "commit": "ff491143e779453de50b979dc7dd35ac0f2ef40a",
     "path": "/nix/store/4lhzsk1lq4hirb9fp6hv43w56cq88lpi-replit-module-nix"
+  },
+  "python-with-prybar-3.10:v1-20230922-2188036": {
+    "commit": "218803652b5f832ae83ad1cd5767721f9f8314ca",
+    "path": "/nix/store/hlfmbqwq02rsn2012xh0j7iaxjwk2wqs-replit-module-python-with-prybar-3.10"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -18,6 +18,7 @@ let
       python = pkgs.python311Full;
       pypkgs = pkgs.python311Packages;
     }))
+    (mkModule ./python-with-prybar)
     (mkModule ./pyright-extended)
 
     (mkModule (import ./nodejs {

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -1,0 +1,48 @@
+{ pkgs, pkgs-unstable, lib, ... }:
+let
+  python = pkgs.python310Full;
+
+  pypkgs = pkgs.python310Packages;
+
+  pythonVersion = lib.versions.majorMinor python.version;
+
+  pythonUtils = import ../../python-utils {
+    inherit pkgs python pypkgs;
+  };
+
+  pythonWrapper = pythonUtils.pythonWrapper;
+
+  prybar-python-version = lib.strings.concatStrings (lib.strings.splitString "." pythonVersion);
+
+  stderred = pkgs.callPackage ../../stderred { };
+
+  run-prybar-bin = pkgs.writeShellScriptBin "run-prybar" ''
+    ${stderred}/bin/stderred -- ${pkgs.prybar."prybar-python${prybar-python-version}"}/bin/prybar-python${prybar-python-version} -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i ''$1
+  '';
+
+  run-prybar = pythonWrapper { bin = "${run-prybar-bin}/bin/run-prybar"; name = "run-prybar"; };
+in
+{
+
+  id = lib.mkForce "python-with-prybar-${pythonVersion}";
+
+  name = lib.mkForce "Python ${pythonVersion} Tools (with Prybar)";
+
+  imports = [
+    (import ../python {
+      inherit python pypkgs;
+    })
+  ];
+
+  packages = [
+    run-prybar
+  ];
+
+  replit.runners.python-prybar = {
+    name = "Prybar for Python ${pythonVersion}";
+    optionalFileParam = true;
+    language = "python3";
+    start = "${run-prybar}/bin/run-prybar $file";
+  };
+
+}

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -1,0 +1,49 @@
+{ pkgs, python, pypkgs }:
+let
+  cppLibs = pkgs.stdenvNoCC.mkDerivation {
+    name = "cpplibs";
+    dontUnpack = true;
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib
+      cp ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++* $out/lib
+
+      runHook postInstall
+    '';
+  };
+
+  python-ld-library-path = pkgs.lib.makeLibraryPath ([
+    # Needed for pandas / numpy
+    cppLibs
+    pkgs.zlib
+    pkgs.glib
+    # Needed for matplotlib
+    pkgs.xorg.libX11
+    # Needed for pygame
+  ] ++ (with pkgs.xorg; [ libXext libXinerama libXcursor libXrandr libXi libXxf86vm ]));
+
+  pythonWrapper = { bin, name, aliases ? [ ] }:
+    let
+      ldLibraryPathConvertWrapper = pkgs.writeShellScriptBin name ''
+        export LD_LIBRARY_PATH=''${PYTHON_LD_LIBRARY_PATH}
+        exec "${bin}" "$@"
+      '';
+    in
+    pkgs.stdenvNoCC.mkDerivation {
+      name = "${name}-wrapper";
+      buildInputs = [ pkgs.makeWrapper ];
+
+      buildCommand = ''
+        mkdir -p $out/bin
+        makeWrapper ${ldLibraryPathConvertWrapper}/bin/${name} $out/bin/${name} \
+          --set-default PYTHON_LD_LIBRARY_PATH "${python-ld-library-path}" \
+          --prefix PYTHONPATH : "${pypkgs.setuptools}/${python.sitePackages}"
+      '' + pkgs.lib.concatMapStringsSep "\n" (s: "ln -s $out/bin/${name} $out/bin/${s}") aliases;
+
+    };
+in
+{
+  inherit python-ld-library-path pythonWrapper;
+}


### PR DESCRIPTION
Why
===

We had some minor [customer outrage](https://ask.replit.com/t/unable-to-call-python-functions-from-console/66268/15) regarding the removal of Prybar. We are going to add a Python with Prybar 3.10 module with limited support. But it will have `interpreter=false` which will cause it to stop depending on the interp2 service. We plan to deprecate and remove interp2 and shellrun2 at some point. 

What changed
============

1. Added back prybar flake
2. Extracted some common python things to python-utils
3. Created python-with-prybar-3.10 module

Test plan
=========

Test this in a Repl, prybar should be back!