### PR TITLE
Added R_LIBS_USER to env

### DIFF
--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -22,4 +22,8 @@ in
       enabledForHosting = false;
     };
   };
+
+  replit.env = {
+    R_LIBS_USER = "$REPL_HOME/.config/R";
+  };
 }


### PR DESCRIPTION
Why
===

Template https://replit.com/@replit/R has R_LIBS_USER defined, but it's not in the module.

What changed
============

Added it to the module.

Test plan
=========

1. create blank repl
2. add R module to it
3. exit shell
4. echo $R_LIBS_USER and it should have correct value

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
