### PR TITLE
bun: update to 1.0.6

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -507,6 +507,10 @@
     "commit": "0b7fed5df10f1eff802e5698b0a7858886fc6384",
     "path": "/nix/store/a0gdw6r206iry30gfshgfi0212cq3jg3-replit-module-bun-1.0"
   },
+  "bun-1.0:v7-20231013-71b6704": {
+    "commit": "71b670463deb5dc9486a64b5806cb38a216d22d5",
+    "path": "/nix/store/9k4pdc2sk21dfqs1j3yyr18rhn8vgxsv-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.0.3";
+  version = "1.0.6";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-8xMBU3jloMsdekejKrnswWfzXhxwvsHFNgcUf4hn0W4=";
+    hash = "sha256-OQ+jSHtdsTZspgwoy0wrntgNX85lndH2dC3ETGiJKQg=";
   };
 }

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -56,6 +56,7 @@ let
     # };
     "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
     "bun-1.0:v3-20230915-80b0f23" = { to = "bun-1.0:v6-20231002-0b7fed5"; auto = true; };
+    "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; };
 
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };


### PR DESCRIPTION
Why
===

🚀🍞

What changed
============

update bun to 1.0.6

Test plan
=========

`bun --version` prints 1.0.6

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
