### PR TITLE
revert bun

### DIFF
--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -41,19 +41,20 @@ let
         - the `entrypoint` defined in `.replit`
       '';
     };
-    "bun-1.0:v3-20230915-80b0f23" = {
-      to = "bun-1.0:v5-20230921-cc7a2dd";
-      auto = true;
-      changelog = ''# `package.json` runner
-        The runner for bun module has changed for increased flexibility and conformance to standards.
+    # "bun-1.0:v3-20230915-80b0f23" = {
+    #   to = "bun-1.0:v5-20230921-cc7a2dd";
+    #   auto = true;
+    #   changelog = ''# `package.json` runner
+    #     The runner for bun module has changed for increased flexibility and conformance to standards.
 
-        The new precedence is:
-        - the `replit-dev` script defined in `package.json`
-        - the `dev` script defined in `package.json`
-        - the `main` file defined in `package.json`
-        - the `entrypoint` defined in `.replit`
-      '';
-    };
+    #     The new precedence is:
+    #     - the `replit-dev` script defined in `package.json`
+    #     - the `dev` script defined in `package.json`
+    #     - the `main` file defined in `package.json`
+    #     - the `entrypoint` defined in `.replit`
+    #   '';
+    # };
+    "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
 
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };


### PR DESCRIPTION
Why
===
* Run does not work for the bun template

What changed
===
* Go back to the last working one v3, which is still bun 1.0.2
* This will remove the runner ux improvements though

Test plan
===
* Run bun template after forking and see a web view

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
