### PR TITLE
Fixed prybar not taking precedence over normal python runner

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -495,8 +495,8 @@
     "commit": "ff491143e779453de50b979dc7dd35ac0f2ef40a",
     "path": "/nix/store/4lhzsk1lq4hirb9fp6hv43w56cq88lpi-replit-module-nix"
   },
-  "python-with-prybar-3.10:v1-20230922-2188036": {
-    "commit": "218803652b5f832ae83ad1cd5767721f9f8314ca",
-    "path": "/nix/store/hlfmbqwq02rsn2012xh0j7iaxjwk2wqs-replit-module-python-with-prybar-3.10"
+  "python-with-prybar-3.10:v2-20230925-77b13e4": {
+    "commit": "77b13e434deb254c3792ddd97191586c193a83a6",
+    "path": "/nix/store/15zbbslxj7l7qmxra0fxw043w04mll50-replit-module-python-with-prybar-3.10"
   }
 }

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -38,11 +38,12 @@ in
     run-prybar
   ];
 
-  replit.runners.python-prybar = {
-    name = "Prybar for Python ${pythonVersion}";
-    optionalFileParam = true;
-    language = "python3";
-    start = "${run-prybar}/bin/run-prybar $file";
+  replit.runners = lib.mkForce {
+    python-prybar = {
+      name = "Prybar for Python ${pythonVersion}";
+      optionalFileParam = true;
+      language = "python3";
+      start = "${run-prybar}/bin/run-prybar $file";
+    };
   };
-
 }


### PR DESCRIPTION
Why
===

Made a mistake with the Python with Prybar module: because `interpreter` was changed to `false`, it no longer has precedence over the normal python runner.

What changed
============

Removed the normal python runner from the module. The `python3` executable will still be available for them in the path.

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
