### PR TITLE
[rocker] Add the `docker` module to the `custom-bundle-squashfs`

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -93,7 +93,7 @@ rec {
     all-modules;
 
   bundle-squashfs = bundle-squashfs-fn {
-    moduleIds = [ "python-3.10" "nodejs-18" ];
+    moduleIds = [ "python-3.10" "nodejs-18" "docker" ];
     inherit upgrade-maps;
   };
 
@@ -101,6 +101,7 @@ rec {
     # customize these IDs for dev. They can be like "python-3.10:v10-20230711-6807d41" or "python-3.10"
     # publish your feature branch first and make sure modules.json is current, then
     # in goval dir (next to nixmodules), run `make custom-nixmodules-disk` to use this disk in conman
+    # There is no need to check in changes to this.
     moduleIds = [ "python-3.10" "nodejs-18" ];
     inherit upgrade-maps;
   };


### PR DESCRIPTION
Why
===

We want to test this locally.

What changed
============

This change adds `docker` to the squashfs bundles.

Test plan
=========

```shell
make custom-nixmodules-disk
```

in conman, now i'm able to use

```toml
modules = ["docker:v1-20231026-3990bf0"]
```

in `.replit`.

Rollout
=======

- [X] This is fully backward and forward compatible