### PR TITLE
Fix owner group ids

### DIFF
--- a/pkgs/bundle-image/builder.sh
+++ b/pkgs/bundle-image/builder.sh
@@ -69,6 +69,7 @@ echo "copying to image..."
 cptofs -p \
        -t ext4 \
        -i "$diskImage" \
+       --owner 11000 --group 11000 \
        "$root"/* / ||
     (echo >&2 "ERROR: cptofs failed. diskSize might be too small for closure."; exit 1)
 

--- a/pkgs/bundle-image/builder.sh
+++ b/pkgs/bundle-image/builder.sh
@@ -33,7 +33,7 @@ cp "${env["upgrade-maps"]}/recommend-upgrade.json" $root/etc/nixmodules/recommen
 cp "${env["active-modules"]}" $root/etc/nixmodules/active-modules.json
 cp -a --reflink=auto "${env[registry]}" "$root/etc/nixmodules/modules.json"
 
-diskImage=disk.raw
+diskImage=$out/disk.raw
 
 # Compute required space in filesystem blocks
 diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "${env[blockSize]}" | cut -f1 | sum_lines)
@@ -72,6 +72,3 @@ cptofs -p \
        --owner 11000 --group 11000 \
        "$root"/* / ||
     (echo >&2 "ERROR: cptofs failed. diskSize might be too small for closure."; exit 1)
-
-echo "moving image to out..."
-mv "$diskImage" "$out/disk.raw"

--- a/pkgs/bundle-image/default.nix
+++ b/pkgs/bundle-image/default.nix
@@ -11,15 +11,21 @@
 , jq
 , upgrade-maps
 , active-modules
-,
+, fetchFromGitHub
 }:
 
 let
-
   label = "nixmodules-${revstring}";
-
   registry = ../../modules.json;
-
+  # wating for upstream to include our patch: https://github.com/lkl/linux/pull/532
+  lkl' = lkl.overrideAttrs (oldAttrs: {
+    src = fetchFromGitHub {
+      owner = "numtide";
+      repo = "linux-lkl";
+      rev = "7a337bf313c82713f33f7b2e3c0b8847857a78b6";
+      sha256 = "sha256-MfOprw5n7kFOzu5Sl2hVG7+/Q22nKgCWGMO6HYN+SvU=";
+    };
+  });
 in
 
 derivation {
@@ -34,7 +40,7 @@ derivation {
     PATH = lib.makeBinPath [
       coreutils
       findutils
-      lkl
+      lkl'
       e2fsprogs
       jq
     ];

--- a/pkgs/bundle-image/default.nix
+++ b/pkgs/bundle-image/default.nix
@@ -17,13 +17,13 @@
 let
   label = "nixmodules-${revstring}";
   registry = ../../modules.json;
-  # wating for upstream to include our patch: https://github.com/lkl/linux/pull/532
+  # wating for upstream to include our patch: https://github.com/lkl/linux/pull/532 and https://github.com/lkl/linux/pull/534
   lkl' = lkl.overrideAttrs (oldAttrs: {
     src = fetchFromGitHub {
       owner = "numtide";
       repo = "linux-lkl";
-      rev = "7a337bf313c82713f33f7b2e3c0b8847857a78b6";
-      sha256 = "sha256-MfOprw5n7kFOzu5Sl2hVG7+/Q22nKgCWGMO6HYN+SvU=";
+      rev = "2cbcbd26044f72e47740588cfa21bf0e7b698262";
+      sha256 = "sha256-i7uc69bF84kkS7MahpgJ2EnWZLNah+Ees2oRGMzIee0=";
     };
   });
 in

--- a/pkgs/pip/default.nix
+++ b/pkgs/pip/default.nix
@@ -8,7 +8,7 @@ pypkgs.buildPythonPackage rec {
     owner = "replit";
     repo = pname;
     rev = "21.2.dev0";
-    sha256 = "sha256-k4RnK9TnvfJlxpihdHFg3JmYtNDC4KY+f41VwJ+e+1A=";
+    sha256 = "sha256-kSjKeLqXUG91QncrQlqqCWZvnnNnDuhk1jLBRtu7xdw=";
     name = "${pname}-${version}-source";
   };
 


### PR DESCRIPTION
Why
===

Create images with owner 11000 / group 11000 so that they do not come up as the nobody user in the repl.it. 

What changed
============

We switched to an lkl fork that supports this feature. An upstream pull request has been opened: https://github.com/lkl/linux/pull/532

This is the second attempt for this. We also noticed that lkl doesn't properly flush the journal as it reboots too quickly. This is now addressed by https://github.com/lkl/linux/pull/534 The no-recovery option is no longer required after that, even for read-only mounts.

Test plan
=========

```
$ nix build .#bundle-image
$ sudo mount -o ro,loop ./result/disk.raw /mnt
$ ls -lan /mnt
total 37
drwxr-xr-x  5     0     0  4096 Feb  2  1970 .
drwxr-xr-x 21     0     0    21 Oct  6 13:08 ..
drwxr-xr-x  3 11000 11000  4096 Oct  6 14:24 etc
drwx------  2     0     0 16384 Oct  6 14:29 lost+found
drwxr-xr-x  3 11000 11000  4096 Feb  2  1970 nix
```

Rollout
=======

- [x] This is fully backward and forward compatible (assuming that no one depends on quirky behavior where files are owned by nobody)