### PR TITLE
Dev only configs and deployment modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,9 +46,10 @@
           gzip
         ];
       };
-      modules = import ./pkgs/modules {
+    } // (
+      import ./pkgs/modules {
         inherit pkgs;
         inherit pkgs-unstable;
-      };
-    };
+      }
+    );
 }

--- a/modules.json
+++ b/modules.json
@@ -375,6 +375,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/abdgkaiy2i39r9bd1k4c6cm1mfnkynzx-replit-module-swift-5.8"
   },
+  "swift-5.8:v2-20231004-5c14992": {
+    "commit": "5c14992744871ffcb60fe619b0314b4e92195948",
+    "path": "/nix/store/hmzl37s9mykls9rdcfahdpk3k87dyv05-replit-module-swift-5.8"
+  },
   "web:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7lhwlqy8nmrmc27n68ia16q6bn27cwk5-replit-module-web"
@@ -519,8 +523,16 @@
     "commit": "7459cc2a5fd03bda902c2cd8d9d1fb387181b570",
     "path": "/nix/store/kqc84aqshy9v9m5ld4v833b93ym6qbf6-replit-module-python-with-prybar-3.10"
   },
+  "python-with-prybar-3.10:v4-20231004-5c14992": {
+    "commit": "5c14992744871ffcb60fe619b0314b4e92195948",
+    "path": "/nix/store/k9bbbvbl7j6rhq3x6sp9r859z9ckz982-replit-module-python-with-prybar-3.10"
+  },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",
     "path": "/nix/store/8v3laig35f30bvgw8mwjcsznk06l7vf3-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v2-20231004-5c14992": {
+    "commit": "5c14992744871ffcb60fe619b0314b4e92195948",
+    "path": "/nix/store/qnx2vl8q3fpp67m421dsvhw7ffymqky6-replit-module-nodejs-with-prybar-18"
   }
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -101,15 +101,21 @@ rec {
       let
         flake = builtins.getFlake "github:replit/nixmodules/${module.commit}";
         shortModuleId = elemAt (strings.splitString ":" moduleId) 0;
+        moduleToBuild =
+          if builtins.hasAttr "deploymentModules" flake then
+            flake.deploymentModules.${shortModuleId} else
+            flake.modules.${shortModuleId};
       in
       mkPhonyOCI {
         inherit moduleId;
-        module = flake.modules.${shortModuleId};
+        module = moduleToBuild;
       })
     all-modules;
 
   bundle-phony-ocis = mkPhonyOCIs { };
 
   inherit all-modules;
+
+  deploymentModules = self.deploymentModules;
 
 } // modules

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -101,14 +101,10 @@ rec {
       let
         flake = builtins.getFlake "github:replit/nixmodules/${module.commit}";
         shortModuleId = elemAt (strings.splitString ":" moduleId) 0;
-        moduleToBuild =
-          if builtins.hasAttr "deploymentModules" flake then
-            flake.deploymentModules.${shortModuleId} else
-            flake.modules.${shortModuleId};
       in
       mkPhonyOCI {
         inherit moduleId;
-        module = moduleToBuild;
+        module = flake.deploymentModules.${shortModuleId};
       })
     all-modules;
 

--- a/pkgs/mk-phony-ocis/default.nix
+++ b/pkgs/mk-phony-ocis/default.nix
@@ -21,7 +21,7 @@ let
     (name: module:
       let
         module-id = elemAt (strings.splitString ":" name) 0;
-        m = (flakes.${module.commit}).modules.${module-id};
+        m = (flakes.${module.commit}).deploymentModules.${module-id};
       in
       # verify the outpath matches what the lockfile expects
       assert m.outPath == module.path;

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,14 +1,21 @@
 { pkgs ? import <nixpkgs> { }
 , pkgs-unstable ? import <nixpkgs-unstable> { }
 , configPath
+, deployment ? false
 }:
-(pkgs.lib.evalModules {
-  modules = [
-    configPath
-    (import ./module-definition.nix)
-  ];
-  specialArgs = {
-    inherit pkgs pkgs-unstable;
-    modulesPath = builtins.toString ./.;
-  };
-}).config.replit.buildModule
+let
+  module = (pkgs.lib.evalModules {
+    modules = [
+      configPath
+      (import ./module-definition.nix)
+    ];
+    specialArgs = {
+      inherit pkgs pkgs-unstable;
+      modulesPath = builtins.toString ./.;
+    };
+  });
+in
+if deployment then
+  module.config.replit.buildDeploymentModule
+else
+  module.config.replit.buildModule

--- a/pkgs/moduleit/example.nix
+++ b/pkgs/moduleit/example.nix
@@ -16,12 +16,12 @@ in
   id = "nodejs";
   name = "Node.js";
 
-  packages = [
-    pkgs.nodejs_20
-    typescript-language-server
-  ];
-
   replit = {
+
+    packages = [
+      pkgs.nodejs_20
+      typescript-language-server
+    ];
 
     initializers.npmInit = {
       name = "npm init";

--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -13,7 +13,7 @@ in
     fileParam = true;
   };
 
-  replit.packagers.r = {
+  replit.dev.packagers.r = {
     name = "R";
     language = "r";
     features = {

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -35,11 +35,11 @@ in
     })
   ];
 
-  packages = [
+  replit.packages = [
     bun
   ];
 
-  replit.languageServers.typescript-language-server.extensions = extensions;
+  replit.dev.languageServers.typescript-language-server.extensions = extensions;
 
   replit.runners.bun = {
     name = "bun";
@@ -50,7 +50,7 @@ in
     optionalFileParam = true;
   };
 
-  replit.packagers.bun = {
+  replit.dev.packagers.bun = {
     name = "bun";
     language = "bun";
     features = {

--- a/pkgs/modules/c/default.nix
+++ b/pkgs/modules/c/default.nix
@@ -16,10 +16,11 @@ in
   id = "c-clang${clang-version}";
   name = "C Tools (with Clang)";
 
-  packages = [
+  replit.packages = [
     clang
   ];
 
+  # TODO: should compile a binary to use in deployment and not include the runtime
   replit.runners.clang-project = {
     name = "Clang: Project";
     compile = "${clang-compile}/bin/clang-compile main.c c all";
@@ -41,13 +42,13 @@ in
   #   start = "./\${file}.bin";
   # };
 
-  replit.languageServers.ccls = {
+  replit.dev.languageServers.ccls = {
     name = "ccls";
     language = "c";
     start = "${pkgs.ccls}/bin/ccls";
   };
 
-  replit.debuggers.gdb-project = {
+  replit.dev.debuggers.gdb-project = {
     name = "GDB: Project";
     language = "c";
     start = "${dap-cpp}/bin/dap-cpp";

--- a/pkgs/modules/clojure/default.nix
+++ b/pkgs/modules/clojure/default.nix
@@ -13,7 +13,7 @@ in
     fileParam = true;
   };
 
-  replit.languageServers.clojure-lsp = {
+  replit.dev.languageServers.clojure-lsp = {
     name = "Clojure LSP";
     language = "clojure";
 

--- a/pkgs/modules/cpp/default.nix
+++ b/pkgs/modules/cpp/default.nix
@@ -14,10 +14,11 @@ in
   id = "cpp-clang${clang-version}";
   name = "C++ Tools (with Clang)";
 
-  packages = [
+  replit.packages = [
     clang
   ];
 
+  # TODO: should compile a binary to use in deployment and not include the runtime
   replit.runners.clang-project = {
     name = "Clang++: Project";
     compile = "${clang-compile}/bin/clang-compile main.cpp cpp all";
@@ -28,13 +29,13 @@ in
 
   # TODO: add single runners/debuggers when we have priority for runners
 
-  replit.languageServers.ccls = {
+  replit.dev.languageServers.ccls = {
     name = "ccls";
     language = "cpp";
     start = "${pkgs.ccls}/bin/ccls";
   };
 
-  replit.debuggers.gdb-project = {
+  replit.dev.debuggers.gdb-project = {
     name = "GDB C++: Project";
     language = "cpp";
     start = "${dap-cpp}/bin/dap-cpp";

--- a/pkgs/modules/dart/default.nix
+++ b/pkgs/modules/dart/default.nix
@@ -4,7 +4,7 @@ in {
   id = "dart-${dart-version}";
   name = "Dart Tools";
 
-  packages = [
+  replit.packages = [
     pkgs.dart
   ];
 
@@ -15,14 +15,14 @@ in {
     start = "${pkgs.dart}/bin/dart main.dart";
   };
 
-  replit.languageServers.dart-pub = {
+  replit.dev.languageServers.dart-pub = {
     name = "dart";
     language = "dart";
 
     start = "${pkgs.dart}/bin/dart language-server";
   };
 
-  replit.packagers.dart-pub = {
+  replit.dev.packagers.dart-pub = {
     name = "dart pub";
     language = "dart-pub";
     features = {

--- a/pkgs/modules/dotnet/default.nix
+++ b/pkgs/modules/dotnet/default.nix
@@ -12,7 +12,7 @@ in
   id = "dotnet-${dotnet-version}";
   name = ".NET 7 Tools";
 
-  packages = [
+  replit.packages = [
     dotnet
   ];
 
@@ -24,7 +24,7 @@ in
     start = "${dotnet}/bin/dotnet run";
   };
 
-  replit.languageServers.omni-sharp = {
+  replit.dev.languageServers.omni-sharp = {
     inherit extensions;
     name = "OmniSharp";
     language = "dotnet";
@@ -32,7 +32,7 @@ in
     start = "${pkgs.omnisharp-roslyn}/bin/OmniSharp --languageserver";
   };
 
-  replit.packagers.dotnet = {
+  replit.dev.packagers.dotnet = {
     name = ".NET";
     language = "dotnet";
     features = {

--- a/pkgs/modules/gcloud/default.nix
+++ b/pkgs/modules/gcloud/default.nix
@@ -2,7 +2,7 @@
 {
   id = "gcloud";
   name = "Google Cloud Tools";
-  packages = [
+  replit.packages = [
     pkgs.google-cloud-sdk
   ];
 }

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -6,11 +6,15 @@ in
   id = "go-${goversion}";
   name = "Go Tools";
 
-  packages = with pkgs; [
+  replit.packages = with pkgs; [
     go
-    gopls
   ];
 
+  replit.dev.packages = [
+    pkgs.gopls
+  ];
+
+  # TODO: should compile a binary to use in deployment and not include the runtime
   replit.runners.go-run = {
     name = "go run";
     language = "go";
@@ -18,7 +22,7 @@ in
     start = "${pkgs.go}/bin/go run $REPL_HOME";
   };
 
-  replit.formatters.go-fmt = {
+  replit.dev.formatters.go-fmt = {
     name = "go fmt";
     language = "go";
 
@@ -26,7 +30,7 @@ in
     stdin = false;
   };
 
-  replit.languageServers.gopls = {
+  replit.dev.languageServers.gopls = {
     name = "gopls";
     language = "go";
 

--- a/pkgs/modules/haskell/default.nix
+++ b/pkgs/modules/haskell/default.nix
@@ -6,7 +6,7 @@ in
   id = "haskell-ghc${ghc-version}";
   name = "Haskell Tools";
 
-  packages = with pkgs; [
+  replit.packages = with pkgs; [
     ghc
   ];
 
@@ -28,7 +28,7 @@ in
   #   interpreter = true;
   # };
 
-  replit.languageServers.haskell-language-server = {
+  replit.dev.languageServers.haskell-language-server = {
     name = "Haskell Language Server";
     language = "haskell";
 

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -31,8 +31,11 @@ in
   id = "java-graalvm${graalvm-version}";
   name = "Java Tools (with Graal VM)";
 
-  packages = [
+  replit.packages = [
     graalvm
+  ];
+
+  replit.dev.packages = [
     pkgs.maven
   ];
 
@@ -44,7 +47,7 @@ in
     start = "${graalvm}/bin/java -classpath .:target/dependency/* Main";
   };
 
-  replit.packagers.maven = {
+  replit.dev.packagers.maven = {
     name = "Maven";
     language = "java-maven";
     features = {
@@ -54,7 +57,7 @@ in
     };
   };
 
-  replit.debuggers.java-debug = {
+  replit.dev.debuggers.java-debug = {
     name = "Jave Debug";
     language = "java";
     extensions = [ ".java" ];
@@ -90,7 +93,7 @@ in
     };
   };
 
-  replit.languageServers.java-language-server = {
+  replit.dev.languageServers.java-language-server = {
     name = "Java Language Server";
     language = "java";
 

--- a/pkgs/modules/lua/default.nix
+++ b/pkgs/modules/lua/default.nix
@@ -5,7 +5,7 @@ in
   id = "lua-${lua-version}";
   name = "Lua Tools";
 
-  packages = with pkgs; [
+  replit.packages = with pkgs; [
     lua
   ];
 
@@ -17,7 +17,7 @@ in
     fileParam = true;
   };
 
-  replit.languageServers.sumneko = {
+  replit.dev.languageServers.sumneko = {
     name = "lua-language-server";
     language = "lua";
 

--- a/pkgs/modules/nix/default.nix
+++ b/pkgs/modules/nix/default.nix
@@ -2,7 +2,7 @@
   id = "nix";
   name = "Nix";
 
-  replit.languageServers.nixd = {
+  replit.dev.languageServers.nixd = {
     name = "nixd";
     language = "nix";
     start = "${pkgs.nixd}/bin/nixd";

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -23,7 +23,7 @@ in
     })
   ];
 
-  packages = [
+  replit.packages = [
     run-prybar
   ];
 

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -22,14 +22,17 @@ in
     })
   ];
 
-  packages = [
-    nodejs
-    prettier
-  ];
-
   replit = {
 
-    languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".mjs" ".cjs" ".es6" ];
+    packages = [
+      nodejs
+    ];
+
+    dev.packages = [
+      prettier
+    ];
+
+    dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".mjs" ".cjs" ".es6" ];
 
     runners.nodeJS = {
       name = "Node.js";
@@ -38,7 +41,7 @@ in
       fileParam = true;
     };
 
-    debuggers.nodeDAP = {
+    dev.debuggers.nodeDAP = {
       name = "Node DAP";
       language = "javascript";
       transport = "localhost:0";
@@ -82,7 +85,7 @@ in
       };
     };
 
-    formatters.prettier = {
+    dev.formatters.prettier = {
       name = "Prettier";
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ];
@@ -92,7 +95,7 @@ in
       stdin = true;
     };
 
-    packagers.upmNodejs = {
+    dev.packagers.upmNodejs = {
       name = "UPM for Node.js";
       language = "nodejs";
       features = {

--- a/pkgs/modules/php/default.nix
+++ b/pkgs/modules/php/default.nix
@@ -6,9 +6,12 @@ in
   id = "php-${php-version}";
   name = "PHP Tools";
 
-  packages = with pkgs; [
+  replit.packages = with pkgs; [
     php
-    phpPackages.composer
+  ];
+
+  replit.dev.packages = [
+    pkgs.phpPackages.composer
   ];
 
   replit.runners.php = {
@@ -18,14 +21,14 @@ in
     fileParam = true;
   };
 
-  replit.languageServers.phpactor = {
+  replit.dev.languageServers.phpactor = {
     name = "phpactor";
     language = "php";
 
     start = "${pkgs.phpactor}/bin/phpactor language-server";
   };
 
-  replit.packagers.php = {
+  replit.dev.packagers.php = {
     name = "PHP";
     language = "php";
     features = {

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -34,7 +34,7 @@ in
     })
   ];
 
-  packages = [
+  replit.packages = [
     run-prybar
   ];
 

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -121,7 +121,6 @@ in
     python3-wrapper
   ];
 
-
   replit.dev.packages = [
     pip-wrapper
     poetry-wrapper

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -5,6 +5,8 @@ let
 
   pylibs-dir = ".pythonlibs";
 
+  userbase = "$REPL_HOME/${pylibs-dir}";
+
   pip = pkgs.callPackage ../../pip {
     inherit pypkgs;
   };
@@ -115,8 +117,12 @@ in
   id = "python-${pythonVersion}";
   name = "Python ${pythonVersion} Tools";
 
-  packages = [
+  replit.packages = [
     python3-wrapper
+  ];
+
+
+  replit.dev.packages = [
     pip-wrapper
     poetry-wrapper
   ];
@@ -128,15 +134,15 @@ in
     start = "${python3-wrapper}/bin/python3 $file";
   };
 
-  replit.debuggers = debuggerConfig;
+  replit.dev.debuggers = debuggerConfig;
 
-  replit.languageServers.pyright-extended = {
+  replit.dev.languageServers.pyright-extended = {
     name = "pyright-extended";
     language = "python3";
     start = "${pyright-extended}/bin/langserver.index.js --stdio";
   };
 
-  replit.packagers.upmPython = {
+  replit.dev.packagers.upmPython = {
     name = "Python";
     language = "python3";
     ignoredPackages = [ "unit_tests" ];
@@ -148,25 +154,26 @@ in
     };
   };
 
-  replit.env =
-    let userbase = "$REPL_HOME/${pylibs-dir}";
-    in {
-      PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}";
-      PIP_CONFIG_FILE = pip-config.outPath;
-      POETRY_CONFIG_DIR = poetry-config.outPath;
-      POETRY_CACHE_DIR = "$REPL_HOME/.cache/pypoetry";
-      POETRY_VIRTUALENVS_CREATE = "0";
-      POETRY_INSTALLER_MODERN_INSTALLATION = "0";
-      POETRY_PIP_USE_PIP_CACHE = "1";
-      POETRY_PIP_NO_ISOLATE = "1";
-      POETRY_PIP_NO_PREFIX = "1";
-      POETRY_PIP_FROM_PATH = "1";
-      POETRY_USE_USER_SITE = "1";
-      PYTHONUSERBASE = userbase;
-      # Even though it is set-default in the wrapper, add it to the
-      # environment too, so that when someone wants to override it,
-      # they can keep the defaults if they want to.
-      PYTHON_LD_LIBRARY_PATH = python-ld-library-path;
-      PATH = "${userbase}/bin";
-    };
+  replit.dev.env = {
+    PIP_CONFIG_FILE = pip-config.outPath;
+    POETRY_CONFIG_DIR = poetry-config.outPath;
+    POETRY_CACHE_DIR = "$REPL_HOME/.cache/pypoetry";
+    POETRY_VIRTUALENVS_CREATE = "0";
+    POETRY_INSTALLER_MODERN_INSTALLATION = "0";
+    POETRY_PIP_USE_PIP_CACHE = "1";
+    POETRY_PIP_NO_ISOLATE = "1";
+    POETRY_PIP_NO_PREFIX = "1";
+    POETRY_PIP_FROM_PATH = "1";
+    POETRY_USE_USER_SITE = "1";
+    PYTHONUSERBASE = userbase;
+  };
+
+  replit.env = {
+    PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}";
+    # Even though it is set-default in the wrapper, add it to the
+    # environment too, so that when someone wants to override it,
+    # they can keep the defaults if they want to.
+    PYTHON_LD_LIBRARY_PATH = python-ld-library-path;
+    PATH = "${userbase}/bin";
+  };
 }

--- a/pkgs/modules/ruby/default.nix
+++ b/pkgs/modules/ruby/default.nix
@@ -10,7 +10,7 @@ in
   id = "ruby-${ruby-version}";
   name = "Ruby Tools";
 
-  packages = [
+  replit.packages = [
     ruby
   ];
 
@@ -32,14 +32,14 @@ in
   #   fileParam = true;
   # };
 
-  replit.languageServers.solargraph = {
+  replit.dev.languageServers.solargraph = {
     name = "Solargraph: A Ruby Language Server";
     language = "ruby";
 
     start = "${rubyPackages.solargraph}/bin/solargraph stdio";
   };
 
-  replit.packagers.ruby = {
+  replit.dev.packagers.ruby = {
     name = "Ruby";
     language = "ruby";
     features = {

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -15,14 +15,18 @@ in
   id = "rust-${rust-version}";
   name = "Rust Tools";
 
-  packages = with pkgs; [
+  replit.packages = with pkgs; [
     cargo
     clang
     rustc
+  ];
+
+  replit.dev.packages = with pkgs; [
     rustfmt
     rust-analyzer
   ];
 
+  # TODO: should compile a binary to use in deployment and not include the runtime
   replit.runners.cargo = {
     name = "cargo run";
     language = "rust";
@@ -31,14 +35,14 @@ in
     fileParam = false;
   };
 
-  replit.languageServers.rust-analyzer = {
+  replit.dev.languageServers.rust-analyzer = {
     name = "rust-analyzer";
     language = "rust";
 
     start = "${pkgs.rust-analyzer}/bin/rust-analyzer";
   };
 
-  replit.formatters.cargo-fmt = {
+  replit.dev.formatters.cargo-fmt = {
     name = "cargo fmt";
     language = "rust";
 
@@ -46,7 +50,7 @@ in
     stdin = false;
   };
 
-  replit.formatters.rustfmt = {
+  replit.dev.formatters.rustfmt = {
     name = "rustfmt";
     language = "rust";
 
@@ -54,7 +58,7 @@ in
     stdin = false;
   };
 
-  replit.packagers.rust = {
+  replit.dev.packagers.rust = {
     name = "Rust";
     language = "rust";
     features = {

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -4,12 +4,12 @@
   id = "svelte-kit-node-20";
   name = "SvelteKit with Node.js 20 Tools";
 
-  packages = with pkgs-unstable; [
-    nodejs
-  ];
-
   replit = {
-    runners.dev-server = {
+    dev.packages = with pkgs-unstable; [
+      nodejs
+    ];
+    # Nothing required for deployment because app compiles to a static site
+    dev.runners.dev-server = {
       name = "package.json dev script";
       language = "svelte";
       extensions = [
@@ -21,7 +21,7 @@
       start = "${pkgs-unstable.nodejs}/bin/npm run dev";
     };
 
-    languageServers.svelte-language-server = {
+    dev.languageServers.svelte-language-server = {
       name = "Svelte Language Server";
       language = "svelte";
       extensions = [ ".svelte" ".js" ".ts" ];

--- a/pkgs/modules/swift/default.nix
+++ b/pkgs/modules/swift/default.nix
@@ -19,25 +19,20 @@ in
   id = "swift-${swift-version}";
   name = "Swift Tools";
 
-  packages = with pkgs; [
+  replit.packages = with pkgs; [
     swiftc-wrapper
     swift
   ];
 
+  # TODO: should compile a binary to be used in deployment
   replit.runners.swift = {
     name = "Swift";
     language = "swift";
     start = "${pkgs.swift}/bin/swift $file";
     fileParam = true;
-
-    productionOverride = {
-      start = "./\${file%.swift}.bin";
-      compile = "${swiftc-wrapper}/bin/swiftc $file -o \${file%.swift}.bin";
-      fileParam = true;
-    };
   };
 
-  replit.languageServers.sourcekit = {
+  replit.dev.languageServers.sourcekit = {
     name = "SourceKit";
     language = "swift";
 

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -12,7 +12,7 @@ let
   };
 in
 {
-  replit.languageServers.typescript-language-server = {
+  replit.dev.languageServers.typescript-language-server = {
     name = "TypeScript Language Server";
     language = "javascript";
     start = "${typescript-language-server}/bin/typescript-language-server --stdio";

--- a/pkgs/modules/web/default.nix
+++ b/pkgs/modules/web/default.nix
@@ -8,11 +8,11 @@
     })
   ];
 
-  packages = [ ];
+  replit.packages = [ ];
 
-  replit.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".mjs" ".mts" ".cjs" ".cts" ".es6" ];
+  replit.dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".mjs" ".mts" ".cjs" ".cts" ".es6" ];
 
-  replit.languageServers.html = {
+  replit.dev.languageServers.html = {
     name = "HTML Language Server";
     language = "html";
     extensions = [ ".html" ];
@@ -63,7 +63,7 @@
     };
   };
 
-  replit.languageServers.css = {
+  replit.dev.languageServers.css = {
     name = "CSS Language Server";
     language = "css";
     extensions = [ ".css" ".less" ".scss" ];


### PR DESCRIPTION
Why
===

We'd like to have smaller deployment images. Marking dev-only dependencies as such will allow us to remove them from deployment.

What changed
============

1. Added a `dev` section to module definitions
2. Moved `packages` into the `replit` section
3. Added `deploymentModules` output for the flake
4. Use `deploymentModules` to build ocis
5. Removed `productionOverrides`

Previously we could build for Python 3.10 for development with:

```
nix build .#'"python-3.10"'
```
which is just short for
```
nix build .#modules.'"python-3.10"'
```

Now you can build a module for deployment:
```
nix build .#deploymentModules.'"python-3.10"'
```

Building an oci layer will use the deployment module if you are at this commit or later:

```
nix build .#all-phony-oci-bundles.'"python-3.10:v27-20231003-f0f410c"'
```

Test plan
=========

1. Make sure new output JSON files are not changed from the previous one because of this upgrade
2. Make sure OCI images contain the contents of the deployment images
3. Make sure deployments are not broken for any of the templates we maintain

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
