### PR TITLE
update nixpkgs-unstable, add go-1.21 module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694343207,
-        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
+        "lastModified": 1697915759,
+        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
         "type": "github"
       },
       "original": {

--- a/modules.json
+++ b/modules.json
@@ -435,6 +435,10 @@
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/ldrmd6bmx8j695jjps3fs8zlkki2gn3w-replit-module-svelte-kit-node-20"
   },
+  "svelte-kit-node-20:v4-20231024-b3ba53c": {
+    "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
+    "path": "/nix/store/xnl830xrhx5s121q12j5dyyjn8rx9f7v-replit-module-svelte-kit-node-20"
+  },
   "gcloud:v1-20230815-e6e4431": {
     "commit": "e6e4431a8f1d71ec0664ce97828bede1608dcfd1",
     "path": "/nix/store/q67zzk6y4zzw7k6nc2plql97z1yv7xwx-replit-module-gcloud"
@@ -527,6 +531,10 @@
     "commit": "f38c84f1afc4c7d42b2bf7eed5ec49faeb872157",
     "path": "/nix/store/6965w0q9sy4cwzxzz38fxfqd09s2ch56-replit-module-bun-1.0"
   },
+  "bun-1.0:v9-20231024-b3ba53c": {
+    "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
+    "path": "/nix/store/5r595p3m04fy4kr3yzl4p4k72d817s5p-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -562,5 +570,9 @@
   "rust-stable:v1-20231012-19c270f": {
     "commit": "19c270f8c0c3147800ada35d9a0755fe10905344",
     "path": "/nix/store/3hw6spngfg758gz8ygla1458phpdi6x5-replit-module-rust-stable"
+  },
+  "go-1.21:v1-20231024-b3ba53c": {
+    "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
+    "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -35,7 +35,16 @@ let
     })
     (import ./nodejs-with-prybar)
 
-    (import ./go)
+    (import ./go {
+      inherit (pkgs) go gopls;
+    })
+    (import ./go {
+      go = pkgs-unstable.go_1_21;
+      gopls = pkgs-unstable.gopls.override {
+        buildGoModule = pkgs-unstable.buildGo121Module;
+      };
+    })
+
     (import ./rust)
     (import ./swift)
     (import ./bun)

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -1,17 +1,18 @@
-{ pkgs, lib, ... }:
+{ go, gopls }:
+{ lib, ... }:
 let
-  goversion = lib.versions.majorMinor pkgs.go.version;
+  goversion = lib.versions.majorMinor go.version;
 in
 {
   id = "go-${goversion}";
   name = "Go Tools";
 
-  replit.packages = with pkgs; [
+  replit.packages = [
     go
   ];
 
   replit.dev.packages = [
-    pkgs.gopls
+    gopls
   ];
 
   # TODO: should compile a binary to use in deployment and not include the runtime
@@ -19,14 +20,14 @@ in
     name = "go run";
     language = "go";
 
-    start = "${pkgs.go}/bin/go run $REPL_HOME";
+    start = "${go}/bin/go run $REPL_HOME";
   };
 
   replit.dev.formatters.go-fmt = {
     name = "go fmt";
     language = "go";
 
-    start = "${pkgs.go}/bin/go fmt";
+    start = "${go}/bin/go fmt";
     stdin = false;
   };
 
@@ -34,6 +35,6 @@ in
     name = "gopls";
     language = "go";
 
-    start = "${pkgs.gopls}/bin/gopls";
+    start = "${gopls}/bin/gopls";
   };
 }

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -57,6 +57,7 @@ let
         - the `main` file defined in `package.json`
       '';
     };
+    "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
 
     "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
 


### PR DESCRIPTION
Why
===

people want go 1.21 but it's not available on replit

What changed
============

- updated nixpkgs-unstable input
- added go 1.21 module

Test plan
=========

- sveltekit template tests pass
- bun template tests pass
- go template tests pass when set to go 1.21 module
  - note that this will require changing the template and running against the working release. 
  - also note that the template should not be released until enough conmen have attached to the new nixmodules disk build containing these commits

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
