### PR TITLE
[CI] Move the update of prodvana configs out of the build pipeline

### DIFF
--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -55,20 +55,6 @@ blocks:
           commands:
             - nix-shell -p crane --command "./scripts/build_oci.py"
     dependencies: []
-  - name: update prodvana configs
-    run:
-      when: "change_in(['/manifests'], {default_branch: 'main'})"
-    task:
-      secrets:
-        - name: gcp-goval
-        - name: ship-it-bot
-      jobs:
-        - name: update Prodvana manifests
-          commands:
-            - ./scripts/install_prodvana.sh
-            - pvnctl config validate manifests
-            - pvnctl config apply manifests
-    dependencies: []
   - name: trigger prodvana deploy
     task:
       secrets:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ global_job_config:
 blocks:
   - name: update prodvana configs
     run:
-      when: "change_in(['/manifests'], {default_branch: 'main'})"
+      when: "branch = 'main' and change_in(['/manifests'], {default_branch: 'main'})"
     task:
       secrets:
         - name: gcp-goval

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,7 @@ blocks:
             - gcloud auth configure-docker --quiet
             - ./scripts/install_prodvana.sh
             - pvnctl config validate manifests
-            - pvnctl config apply manifests
+            - pvnctl config apply manifests --no-prompt=true
     dependencies: []
 promotions:
 - name: build nixmodules

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: test
 agent:
   machine:
-    type: e1-standard-2
+    type: s1-goval
 fail_fast:
   stop:
     when: "true"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,13 +16,23 @@ global_job_config:
     - name: SEMAPHORE_CACHE_GCS_BUCKET
       value: "goval-semaphore-cache"
 blocks:
-  - name: test
-    dependencies: []
+  - name: update prodvana configs
+    run:
+      when: "change_in(['/manifests'], {default_branch: 'main'})"
     task:
+      secrets:
+        - name: gcp-goval
+        - name: ship-it-bot
       jobs:
-        - name: test
+        - name: update Prodvana manifests
           commands:
-            - echo test
+            - set -e
+            - checkout --use-cache
+            - gcloud auth configure-docker --quiet
+            - ./scripts/install_prodvana.sh
+            - pvnctl config validate manifests
+            - pvnctl config apply manifests
+    dependencies: []
 promotions:
 - name: build nixmodules
   pipeline_file: build-nixmodules.yml

--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -10,6 +10,8 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
+        - name: goval
+          runtime: marine-cycle-160323--goval
       protections:
         - ref:
             name: check-no-datadog-alerts
@@ -210,7 +212,7 @@ application:
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
-          type: EXTENSION 
+          type: EXTENSION
     - name: wesley
       constants:
         - name: name
@@ -222,4 +224,4 @@ application:
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
-          type: EXTENSION        
+          type: EXTENSION

--- a/scripts/prodvana_deploy.sh
+++ b/scripts/prodvana_deploy.sh
@@ -39,5 +39,7 @@ EOF
 curl -X POST \
     -H "Authorization: $SHIP_IT_BOT_AUTH" \
     -H "content-type: application/json" \
+    -H "CF-Access-Client-Secret: $CF_CLIENT_SECRET" \
+    -H "CF-Access-Client-Id: $CF_CLIENT_ID" \
     -d @payload.json \
     $DEPLOY_URL/deploy/$APPLICATION_NAME/$SERVICE_NAME


### PR DESCRIPTION
Why
===

We need a way to update the prodvana configuration without triggering a new nixbuild

What changed
============

Move the update out of the build pipeline

Test plan
=========

CI runs, prodvana gets updated

Rollout
=======

- [X] This is fully backward and forward compatible
