### PR TITLE
[squashfs] set to user and group 11000

### DIFF
--- a/pkgs/bundle-squashfs/builder.sh
+++ b/pkgs/bundle-squashfs/builder.sh
@@ -17,4 +17,4 @@ cp "${env["active-modules"]}" $root/etc/nixmodules/active-modules.json
 echo "${env[registry]}" > "$root/etc/nixmodules/modules.json"
 
 echo "making squashfs..."
-mksquashfs "$root" "$out/disk.sqsh"
+mksquashfs "$root" "$out/disk.sqsh" -force-uid 11000 -force-gid 11000


### PR DESCRIPTION
Why
===
* We want /nix/store to be owned by 11000 in the Repl. When it isn't, it can cause problems with nix building

What changed
===
* Change the squashfs owner and group for files to be 11000, the Runner user. This fixes the issue in local Dev.

Test plan
===
```
$ nix build .#bundle-squashfs
$ sudo mount -o ro,loop ./result/disk.sqsh /mnt
total 4
drwxr-xr-x  4 11000 11000   49 Oct  6 09:58 .
drwxr-xr-x 24 root  root  4096 Sep 19 08:59 ..
drwxr-xr-x  3 11000 11000   33 Oct  6 09:58 etc
drwxr-xr-x  3 11000 11000   28 Oct  6 09:58 nix
$ ls -la /mnt
$ sudo umount /mnt
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
