### PR TITLE
[regional goval] deploy nixmodules into regional goval

### DIFF
--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -144,11 +144,11 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
-    - name: spock
+    - name: worf
       constants:
         - name: name
           string:
-            value: spock
+            value: worf
       preconditions:
         - releaseChannelStable:
             releaseChannel: picard
@@ -156,3 +156,51 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
+    - name: janeway
+      constants:
+        - name: name
+          string:
+            value: janeway
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
+    - name: sisko
+      constants:
+        - name: name
+          string:
+            value: sisko
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
+    - name: pike
+      constants:
+        - name: name
+          string:
+            value: pike
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION 
+    - name: wesley
+      constants:
+        - name: name
+          string:
+            value: wesley
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION        

--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -84,6 +84,18 @@ application:
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
 # regional goval
+    - name: staging
+      constants:
+        - name: name
+          string:
+            value: staging
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: global
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
     - name: picard
       constants:
         - name: name
@@ -91,7 +103,7 @@ application:
             value: picard
       preconditions:
         - releaseChannelStable:
-            releaseChannel: global
+            releaseChannel: staging
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -120,11 +132,11 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
-    - name: picard
+    - name: spock
       constants:
         - name: name
           string:
-            value: picard
+            value: spock
       preconditions:
         - releaseChannelStable:
             releaseChannel: picard

--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -83,3 +83,64 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
+# regional goval
+    - name: picard
+      constants:
+        - name: name
+          string:
+            value: picard
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: global
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
+    - name: riker
+      constants:
+        - name: name
+          string:
+            value: riker
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
+    - name: kirk
+      constants:
+        - name: name
+          string:
+            value: kirk
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
+    - name: picard
+      constants:
+        - name: name
+          string:
+            value: picard
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
+    - name: spock
+      constants:
+        - name: name
+          string:
+            value: spock
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: picard
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION

--- a/scripts/prodvana_deploy.sh
+++ b/scripts/prodvana_deploy.sh
@@ -10,12 +10,20 @@ APPLICATION_NAME=nixmodules
 
 # check existence of disk
 img_name="nixmodules-${rev}"
-disks=$(gcloud compute disks list --project=marine-cycle-160323 --filter="name~${img_name}'.*'" --format="value(name)")
 
-if [[ ! $disks ]]; then
-  echo "Disks for ${img_name} do not exist. Exiting."
-  exit 1
-fi
+function check_disks() {
+  local PROJECT=$1
+  disks=$(gcloud compute disks list --project=$PROJECT --filter="name~${img_name}'.*'" --format="value(name)")
+
+  if [[ ! $disks ]]; then
+    echo "Disks for ${img_name} do not exist. Exiting."
+    exit 1
+  fi
+}
+
+check_disks marine-cycle-160323
+check_disks replit-platform-staging
+check_disks replit-platform-prod
 
 echo "Triggering ship-it-bot webhook"
 

--- a/scripts/provision_disks.py
+++ b/scripts/provision_disks.py
@@ -61,6 +61,7 @@ async def main():
 
     create_disk(project_replit_platform_prod, "asia", "asia-south1-a"),
     create_disk(project_replit_platform_prod, "asia", "asia-south1-b"),
+    create_disk(project_replit_platform_prod, "asia", "asia-south1-c"),
 
     create_disk(project_replit_platform_staging, "us", "us-central1-a"),
     create_disk(project_replit_platform_staging, "us", "us-central1-c"),

--- a/scripts/provision_disks.py
+++ b/scripts/provision_disks.py
@@ -10,7 +10,9 @@ rev = None
 img_name = None
 gcs_path = None
 labels = None
-project = "marine-cycle-160323"
+project_marine_cycle = "marine-cycle-160323"
+project_replit_platform_prod = "replit-platform-prod"
+project_replit_platform_staging = "replit-platform-staging"
 nix_flags = ['--extra-experimental-features', 'nix-command flakes discard-references']
 
 async def main():
@@ -21,27 +23,43 @@ async def main():
   labels="sha=%s,service=nixmodules,component=nixmodules,cost-center=platform_packager,environment=production" % rev
 
   await asyncio.gather(
-    create_image("us"),
-    create_image("asia")
+    create_image(project_marine_cycle, "us"),
+    create_image(project_marine_cycle, "asia"),
+
+    create_image(project_replit_platform_prod, "us"),
+
+    create_image(project_replit_platform_staging, "us"),
   )
   await asyncio.gather(
-    create_disk("asia", "asia-south1-a"),
-    create_disk("asia", "asia-south1-b"),
+    create_disk(project_marine_cycle, "asia", "asia-south1-a"),
+    create_disk(project_marine_cycle, "asia", "asia-south1-b"),
 
-    create_disk("us", "us-west1-a"),
-    create_disk("us", "us-west1-b"),
-    create_disk("us", "us-west1-c"),
+    create_disk(project_marine_cycle, "us", "us-west1-a"),
+    create_disk(project_marine_cycle, "us", "us-west1-b"),
+    create_disk(project_marine_cycle, "us", "us-west1-c"),
 
-    create_disk("us", "us-central1-a"),
-    create_disk("us", "us-central1-c"),
-    create_disk("us", "us-central1-f"),
+    create_disk(project_marine_cycle, "us", "us-central1-a"),
+    create_disk(project_marine_cycle, "us", "us-central1-c"),
+    create_disk(project_marine_cycle, "us", "us-central1-f"),
 
-    create_disk("us", "us-east1-b"),
-    create_disk("us", "us-east1-c"),
-    create_disk("us", "us-east1-d"),
+    create_disk(project_marine_cycle, "us", "us-east1-b"),
+    create_disk(project_marine_cycle, "us", "us-east1-c"),
+    create_disk(project_marine_cycle, "us", "us-east1-d"),
+
+    create_disk(project_replit_platform_prod, "us", "us-west1-a"),
+    create_disk(project_replit_platform_prod, "us", "us-west1-b"),
+    create_disk(project_replit_platform_prod, "us", "us-west1-c"),
+
+    create_disk(project_replit_platform_prod, "us", "us-central1-a"),
+    create_disk(project_replit_platform_prod, "us", "us-central1-c"),
+    create_disk(project_replit_platform_prod, "us", "us-central1-f"),
+
+    create_disk(project_replit_platform_staging, "us", "us-central1-a"),
+    create_disk(project_replit_platform_staging, "us", "us-central1-c"),
+    create_disk(project_replit_platform_staging, "us", "us-central1-f"),
   )
 
-async def create_image(region):
+async def create_image(project, region):
   image_storage_location = region
   
   await async_exec([
@@ -54,7 +72,7 @@ async def create_image(region):
     '%s-%s' % (img_name, image_storage_location)
   ])
 
-async def create_disk(region, zone):
+async def create_disk(project, region, zone):
   image_storage_location = region
   await async_exec([
     'gcloud', 'compute', 'disks', 'create',

--- a/scripts/provision_disks.py
+++ b/scripts/provision_disks.py
@@ -27,6 +27,7 @@ async def main():
     create_image(project_marine_cycle, "asia"),
 
     create_image(project_replit_platform_prod, "us"),
+    create_image(project_replit_platform_prod, "asia"),
 
     create_image(project_replit_platform_staging, "us"),
   )
@@ -53,6 +54,13 @@ async def main():
     create_disk(project_replit_platform_prod, "us", "us-central1-a"),
     create_disk(project_replit_platform_prod, "us", "us-central1-c"),
     create_disk(project_replit_platform_prod, "us", "us-central1-f"),
+
+    create_disk(project_replit_platform_prod, "us", "us-east1-b"),
+    create_disk(project_replit_platform_prod, "us", "us-east1-c"),
+    create_disk(project_replit_platform_prod, "us", "us-east1-d"),
+
+    create_disk(project_replit_platform_prod, "asia", "asia-south1-a"),
+    create_disk(project_replit_platform_prod, "asia", "asia-south1-b"),
 
     create_disk(project_replit_platform_staging, "us", "us-central1-a"),
     create_disk(project_replit_platform_staging, "us", "us-central1-c"),


### PR DESCRIPTION
Why
===

We need nixmodules in the new regional goval projects.

https://linear.app/replit/issue/GOV-323/make-nixmodules-script-deploy-to-replit-platform-project-as-well-as


What changed
============

Updated some deployment scripts to create nixmodules in new projects.

Test plan
=========

Overrode `rev` to latest `f134fa2` and the scripts ran successfully and created the new snapshots & disks.

Errors like `mount nixmodules: failed to mount nixmodules disk: failed to attach nixmodules disk: attach disk: googleapi: Error 404: The resource 'projects/replit-platform-prod/zones/us-central1-f/disks/nixmodules-cfb1ecb-us-central1-f' was not found, notFound` go away

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
