### PR TITLE
[python] update LD_LIBRARY_PATH logic

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -343,6 +343,10 @@
     "commit": "7459cc2a5fd03bda902c2cd8d9d1fb387181b570",
     "path": "/nix/store/xnhi7jal6q86lvck9vpc1fhaxl38drzb-replit-module-python-3.10"
   },
+  "python-3.10:v27-20231026-3dd69ae": {
+    "commit": "3dd69ae594a9e2ca5bdf33582e036c0788d0e804",
+    "path": "/nix/store/b97qa0cjljqf97637pd6nbpiq5dphfv6-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -483,6 +487,10 @@
     "commit": "35990c496af3e4a137a67c1c7a5ebec0849610b3",
     "path": "/nix/store/s2w2qadghhr4gywnc6n1s70x2cl86j43-replit-module-python-3.11"
   },
+  "python-3.11:v8-20231026-3dd69ae": {
+    "commit": "3dd69ae594a9e2ca5bdf33582e036c0788d0e804",
+    "path": "/nix/store/qy2gjvsiq6kmg3c1iish3bj6wq905vdb-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -510,6 +518,10 @@
   "python-3.8:v7-20231016-35990c4": {
     "commit": "35990c496af3e4a137a67c1c7a5ebec0849610b3",
     "path": "/nix/store/904k10vqg0avp4pg7fpzzma36p3jnw9v-replit-module-python-3.8"
+  },
+  "python-3.8:v8-20231026-3dd69ae": {
+    "commit": "3dd69ae594a9e2ca5bdf33582e036c0788d0e804",
+    "path": "/nix/store/gn56kbip9c7yg2knsnb7sk99varjsvbg-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -566,6 +578,10 @@
   "python-with-prybar-3.10:v4-20231004-5c14992": {
     "commit": "5c14992744871ffcb60fe619b0314b4e92195948",
     "path": "/nix/store/k9bbbvbl7j6rhq3x6sp9r859z9ckz982-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v5-20231026-3dd69ae": {
+    "commit": "3dd69ae594a9e2ca5bdf33582e036c0788d0e804",
+    "path": "/nix/store/31qxlfiz89z76d8hsxi47cvwa86ydk5r-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",


### PR DESCRIPTION
Why
===
* When the System Dependency Assistance code added the PYTHON_LD_LIBRARY_PATH, it made the default paths not be used. This caused certain libraries to break like matplotlib.
* Instead, always include those base libraries.

What changed
==
* Always include the python-ld-library-path paths, but give them the least precedence. Give next precedece to the now-deprecated PYTHON_LD_LIBRARY_PATH and give the most precedence to REPLIT_LD_LIBRARY_PATH like in #146.

Test plan
===

```
[ryantm@replit1:~/p/replit/nixmodules2]$ /nix/store/7mrral8h5h37fcn5bs3r15waxfs8ggfj-python3-wrapper/bin/python3
Python 3.11.3 (main, Apr  4 2023, 22:36:41) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
print(os.environ['LD_LIBRARY_PATH'])
>>> /nix/store/ia1nj04xx5v5rbg349m6dpicl1j11cwi-cpplibs/lib:/nix/store/fxq6yn4mfnsnh418l2k218j7sp365sa9-zlib-1.2.13/lib:/nix/store/rympfmzvl838agp9xlkyi0w48wjb9p3a-glib-2.76.2/lib:/nix/store/gzs13l92w3308ichywy2013bw2n6l413-libX11-1.8.4/li\
b:/nix/store/pfn3d53934dswdsf269kmi2acbcjkq2p-libXext-1.3.4/lib:/nix/store/sc2acmp2zv7402lz42v4dhx0cnwpqk97-libXinerama-1.1.4/lib:/nix/store/jf4bifqwrj95skzspw195bbdly6lgkvk-libXcursor-1.2.0/lib:/nix/store/0ypjj16v283nfi76z4pa6wbyr0qqxrsp-\
libXrandr-1.5.2/lib:/nix/store/4jpzk3ryi0pmmyyzqi1nqw566368bz46-libXi-1.8/lib:/nix/store/b0bw49b9rfgg55i739dgkdfk8y6vb4hh-libXxf86vm-1.1.5/lib
>>>

[ryantm@replit1:~/p/replit/nixmodules2]$ PYTHON_LD_LIBRARY_PATH=a /nix/store/7mrral8h5h37fcn5bs3r15waxfs8ggfj-python3-wrapper/bin/python3
Python 3.11.3 (main, Apr  4 2023, 22:36:41) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
print(os.environ['LD_LIBRARY_PATH'])
>>> a:/nix/store/ia1nj04xx5v5rbg349m6dpicl1j11cwi-cpplibs/lib:/nix/store/fxq6yn4mfnsnh418l2k218j7sp365sa9-zlib-1.2.13/lib:/nix/store/rympfmzvl838agp9xlkyi0w48wjb9p3a-glib-2.76.2/lib:/nix/store/gzs13l92w3308ichywy2013bw2n6l413-libX11-1.8.4/\
lib:/nix/store/pfn3d53934dswdsf269kmi2acbcjkq2p-libXext-1.3.4/lib:/nix/store/sc2acmp2zv7402lz42v4dhx0cnwpqk97-libXinerama-1.1.4/lib:/nix/store/jf4bifqwrj95skzspw195bbdly6lgkvk-libXcursor-1.2.0/lib:/nix/store/0ypjj16v283nfi76z4pa6wbyr0qqxrs\
p-libXrandr-1.5.2/lib:/nix/store/4jpzk3ryi0pmmyyzqi1nqw566368bz46-libXi-1.8/lib:/nix/store/b0bw49b9rfgg55i739dgkdfk8y6vb4hh-libXxf86vm-1.1.5/lib
>>>

[ryantm@replit1:~/p/replit/nixmodules2]$ REPLIT_LD_LIBRARY_PATH=b PYTHON_LD_LIBRARY_PATH=a /nix/store/7mrral8h5h37fcn5bs3r15waxfs8ggfj-python3-wrapper/bin/python3
Python 3.11.3 (main, Apr  4 2023, 22:36:41) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
print(os.environ['LD_LIBRARY_PATH'])
>>> b:a:/nix/store/ia1nj04xx5v5rbg349m6dpicl1j11cwi-cpplibs/lib:/nix/store/fxq6yn4mfnsnh418l2k218j7sp365sa9-zlib-1.2.13/lib:/nix/store/rympfmzvl838agp9xlkyi0w48wjb9p3a-glib-2.76.2/lib:/nix/store/gzs13l92w3308ichywy2013bw2n6l413-libX11-1.8.\
4/lib:/nix/store/pfn3d53934dswdsf269kmi2acbcjkq2p-libXext-1.3.4/lib:/nix/store/sc2acmp2zv7402lz42v4dhx0cnwpqk97-libXinerama-1.1.4/lib:/nix/store/jf4bifqwrj95skzspw195bbdly6lgkvk-libXcursor-1.2.0/lib:/nix/store/0ypjj16v283nfi76z4pa6wbyr0qqx\
rsp-libXrandr-1.5.2/lib:/nix/store/4jpzk3ryi0pmmyyzqi1nqw566368bz46-libXi-1.8/lib:/nix/store/b0bw49b9rfgg55i739dgkdfk8y6vb4hh-libXxf86vm-1.1.5/lib
>>>

[ryantm@replit1:~/p/replit/nixmodules2]$ REPLIT_LD_LIBRARY_PATH=b /nix/store/7mrral8h5h37fcn5bs3r15waxfs8ggfj-python3-wrapper/bin/python3
Python 3.11.3 (main, Apr  4 2023, 22:36:41) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
print(os.environ['LD_LIBRARY_PATH'])
>>> b:/nix/store/ia1nj04xx5v5rbg349m6dpicl1j11cwi-cpplibs/lib:/nix/store/fxq6yn4mfnsnh418l2k218j7sp365sa9-zlib-1.2.13/lib:/nix/store/rympfmzvl838agp9xlkyi0w48wjb9p3a-glib-2.76.2/lib:/nix/store/gzs13l92w3308ichywy2013bw2n6l413-libX11-1.8.4/\
lib:/nix/store/pfn3d53934dswdsf269kmi2acbcjkq2p-libXext-1.3.4/lib:/nix/store/sc2acmp2zv7402lz42v4dhx0cnwpqk97-libXinerama-1.1.4/lib:/nix/store/jf4bifqwrj95skzspw195bbdly6lgkvk-libXcursor-1.2.0/lib:/nix/store/0ypjj16v283nfi76z4pa6wbyr0qqxrs\
p-libXrandr-1.5.2/lib:/nix/store/4jpzk3ryi0pmmyyzqi1nqw566368bz46-libXi-1.8/lib:/nix/store/b0bw49b9rfgg55i739dgkdfk8y6vb4hh-libXxf86vm-1.1.5/lib
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible

It is not backwards compatible, after we start supporting this, we shouldn't go back. Unless something dire happens.
