### PR TITLE
upload modules to binary cache before building disk

### DIFF
--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -1,7 +1,7 @@
 version: v1.0
 name: build nixmodules
 execution_time_limit:
-  hours: 8
+  hours: 3
 agent:
   machine:
     type: s1-goval

--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -1,7 +1,7 @@
 version: v1.0
 name: build nixmodules
 execution_time_limit:
-  hours: 3
+  hours: 8
 agent:
   machine:
     type: s1-goval
@@ -36,6 +36,7 @@ blocks:
         - name: build nixmodules disk image
           commands:
             - scripts/setup_nix_binary_cache.py
+            - python3 scripts/cache_all_modules.py
             - scripts/build_disk_image.sh 2>&1 | tee nixmodules_build.log
       epilogue:
         always:


### PR DESCRIPTION
Why
===

Not sure why, but disk builds are still timing out. But if I build/cache each individual historical module first before building the disk, it works.

What changed
============

Run script that caches the builds first.

Test plan
=========

Run another build.