### PR TITLE
package json runner again

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -511,6 +511,10 @@
     "commit": "71b670463deb5dc9486a64b5806cb38a216d22d5",
     "path": "/nix/store/9k4pdc2sk21dfqs1j3yyr18rhn8vgxsv-replit-module-bun-1.0"
   },
+  "bun-1.0:v8-20231013-f38c84f": {
+    "commit": "f38c84f1afc4c7d42b2bf7eed5ec49faeb872157",
+    "path": "/nix/store/6965w0q9sy4cwzxzz38fxfqd09s2ch56-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -6,23 +6,6 @@ let
   extensions = [ ".json" ".js" ".jsx" ".ts" ".tsx" ];
 
   community-version = lib.versions.majorMinor bun.version;
-
-  package-json-runner = pkgs.writeScript "bun-runner" ''
-    #!${pkgs.bash}/bin/bash
-    if start=$(${pkgs.jq}/bin/jq -r '.scripts.start? // empty' package.json 2>/dev/null); [[ -n $start ]]; then
-      echo "+ bun run start";
-      ${bun}/bin/bun run start;
-    elif module=$(${pkgs.jq}/bin/jq -r 'if .type == "module" then .module // empty else empty end' package.json 2>/dev/null); [[ -n $module ]]; then
-      echo "+ bun $module";
-      ${bun}/bin/bun $module;
-    elif main=$(${pkgs.jq}/bin/jq -r '.main // empty' package.json 2>/dev/null); [[ -n $main ]]; then
-      echo "+ bun $main";
-      ${bun}/bin/bun $main;
-    elif [[ -n $file ]]; then
-      echo "+ bun $file";
-      ${bun}/bin/bun $file;
-    fi
-  '';
 in
 
 {
@@ -30,6 +13,10 @@ in
   name = "Bun Tools";
 
   imports = [
+    (import ../run-package-json {
+      runPackageJsonScript = "${bun}/bin/bun run";
+      runFileScript = "${bun}/bin/bun";
+    })
     (import ../typescript-language-server {
       nodepkgs = pkgs.nodePackages;
     })
@@ -41,13 +28,9 @@ in
 
   replit.dev.languageServers.typescript-language-server.extensions = extensions;
 
-  replit.runners.bun = {
-    name = "bun";
+  replit.runners."package.json" = {
     language = "javascript";
     inherit extensions;
-
-    start = "${package-json-runner}";
-    optionalFileParam = true;
   };
 
   replit.dev.packagers.bun = {

--- a/pkgs/modules/run-package-json/default.nix
+++ b/pkgs/modules/run-package-json/default.nix
@@ -11,7 +11,7 @@ let
 in
 
 {
-  packages = [
+  replit.packages = [
     script
   ];
 

--- a/pkgs/modules/run-package-json/script.js
+++ b/pkgs/modules/run-package-json/script.js
@@ -1,13 +1,13 @@
-const fs = require("node:fs");
-const path = require("node:path");
-const { spawn } = require("node:child_process");
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
 
 const args = process.argv.slice(1);
 
 let runPackageJsonScript = null;
-const runPackageJsonScriptFlag = "--run-package-json-script";
+const runPackageJsonScriptFlag = '--run-package-json-script';
 let runScript = null;
-const runScriptFlag = "--run-script";
+const runScriptFlag = '--run-script';
 
 const checkPackageJsonScript = () => {
   if (!runPackageJsonScript) {
@@ -30,44 +30,44 @@ const checkRunScript = () => {
 while (args.length > 0) {
   const flag = args.shift();
 
-  if (flag.startsWith("--run-package-json-script")) {
+  if (flag.startsWith('--run-package-json-script')) {
     runPackageJsonScript = args.shift();
-  } else if (flag.startsWith("--run-script")) {
+  } else if (flag.startsWith('--run-script')) {
     runScript = args.shift();
   }
 }
 
-const packageJsonPath = path.join(process.cwd(), "package.json");
+const packageJsonPath = path.join(process.cwd(), 'package.json');
 if (!fs.existsSync(packageJsonPath)) {
-  console.error("No package.json found");
+  console.error('No package.json found');
   process.exit(1);
 }
 
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
 const hasScripts = Boolean(packageJson.scripts);
 
 let cmd = null;
-if (hasScripts && packageJson.scripts["replit-dev"]) {
+if (hasScripts && packageJson.scripts['replit-dev']) {
   checkPackageJsonScript();
   cmd = [runPackageJsonScript, 'replit-dev'];
-} else if (hasScripts && packageJson.scripts["dev"]) {
+} else if (hasScripts && packageJson.scripts['dev']) {
   checkPackageJsonScript();
   cmd = [runPackageJsonScript, 'dev'];
-} else if (packageJson["main"]) {
+} else if (process.env['file']) {
   checkRunScript();
-  cmd = [runScript, packageJson["main"]];
-} else if (process.env.file) {
+  cmd = [runScript, process.env['file']];
+} else if (packageJson['main']) {
   checkRunScript();
-  cmd = [runScript, process.env.file];
+  cmd = [runScript, packageJson['main']];
 } else {
-  console.error("Nothing to run.");
+  console.error('Nothing to run.');
   process.exit(1);
 }
 
 console.info(`+ ${cmd.join(' ')}`);
 
-spawn(cmd[0], cmd.slice(1).join(' '), {
+spawn(cmd[0], cmd.slice(1), {
 	stdio: 'inherit',
 	cwd: process.cwd(),
 	shell: false,

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -41,22 +41,22 @@ let
         - the `entrypoint` defined in `.replit`
       '';
     };
-    # "bun-1.0:v3-20230915-80b0f23" = {
-    #   to = "bun-1.0:v5-20230921-cc7a2dd";
-    #   auto = true;
-    #   changelog = ''# `package.json` runner
-    #     The runner for bun module has changed for increased flexibility and conformance to standards.
-
-    #     The new precedence is:
-    #     - the `replit-dev` script defined in `package.json`
-    #     - the `dev` script defined in `package.json`
-    #     - the `main` file defined in `package.json`
-    #     - the `entrypoint` defined in `.replit`
-    #   '';
-    # };
     "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
     "bun-1.0:v3-20230915-80b0f23" = { to = "bun-1.0:v6-20231002-0b7fed5"; auto = true; };
-    "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; };
+    "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; changelog = "bun 1.0.6 release"; };
+    "bun-1.0:v7-20231013-71b6704" = {
+      to = "bun-1.0:v8-20231013-f38c84f";
+      auto = true;
+      changelog = ''# `package.json` runner
+        The runner for bun module has changed for increased flexibility and conformance to standards.
+
+        The new precedence is:
+        - the `replit-dev` script defined in `package.json`
+        - the `dev` script defined in `package.json`
+        - the `entrypoint` defined in `.replit`
+        - the `main` file defined in `package.json`
+      '';
+    };
 
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
     "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };


### PR DESCRIPTION
Why
===

the last package.json runner script only works for bun and is frankly subpar. however the last time i introduced this package.json runner script everybody was sad because run button stopped working

What changed
============

brought back the new-and-improved package.json runner script but this time 👉😎👉 with no bugs

Test plan
=========

- WHEN TESTING IN CANARY MAKE SURE THE RIGHT DISK IS ATTACHED
- ALSO MAKE SURE YOU HAVE THE RIGHT MODULE INSTALLED
- try the matrix of setting the following: `scripts.replit-dev` in `package.json`, `scripts.dev` in `package.json`, `main` in `package.json`, and setting `entrypoint` in `.replit`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
