### PR TITLE
[Prodvana] wait before approval

### DIFF
--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -10,6 +10,25 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
+      protections:
+        - ref:
+            name: check-no-datadog-alerts
+            parameters:
+              - name: apiKey
+                secret:
+                  secretRef:
+                    key: datadogApiKey
+                    version: datadogApiKey-0
+              - name: appKey
+                secret:
+                  secretRef:
+                    key: datadogAppKey
+                    version: datadogAppKey-0
+              - name: tagList
+                string: "prodvana-monitor:nixmodules"
+          lifecycle:
+            - postDeployment:
+                checkDuration: 300s
     - name: tarpit
       constants:
         - name: name

--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -28,7 +28,7 @@ application:
                 string: "prodvana-monitor:nixmodules"
           lifecycle:
             - postDeployment:
-                checkDuration: 300s
+                checkDuration: 600s
     - name: tarpit
       constants:
         - name: name


### PR DESCRIPTION
Why
===

Conman takes a bit to update the nixmodules after we deploy the new config; this confused the team during a recent incident where it was hard to know what version they were approving.

What changed
============

This config introduces a waiting period after deploying to Canary to wait for the change to propagate and to introduce a place where we can check for alerts in datadog,


If there is an alert, the deployment will fail and not advance to other release channels.

Test plan
=========

CD should have a new protection after deploying to Canary; if no dd alert in datadog is fired for 5 minutes, it will ask for approval.


Rollout
=======


- [X] This is fully backward and forward-compatible
