### PR TITLE
remove deleted dependency

### DIFF
--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -67,4 +67,3 @@ blocks:
     dependencies:
       - build oci images
       - provision nixmodules disks
-      - update prodvana configs


### PR DESCRIPTION
Why
===

last CD handoff failed because a block was deleted but another block depended on it

What changed
============

remove deleted block from list of dependencies

Test plan
=========

click the button, release happens

Rollout
=======

- [X] This is fully backward and forward compatible
