### PR TITLE
Fix owner group ids

### DIFF
--- a/pkgs/bundle-image/builder.sh
+++ b/pkgs/bundle-image/builder.sh
@@ -69,6 +69,7 @@ echo "copying to image..."
 cptofs -p \
        -t ext4 \
        -i "$diskImage" \
+       --owner 11000 --group 11000 \
        "$root"/* / ||
     (echo >&2 "ERROR: cptofs failed. diskSize might be too small for closure."; exit 1)
 

--- a/pkgs/bundle-image/default.nix
+++ b/pkgs/bundle-image/default.nix
@@ -11,15 +11,21 @@
 , jq
 , upgrade-maps
 , active-modules
-,
+, fetchFromGitHub
 }:
 
 let
-
   label = "nixmodules-${revstring}";
-
   registry = ../../modules.json;
-
+  # wating for upstream to include our patch: https://github.com/lkl/linux/pull/532
+  lkl' = lkl.overrideAttrs (oldAttrs: {
+    src = fetchFromGitHub {
+      owner = "numtide";
+      repo = "linux-lkl";
+      rev = "7a337bf313c82713f33f7b2e3c0b8847857a78b6";
+      sha256 = "sha256-MfOprw5n7kFOzu5Sl2hVG7+/Q22nKgCWGMO6HYN+SvU=";
+    };
+  });
 in
 
 derivation {
@@ -34,7 +40,7 @@ derivation {
     PATH = lib.makeBinPath [
       coreutils
       findutils
-      lkl
+      lkl'
       e2fsprogs
       jq
     ];

--- a/pkgs/pip/default.nix
+++ b/pkgs/pip/default.nix
@@ -8,7 +8,7 @@ pypkgs.buildPythonPackage rec {
     owner = "replit";
     repo = pname;
     rev = "21.2.dev0";
-    sha256 = "sha256-k4RnK9TnvfJlxpihdHFg3JmYtNDC4KY+f41VwJ+e+1A=";
+    sha256 = "sha256-kSjKeLqXUG91QncrQlqqCWZvnnNnDuhk1jLBRtu7xdw=";
     name = "${pname}-${version}-source";
   };
 


### PR DESCRIPTION
Why
===

Create images with owner 11000 / group 11000 so that they do not come up as the nobody user in the repl.it.

What changed
============

We switched to an lkl fork that supports this feature. An upstream pull request has been opened: https://github.com/lkl/linux/pull/532

Test plan
=========

```
$ nix build .#bundle-image
$ sudo mount -o ro,loop,norecovery ./result/disk.raw /mnt
$ ls -lan /mnt
total 37
drwxr-xr-x  5     0     0  4096 Feb  2  1970 .
drwxr-xr-x 21     0     0    21 Oct  6 13:08 ..
drwxr-xr-x  3 11000 11000  4096 Oct  6 14:24 etc
drwx------  2     0     0 16384 Oct  6 14:29 lost+found
drwxr-xr-x  3 11000 11000  4096 Feb  2  1970 nix
```

Rollout
=======

- [x] This is fully backward and forward compatible (assuming that no one depends on quirky behavior where files are owned by nobody)
