### PR TITLE
use fenix for rust module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,6 +40,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1697437401,
+        "narHash": "sha256-f4XpURQ8OxZV7txHkbJKcFj2sJJAvuk0p8SkNYitIkQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "ff913e22a14fd9728318997f2694ab2275ab1ad0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -264,6 +285,7 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "java-language-server": "java-language-server",
         "nixd": "nixd",
         "nixpkgs": "nixpkgs",
@@ -271,6 +293,23 @@
         "prybar": "prybar",
         "zig-overlay": "zig-overlay",
         "ztoc-rs": "ztoc-rs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696546231,
+        "narHash": "sha256-gueDbtDnrGP6fhI6j17vaImGETi/3aYFVQ6591l0YsI=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "03c56030350decb7f1c13c27eb7547ba5ed6b201",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,8 @@
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.fenix.url = "github:nix-community/fenix";
+  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.nixd.url = "github:nix-community/nixd";
   inputs.nixd.inputs.nixpkgs.follows = "nixpkgs";
   inputs.prybar.url = "github:replit/prybar";
@@ -13,7 +15,7 @@
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
   inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, zig-overlay, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, zig-overlay, fenix, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -23,6 +25,7 @@
           java-language-server.overlays.default
           nixd.overlays.default
           zig-overlay.overlays.default
+          fenix.overlays.default
         ];
         # replbox has an unfree license
         config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [

--- a/modules.json
+++ b/modules.json
@@ -554,5 +554,9 @@
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
+  },
+  "rust-stable:v1-20231012-19c270f": {
+    "commit": "19c270f8c0c3147800ada35d9a0755fe10905344",
+    "path": "/nix/store/3hw6spngfg758gz8ygla1458phpdi6x5-replit-module-rust-stable"
   }
 }

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -59,7 +59,13 @@ let
     };
 
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
+
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
+    "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };
+    "rust-1.69:v2-20230623-0b7a606" = { to = "rust-1.70:v1-20230724-17660e5"; auto = true; };
+    "rust-1.70:v1-20230724-17660e5" = { to = "rust-1.72:v1-20230911-f253fb1"; auto = true; };
+    "rust-1.72:v1-20230911-f253fb1" = { to = "rust-stable:v1-20231012-19c270f"; auto = true; };
+
     "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
   }
   // (fns.linearUpgrade "go-1.20")


### PR DESCRIPTION
Why
===

the rust module currently uses nixpkgs, but that comes with a few problems:
1. nixpkgs doesn't always get every version of the toolchain
  - for example, 1.72.1 has never been added to unstable, even though 1.73 is out now
  - 1.73 has been out for a week, but still isn't in unstable (which has a delay of ~36 hours iirc)
2. nixpkgs doesn't have every component in the toolchain
  - `rust-src` and `rust-std` aren't included, which means cross-compiling is impossible without overriding nixpkgs config attrs, which isn't possible
3. we don't update nixpkgs often, and it'd be nice if we could update the rust nixmodule independently of other nixmodules

What changed
============

- added input on [my fork of fenix](https://github.com/cdmistman/fenix) that has some patches so that the `version` attribute on various toolchain derivations are more 'accessible' (ie, it uses the tool's version number instead of the date the toolchain is built from)
- the module name no longer uses the rust version (when rust 2.0 drops we'll talk)
- changed rust nixmodule to use the fenix toolchain
- got rid of `cargo_run` script since we plan on adding support for project initializers
- got rid of `rustfmt` formatter since that's quite uncommon to invoke directly (when we add bazel support we'll talk)

Test plan
=========

with a blank repl:
- install the new nixmodule
- `cargo init` in the shell works
- open `src/main.rs`
- lsp status is green
- `println!` autocompletes
- run button works
- adding `eyre` via packages pane works

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
