### PR TITLE
[docker] Add the Docker module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -586,5 +586,9 @@
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
+  },
+  "docker:v1-20231026-3990bf0": {
+    "commit": "3990bf05353ec3cffd54b8376616fdf6165d4580",
+    "path": "/nix/store/0c5i7v9vizdn2yfkkk46haxakrlpjbax-replit-module-docker"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -51,6 +51,7 @@ let
     (import ./c)
     (import ./cpp)
     (import ./dart)
+    (import ./docker)
     (import ./gcloud)
     (import ./clojure)
     (import ./dotnet)

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -1,0 +1,78 @@
+{ pkgs, pkgs-unstable, ... }:
+
+let
+
+  replit-runc = pkgs-unstable.buildGo121Module {
+    pname = "replit-runc";
+    version = "1.1.9+replit";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "opencontainers";
+      repo = "runc";
+      rev = "b17c6f237dfd6d2dab9bd9c9b36cb9e429ee1fd1";
+      sha256 = "sha256-KyEIXwQiu/ZpqiuLzJv6nxLmD6qzr6+hpiDVE1q9MAY=";
+    };
+
+    # We have a few patches in place to be able to run runc without privileges
+    # and ask ruse to create the privileged part of the container.
+    patches = [ ./replit-runc.patch ];
+
+    subPackages = [ "./" ];
+
+    vendorSha256 = null;
+
+    doCheck = false;
+
+    postInstall = ''
+      mv $out/bin/runc $out/bin/replit-runc
+    '';
+  };
+
+  replit-shim-runc = pkgs-unstable.buildGo121Module {
+    pname = "replit-shim-runc";
+    version = "1.7.5+replit";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "containerd";
+      repo = "containerd";
+      rev = "v1.7.5";
+      sha256 = "sha256-g+1JfXO1k0ijPpVTo+WxmXro4p4MbRCIZdgtgy58M60=";
+    };
+
+    # We have a few patches in place to be able to invoke the replit-runc.
+    patches = [ ./replit-shim-runc.patch ];
+
+    subPackages = [ "./cmd/containerd-shim-runc-v2" ];
+
+    vendorSha256 = null;
+
+    doCheck = false;
+
+    postInstall = ''
+      mv $out/bin/containerd-shim-runc-v2 $out/bin/replit-shim-runc
+    '';
+  };
+
+  containerdAdditions = pkgs.copyPathToStore ./etc;
+  containerd = pkgs.containerd.overrideAttrs (old: {
+    postInstall = ''
+      mkdir $out/etc
+      cp ${containerdAdditions}/containerd.toml $out/etc/
+    '';
+  });
+
+in
+
+{
+  id = "docker";
+  name = "Support for Docker containers";
+
+  replit.packages = [ ];
+
+  replit.dev.packages = [
+    pkgs.docker-client
+    containerd
+    replit-shim-runc
+    replit-runc
+  ];
+}

--- a/pkgs/modules/docker/etc/containerd.toml
+++ b/pkgs/modules/docker/etc/containerd.toml
@@ -1,0 +1,253 @@
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = ""
+state = "/run/containerd"
+temp = ""
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  gid = 1000
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_ca = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 1000
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = false
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    enable_unprivileged_icmp = false
+    enable_unprivileged_ports = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "registry.k8s.io/pause:3.6"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "./bin"
+      conf_dir = "./.config/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "replit-runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      ignore_rdt_not_enabled_errors = false
+      no_pivot = false
+      snapshotter = "native"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.replit-runc]
+          base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.replit-runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.replit-runc.options]
+            BinaryName = "replit-runc"
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = false
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.internal.v1.tracing"]
+    sampling_ratio = 1.0
+    service_name = "containerd"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.runtime.v1.linux"]
+    no_shim = false
+    runtime = "runc"
+    runtime_root = ""
+    shim = "./bin/replit-shim-runc"
+    shim_debug = false
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+    sched_core = false
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.service.v1.tasks-service"]
+    rdt_config_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.aufs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    discard_blocks = false
+    fs_options = ""
+    fs_type = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = ""
+    upperdir_label = false
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+    endpoint = ""
+    insecure = false
+    protocol = ""
+
+[proxy_plugins]
+  [proxy_plugins."replit-snapshotter"]
+    type = "snapshot"
+    address = "/run/replit-snapshotter.sock"
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.bolt.open" = "0s"
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0

--- a/pkgs/modules/docker/replit-runc.patch
+++ b/pkgs/modules/docker/replit-runc.patch
@@ -1,0 +1,279 @@
+diff --git a/init.go b/init.go
+index 79336306..1b4675ba 100644
+--- a/init.go
++++ b/init.go
+@@ -1,16 +1,90 @@
+ package main
+ 
+ import (
++	"bytes"
+ 	"os"
++	"os/exec"
++	"strconv"
++	"time"
+ 
+-	"github.com/opencontainers/runc/libcontainer"
+-	_ "github.com/opencontainers/runc/libcontainer/nsenter"
++	"github.com/sirupsen/logrus"
+ )
+ 
+ func init() {
+ 	if len(os.Args) > 1 && os.Args[1] == "init" {
+-		// This is the golang entry point for runc init, executed
+-		// before main() but after libcontainer/nsenter's nsexec().
+-		libcontainer.Init()
++		// Replit mod: we recruit the help of the roci binary to
++		// have the container be setup for us.
++		systemLogFile, err := os.OpenFile("/tmp/runc.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0o644)
++		if err != nil {
++			panic(err)
++		}
++		logrus.SetOutput(systemLogFile)
++
++		logrus.Info("running roci")
++
++		// In Replit, we just ask roci to initialize the container for us.
++		args := []string{"runc", "init"}
++		cmd := exec.Command("/usr/bin/roci", args...)
++		cmd.Stdin = os.Stdin
++		cmd.Stdout = os.Stdout
++		var stderr bytes.Buffer
++		cmd.Stderr = &stderr
++		fds := make(map[int]*os.File)
++		maxFd := 0
++		for _, name := range []string{
++			"_LIBCONTAINER_INITPIPE",
++			"_LIBCONTAINER_LOGPIPE",
++			"_LIBCONTAINER_CONSOLE",
++			"_LIBCONTAINER_FIFOFD",
++		} {
++			value := os.Getenv(name)
++			if value == "" {
++				continue
++			}
++			fd, err := strconv.Atoi(os.Getenv(name))
++			if err != nil {
++				logrus.
++					WithError(err).
++					WithField("source", "runc").
++					Errorf("roci %q: %q", args, stderr.String())
++				os.Exit(1)
++			}
++			fds[fd] = os.NewFile(uintptr(fd), name)
++			if maxFd < fd {
++				maxFd = fd
++			}
++		}
++		null, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
++		if err != nil {
++			logrus.
++				WithError(err).
++				WithField("source", "runc").
++				Errorf("roci %q: open /dev/null", args)
++			os.Exit(1)
++		}
++		defer null.Close()
++		for fd := 3; fd <= maxFd; fd++ {
++			cmd.ExtraFiles = append(cmd.ExtraFiles, null)
++		}
++		for fd, f := range fds {
++			cmd.ExtraFiles[fd - 3] = f
++		}
++		cmd.ExtraFiles = append(cmd.ExtraFiles, os.Stderr)
++		cmd.Env = append(os.Environ(), "_ROCI_STDERR_FD=" + strconv.Itoa(len(cmd.ExtraFiles) + 2))
++		err = cmd.Run()
++		if err != nil {
++			logrus.
++				WithError(err).
++				WithField("source", "runc").
++				WithField("env", cmd.Env).
++				Error("roci failed, chilling a bit")
++			time.Sleep(1 * time.Second)
++			logrus.
++				WithError(err).
++				WithField("source", "runc").
++				Errorf("roci %q: %q", args, stderr.String())
++			os.Exit(1)
++		}
++		os.Exit(0)
+ 	}
+ }
+diff --git a/libcontainer/configs/validate/rootless.go b/libcontainer/configs/validate/rootless.go
+index 6d32704a..b00e4533 100644
+--- a/libcontainer/configs/validate/rootless.go
++++ b/libcontainer/configs/validate/rootless.go
+@@ -1,10 +1,6 @@
+ package validate
+ 
+ import (
+-	"errors"
+-	"strconv"
+-	"strings"
+-
+ 	"github.com/opencontainers/runc/libcontainer/configs"
+ )
+ 
+@@ -38,53 +34,13 @@ func hasIDMapping(id int, mappings []configs.IDMap) bool {
+ }
+ 
+ func rootlessEUIDMappings(config *configs.Config) error {
+-	if !config.Namespaces.Contains(configs.NEWUSER) {
+-		return errors.New("rootless container requires user namespaces")
+-	}
+-
+-	if len(config.UIDMappings) == 0 {
+-		return errors.New("rootless containers requires at least one UID mapping")
+-	}
+-	if len(config.GIDMappings) == 0 {
+-		return errors.New("rootless containers requires at least one GID mapping")
+-	}
++	// Replit mod: This is handled outside of the container.
+ 	return nil
+ }
+ 
+ // rootlessEUIDMount verifies that all mounts have valid uid=/gid= options,
+ // i.e. their arguments has proper ID mappings.
+ func rootlessEUIDMount(config *configs.Config) error {
+-	// XXX: We could whitelist allowed devices at this point, but I'm not
+-	//      convinced that's a good idea. The kernel is the best arbiter of
+-	//      access control.
+-
+-	for _, mount := range config.Mounts {
+-		// Check that the options list doesn't contain any uid= or gid= entries
+-		// that don't resolve to root.
+-		for _, opt := range strings.Split(mount.Data, ",") {
+-			if str := strings.TrimPrefix(opt, "uid="); len(str) < len(opt) {
+-				uid, err := strconv.Atoi(str)
+-				if err != nil {
+-					// Ignore unknown mount options.
+-					continue
+-				}
+-				if !hasIDMapping(uid, config.UIDMappings) {
+-					return errors.New("cannot specify uid= mount options for unmapped uid in rootless containers")
+-				}
+-			}
+-
+-			if str := strings.TrimPrefix(opt, "gid="); len(str) < len(opt) {
+-				gid, err := strconv.Atoi(str)
+-				if err != nil {
+-					// Ignore unknown mount options.
+-					continue
+-				}
+-				if !hasIDMapping(gid, config.GIDMappings) {
+-					return errors.New("cannot specify gid= mount options for unmapped gid in rootless containers")
+-				}
+-			}
+-		}
+-	}
+-
++	// Replit mod: This is handled outside of the container.
+ 	return nil
+ }
+diff --git a/libcontainer/process_linux.go b/libcontainer/process_linux.go
+index 8785d657..328b27f8 100644
+--- a/libcontainer/process_linux.go
++++ b/libcontainer/process_linux.go
+@@ -162,62 +162,8 @@ func (p *setnsProcess) start() (retErr error) {
+ 		return fmt.Errorf("error writing config to pipe: %w", err)
+ 	}
+ 
+-	ierr := parseSync(p.messageSockPair.parent, func(sync *syncT) error {
+-		switch sync.Type {
+-		case procReady:
+-			// This shouldn't happen.
+-			panic("unexpected procReady in setns")
+-		case procHooks:
+-			// This shouldn't happen.
+-			panic("unexpected procHooks in setns")
+-		case procSeccomp:
+-			if p.config.Config.Seccomp.ListenerPath == "" {
+-				return errors.New("seccomp listenerPath is not set")
+-			}
+-			if sync.Arg == nil {
+-				return fmt.Errorf("sync %q is missing an argument", sync.Type)
+-			}
+-			var srcFd int
+-			if err := json.Unmarshal(*sync.Arg, &srcFd); err != nil {
+-				return fmt.Errorf("sync %q passed invalid fd arg: %w", sync.Type, err)
+-			}
+-			seccompFd, err := pidGetFd(p.pid(), srcFd)
+-			if err != nil {
+-				return fmt.Errorf("sync %q get fd %d from child failed: %w", sync.Type, srcFd, err)
+-			}
+-			defer seccompFd.Close()
+-			// We have a copy, the child can keep working. We don't need to
+-			// wait for the seccomp notify listener to get the fd before we
+-			// permit the child to continue because the child will happily wait
+-			// for the listener if it hits SCMP_ACT_NOTIFY.
+-			if err := writeSync(p.messageSockPair.parent, procSeccompDone); err != nil {
+-				return err
+-			}
+-
+-			bundle, annotations := utils.Annotations(p.config.Config.Labels)
+-			containerProcessState := &specs.ContainerProcessState{
+-				Version:  specs.Version,
+-				Fds:      []string{specs.SeccompFdName},
+-				Pid:      p.cmd.Process.Pid,
+-				Metadata: p.config.Config.Seccomp.ListenerMetadata,
+-				State: specs.State{
+-					Version:     specs.Version,
+-					ID:          p.config.ContainerID,
+-					Status:      specs.StateRunning,
+-					Pid:         p.initProcessPid,
+-					Bundle:      bundle,
+-					Annotations: annotations,
+-				},
+-			}
+-			if err := sendContainerProcessState(p.config.Config.Seccomp.ListenerPath,
+-				containerProcessState, seccompFd); err != nil {
+-				return err
+-			}
+-		default:
+-			return errors.New("invalid JSON payload from child")
+-		}
+-		return nil
+-	})
++	// Replit mod: our runc implementation does not send this message and instead jumps directly onto the next stage.
++	var ierr error
+ 
+ 	if err := unix.Shutdown(int(p.messageSockPair.parent.Fd()), unix.SHUT_WR); err != nil {
+ 		return &os.PathError{Op: "shutdown", Path: "(init pipe)", Err: err}
+@@ -514,6 +460,38 @@ func (p *initProcess) start() (retErr error) {
+ 			if err := setupRlimits(p.config.Rlimits, p.pid()); err != nil {
+ 				return fmt.Errorf("error setting rlimits for ready process: %w", err)
+ 			}
++			// Replit mod: call prestart and CreateRuntime hooks.
++			// Our implementation of the runc init is run in a separate
++			// binary and therefore we need to still run this code here.
++			if !p.config.Config.Namespaces.Contains(configs.NEWNS) {
++				// Setup cgroup before the hook, so that the prestart and CreateRuntime hook could apply cgroup permissions.
++				if err := p.manager.Set(p.config.Config.Cgroups.Resources); err != nil {
++					return fmt.Errorf("error setting cgroup config for ready process: %w", err)
++				}
++				if p.intelRdtManager != nil {
++					if err := p.intelRdtManager.Set(p.config.Config); err != nil {
++						return fmt.Errorf("error setting Intel RDT config for ready process: %w", err)
++					}
++				}
++
++				if len(p.config.Config.Hooks) != 0 {
++					s, err := p.container.currentOCIState()
++					if err != nil {
++						return err
++					}
++					// initProcessStartTime hasn't been set yet.
++					s.Pid = p.cmd.Process.Pid
++					s.Status = specs.StateCreating
++					hooks := p.config.Config.Hooks
++
++					if err := hooks.Run(configs.Prestart, s); err != nil {
++						return err
++					}
++					if err := hooks.Run(configs.CreateRuntime, s); err != nil {
++						return err
++					}
++				}
++			}
+ 
+ 			// generate a timestamp indicating when the container was started
+ 			p.container.created = time.Now().UTC()

--- a/pkgs/modules/docker/replit-shim-runc.patch
+++ b/pkgs/modules/docker/replit-shim-runc.patch
@@ -1,0 +1,160 @@
+diff --git a/runtime/v2/runc/task/service.go b/runtime/v2/runc/task/service.go
+index 43dfdf941..9105879c1 100644
+--- a/runtime/v2/runc/task/service.go
++++ b/runtime/v2/runc/task/service.go
+@@ -38,7 +38,6 @@ import (
+ 	"github.com/containerd/containerd/pkg/process"
+ 	"github.com/containerd/containerd/pkg/shutdown"
+ 	"github.com/containerd/containerd/pkg/stdio"
+-	"github.com/containerd/containerd/pkg/userns"
+ 	"github.com/containerd/containerd/protobuf"
+ 	ptypes "github.com/containerd/containerd/protobuf/types"
+ 	"github.com/containerd/containerd/runtime/v2/runc"
+@@ -273,21 +272,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
+ 				logrus.WithError(err).Error("add cg to OOM monitor")
+ 			}
+ 		case *cgroupsv2.Manager:
+-			allControllers, err := cg.RootControllers()
+-			if err != nil {
+-				logrus.WithError(err).Error("failed to get root controllers")
+-			} else {
+-				if err := cg.ToggleControllers(allControllers, cgroupsv2.Enable); err != nil {
+-					if userns.RunningInUserNS() {
+-						logrus.WithError(err).Debugf("failed to enable controllers (%v)", allControllers)
+-					} else {
+-						logrus.WithError(err).Errorf("failed to enable controllers (%v)", allControllers)
+-					}
+-				}
+-			}
+-			if err := s.ep.Add(container.ID, cg); err != nil {
+-				logrus.WithError(err).Error("add cg to OOM monitor")
+-			}
++			// Replit mod: TODO: Figure out how to wire up cgroups correctly.
+ 		}
+ 
+ 		s.send(&eventstypes.TaskStart{
+diff --git a/runtime/v2/shim/shim.go b/runtime/v2/shim/shim.go
+index cf006d805..54791a433 100644
+--- a/runtime/v2/shim/shim.go
++++ b/runtime/v2/shim/shim.go
+@@ -37,6 +37,7 @@ import (
+ 	"github.com/containerd/containerd/plugin"
+ 	"github.com/containerd/containerd/protobuf"
+ 	"github.com/containerd/containerd/protobuf/proto"
++	"github.com/containerd/containerd/sys/reaper"
+ 	"github.com/containerd/containerd/version"
+ 	"github.com/containerd/ttrpc"
+ 	"github.com/sirupsen/logrus"
+@@ -518,6 +519,9 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
+ 		}
+ 	}()
+ 
++	// Replit mod: Containers are not our direct descendants, so
++	// we need to have an external listener for child death events.
++	reaper.ListenExternalReaps()
+ 	go handleExitSignals(ctx, logger, shutdown)
+ 	return reap(ctx, logger, signals)
+ }
+diff --git a/sys/reaper/reaper_unix.go b/sys/reaper/reaper_unix.go
+index 8172f224e..a4c5941fd 100644
+--- a/sys/reaper/reaper_unix.go
++++ b/sys/reaper/reaper_unix.go
+@@ -21,10 +21,16 @@ package reaper
+ import (
+ 	"errors"
+ 	"fmt"
++	"net"
+ 	"sync"
+ 	"syscall"
++	"path"
++	"os"
++	"encoding/json"
+ 	"time"
+ 
++	log "github.com/sirupsen/logrus"
++
+ 	runc "github.com/containerd/go-runc"
+ 	exec "golang.org/x/sys/execabs"
+ 	"golang.org/x/sys/unix"
+@@ -58,6 +64,67 @@ func (s *subscriber) do(fn func()) {
+ 	s.Unlock()
+ }
+ 
++// Replit mod: Since roci-started containers are not direct descendants
++// of the shim (like they are in a regular containerd system), we need
++// a way to let the various places where the shim waits for the
++// various processes involved in container creation to exit.
++var externalReapsOnce sync.Once
++
++// ListenExternalReaps installs a UNIX domain socket that listens
++// for roci's notifications of when the container process dies.
++func ListenExternalReaps() {
++	externalReapsOnce.Do(func() {
++		go listenExternalReaps()
++	})
++}
++
++func listenExternalReaps() {
++	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
++	if runtimeDir == "" {
++		runtimeDir = "/run"
++	}
++	socketPath := path.Join(runtimeDir, "containerd/containerd-reaper.sock")
++	os.Remove(socketPath)
++	addr, err := net.ResolveUnixAddr("unix", socketPath)
++	if err != nil {
++		return
++	}
++	l, err := net.ListenUnix("unix", addr)
++	if err != nil {
++		return
++	}
++	for {
++		conn, err := l.Accept()
++		if err != nil {
++			log.WithError(err).Error("reaper.ListenExternalReaps: l.Accept")
++			break
++		}
++		go func() {
++			defer conn.Close()
++			type exit struct {
++				Pid    int `json:"pid"`
++				Status int `json:"status"`
++			}
++			var e exit
++			err := json.NewDecoder(conn).Decode(&e)
++			if err != nil {
++				log.WithError(err).Error("reaper.ListenExternalReaps: Decode")
++				return
++			}
++			done := Default.notify(runc.Exit{
++				Timestamp: time.Now(),
++				Pid:       e.Pid,
++				Status:    e.Status,
++			})
++
++			select {
++			case <-done:
++			case <-time.After(1 * time.Second):
++			}
++		}()
++	}
++}
++
+ // Reap should be called when the process receives an SIGCHLD.  Reap will reap
+ // all exited processes and close their wait channels
+ func Reap() error {
+diff --git a/vendor/github.com/containerd/go-runc/runc.go b/vendor/github.com/containerd/go-runc/runc.go
+index f5f03ae95..d292d4c81 100644
+--- a/vendor/github.com/containerd/go-runc/runc.go
++++ b/vendor/github.com/containerd/go-runc/runc.go
+@@ -51,7 +51,8 @@ const (
+ 	JSON Format = "json"
+ 	Text Format = "text"
+ 	// DefaultCommand is the default command for Runc
+-	DefaultCommand = "runc"
++	// Replit mod: Use our own fork of runc.
++	DefaultCommand = "replit-runc"
+ )
+ 
+ // List returns all containers created inside the provided runc root directory

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -69,6 +69,7 @@ let
 
     "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
   }
+  // (fns.linearUpgrade "docker")
   // (fns.linearUpgrade "go-1.20")
   // (fns.linearUpgrade "java-graalvm22.3")
   // (fns.linearUpgrade "nodejs-14")


### PR DESCRIPTION
Why
===

We want to try seeing what would be needed to support running Docker containers in Replspace.


What changed
============

This change adds the necessary support to run containers in Replspace (with the exception of `replit-dockerd`, which will be provided elsewhere).

Test plan
=========

This was tested on one Repl. e2e test coming soon!

Rollout
=======

- [X] This is fully backward and forward compatible