### PR TITLE
Revert "Fix owner group ids"

### DIFF
--- a/pkgs/bundle-image/builder.sh
+++ b/pkgs/bundle-image/builder.sh
@@ -69,7 +69,6 @@ echo "copying to image..."
 cptofs -p \
        -t ext4 \
        -i "$diskImage" \
-       --owner 11000 --group 11000 \
        "$root"/* / ||
     (echo >&2 "ERROR: cptofs failed. diskSize might be too small for closure."; exit 1)
 

--- a/pkgs/bundle-image/default.nix
+++ b/pkgs/bundle-image/default.nix
@@ -11,21 +11,15 @@
 , jq
 , upgrade-maps
 , active-modules
-, fetchFromGitHub
+,
 }:
 
 let
+
   label = "nixmodules-${revstring}";
+
   registry = ../../modules.json;
-  # wating for upstream to include our patch: https://github.com/lkl/linux/pull/532
-  lkl' = lkl.overrideAttrs (oldAttrs: {
-    src = fetchFromGitHub {
-      owner = "numtide";
-      repo = "linux-lkl";
-      rev = "7a337bf313c82713f33f7b2e3c0b8847857a78b6";
-      sha256 = "sha256-MfOprw5n7kFOzu5Sl2hVG7+/Q22nKgCWGMO6HYN+SvU=";
-    };
-  });
+
 in
 
 derivation {
@@ -40,7 +34,7 @@ derivation {
     PATH = lib.makeBinPath [
       coreutils
       findutils
-      lkl'
+      lkl
       e2fsprogs
       jq
     ];


### PR DESCRIPTION
Reverts replit/nixmodules#131

# Why

[Disk mount is failing.](https://replit.slack.com/archives/C04E0RA5WH5/p1696954248866829?thread_ts=1696949007.740159&cid=C04E0RA5WH5)