### PR TITLE
all the package managers

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -179,6 +179,10 @@
     "commit": "bd784b9a75c0781fd3efcdd4d51d255b6e991c86",
     "path": "/nix/store/v8s35zdng75sxnx677a6d7wdx5al9qfz-replit-module-nodejs-18"
   },
+  "nodejs-18:v12-20231020-a3526c9": {
+    "commit": "a3526c9c9fa746df4f7b733d2ca4eb487fb8ae1c",
+    "path": "/nix/store/shq2nm1dmzkag17g9yqb4kzny5wqzr1c-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -222,6 +226,10 @@
   "nodejs-20:v8-20230920-bd784b9": {
     "commit": "bd784b9a75c0781fd3efcdd4d51d255b6e991c86",
     "path": "/nix/store/88ya7kk44c8z35g7kaw3wa3anqy9i50i-replit-module-nodejs-20"
+  },
+  "nodejs-20:v9-20231020-a3526c9": {
+    "commit": "a3526c9c9fa746df4f7b733d2ca4eb487fb8ae1c",
+    "path": "/nix/store/h47lk59kdj5hidq79dlbzcly7z5nzswz-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -562,6 +570,10 @@
   "nodejs-with-prybar-18:v2-20231004-5c14992": {
     "commit": "5c14992744871ffcb60fe619b0314b4e92195948",
     "path": "/nix/store/qnx2vl8q3fpp67m421dsvhw7ffymqky6-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v3-20231020-a3526c9": {
+    "commit": "a3526c9c9fa746df4f7b733d2ca4eb487fb8ae1c",
+    "path": "/nix/store/m8rs0v4766zq51hmmrr7x3gxisag210v-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -1,16 +1,16 @@
 { nodejs }:
-{ pkgs, lib, ... }:
+{ pkgs, pkgs-unstable, lib, ... }:
 
 let
-
   community-version = lib.versions.major nodejs.version;
+
+  bun = pkgs-unstable.callPackage ../../bun { };
 
   nodepkgs = pkgs.nodePackages.override {
     inherit nodejs;
   };
 
   prettier = nodepkgs.prettier;
-
 in
 
 {
@@ -23,13 +23,15 @@ in
   ];
 
   replit = {
-
     packages = [
       nodejs
     ];
 
     dev.packages = [
+      bun
       prettier
+      nodepkgs.pnpm
+      nodepkgs.yarn
     ];
 
     dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".mjs" ".cjs" ".es6" ];


### PR DESCRIPTION
Why
===

it doesn't make sense for only `npm` to be available in nodejs repls. users should have choice!

https://linear.app/replit/issue/DX-240/add-all-package-managers-to-path-for-js-nixmodules

couldn't get `bun` in there without adding pkgs-unstable to the derivation 🤷

What changed
============

added yarn and pnpm to PATH for nodejs modules

Test plan
=========

- `which yarn` in an empty repl with nodejs nixmodules installed works
- ditto with `which pnpm`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
