### PR TITLE
prune disk to just terminal and previous modules

### DIFF
--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -4,7 +4,7 @@ execution_time_limit:
   hours: 3
 agent:
   machine:
-    type: s1-goval
+    type: s1-nixmodules
 fail_fast:
   stop:
     when: "true"

--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -38,7 +38,6 @@ blocks:
         - name: build nixmodules disk image
           commands:
             - scripts/setup_nix_binary_cache.py
-            - python3 scripts/cache_all_modules.py
             - scripts/build_disk_image.sh 2>&1 | tee nixmodules_build.log
       epilogue:
         always:

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -8,6 +8,10 @@ let
   revstring = builtins.substring 0 7 revstring_long;
   all-modules = builtins.fromJSON (builtins.readFile ../modules.json);
 
+  upgrade-maps = import ./upgrade-maps {
+    inherit pkgs;
+  };
+
   bundle-locked-fn = { modulesLocks }: pkgs.callPackage ./bundle-locked {
     inherit modulesLocks;
     inherit revstring;
@@ -18,7 +22,7 @@ let
   mkPhonyOCIs = { moduleIds ? null }: pkgs.callPackage ./mk-phony-ocis {
     inherit mkPhonyOCI;
     modulesLocks = import ./filter-modules-locks {
-      inherit pkgs;
+      inherit pkgs upgrade-maps;
       inherit moduleIds;
     };
     inherit revstring;
@@ -27,7 +31,7 @@ let
   bundle-squashfs-fn = { moduleIds ? null, upgrade-maps }:
     let
       modulesLocks = import ./filter-modules-locks {
-        inherit pkgs;
+        inherit pkgs upgrade-maps;
         inherit moduleIds;
       };
     in
@@ -46,6 +50,8 @@ let
 
 in
 rec {
+  inherit upgrade-maps;
+
   default = moduleit;
   moduleit = pkgs.callPackage ./moduleit { };
 
@@ -65,10 +71,6 @@ rec {
     inherit all-modules;
   };
 
-  upgrade-maps = import ./upgrade-maps {
-    inherit pkgs;
-  };
-
 
   bundle-image = pkgs.callPackage ./bundle-image {
     inherit bundle-locked revstring;
@@ -79,7 +81,7 @@ rec {
 
   bundle-locked = bundle-locked-fn {
     modulesLocks = import ./filter-modules-locks {
-      inherit pkgs;
+      inherit pkgs upgrade-maps;
     };
   };
 

--- a/pkgs/filter-modules-locks/default.nix
+++ b/pkgs/filter-modules-locks/default.nix
@@ -1,14 +1,14 @@
 { pkgs
 
-# moduleIds is a list of fully or partially resolved module IDs,
-#   or null.
-#
-# if null (the default), return the terminal modules of the upgrade
-# mapping, and their immediate predecessors in the graph.
+  # moduleIds is a list of fully or partially resolved module IDs,
+  #   or null.
+  #
+  # if null (the default), return the terminal modules of the upgrade
+  # mapping, and their immediate predecessors in the graph.
 
-# fully resolved module ID ex: ["php-8.1:v1-20230525-c48c43c" "python-3.10:v10-20230711-6807d41"]
-# partially resolved module ID ex: ["python-3.10" "nodejs-18"]
-#   - when a partially resolved ID is used, the latest 2 versions of that module will be built
+  # fully resolved module ID ex: ["php-8.1:v1-20230525-c48c43c" "python-3.10:v10-20230711-6807d41"]
+  # partially resolved module ID ex: ["python-3.10" "nodejs-18"]
+  #   - when a partially resolved ID is used, the latest 2 versions of that module will be built
 , moduleIds ? null
 
 , upgrade-maps

--- a/pkgs/filter-modules-locks/default.nix
+++ b/pkgs/filter-modules-locks/default.nix
@@ -1,10 +1,17 @@
 { pkgs
+
+# moduleIds is a list of fully or partially resolved module IDs,
+#   or null.
+#
+# if null (the default), return the terminal modules of the upgrade
+# mapping, and their immediate predecessors in the graph.
+
+# fully resolved module ID ex: ["php-8.1:v1-20230525-c48c43c" "python-3.10:v10-20230711-6807d41"]
+# partially resolved module ID ex: ["python-3.10" "nodejs-18"]
+#   - when a partially resolved ID is used, the latest 2 versions of that module will be built
 , moduleIds ? null
-  # moduleIds is a list of fully or partially resolved module IDs, 
-  #   or null which means include all module IDs.
-  # fully resolved module ID ex: ["php-8.1:v1-20230525-c48c43c" "python-3.10:v10-20230711-6807d41"]
-  # partially resolved module ID ex: ["python-3.10" "nodejs-18"]
-  #   - when a partially resolved ID is used, the latest 2 versions of that module will be built
+
+, upgrade-maps
 }:
 with builtins; with pkgs.lib;
 let
@@ -32,7 +39,7 @@ let
 
   filteredModulesLocks =
     if moduleIds == null
-    then modulesLocks
+    then upgrade-maps.terminalAndPreviousModuleLocks
     else
       foldr
         (

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -2,101 +2,8 @@
 with pkgs.lib.attrsets;
 let
   fns = import ./fns.nix { inherit pkgs; };
-  mapping = {
-    # Examples:
-    #"bun-0.5:v1-20230522-49470df" = { to = "bun-0.5:v2-20230522-0f45db1"; auto = true; changelog = "A better lsp!"; };
-    #"bun-0.5:v2-20230522-0f45db1" = { to = "bun-0.5:v3-20230522-9e0a3f9"; auto = true; changelog = "bug fix"; };
-    #"nodejs-16:v1-20230522-49470df" = { to = "nodejs-16:v2-20230522-4c01fa0"; auto = true; changelog = "improved your experience"; };
-    #"nodejs-14:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 14 is deprecated. Upgrade to 18!"; };
-    #"nodejs-16:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 16 is deprecated. Upgrade to 18!"; };
-    # // (fns.linearUpgrade "python-3.10")
-    # // (fns.stepUpgrade [
-    #       "bun-0.5:v1-20230525-c48c43c"
-    #       "bun-0.6:v1-20230607-15011da"
-    #       "bun-0.7:v1-20230724-4274858"
-    #     ])
 
-    "bun" = { to = "bun-0.5:v1-20230525-c48c43c"; auto = true; };
-    "bun-0.5:v1-20230525-c48c43c" = { to = "bun-0.6:v1-20230607-15011da"; auto = true; };
-    "bun-0.6:v1-20230607-15011da" = { to = "bun-0.6:v2-20230608-10cb54c"; auto = true; };
-    "bun-0.6:v2-20230608-10cb54c" = { to = "bun-0.6:v3-20230623-0b7a606"; auto = true; };
-    "bun-0.6:v3-20230623-0b7a606" = { to = "bun-0.6:v4-20230721-719ce58"; auto = true; };
-    "bun-0.6:v4-20230721-719ce58" = { to = "bun-0.7:v1-20230724-4274858"; auto = true; };
-    "bun-0.7:v1-20230724-4274858" = { to = "bun-1.0:v1-20230911-f253fb1"; auto = true; changelog = "bun 1.0.0 release"; };
-    "bun-1.0:v1-20230911-f253fb1" = { to = "bun-1.0:v2-20230913-4d3c541"; auto = true; changelog = "bun 1.0.1 release"; };
-    "bun-1.0:v2-20230913-4d3c541" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; changelog = "bun 1.0.2 release"; };
-    "bun-1.0:v4-20230915-82a14e9" = {
-      to = "bun-1.0:v3-20230915-80b0f23";
-      auto = true;
-      changelog = ''**REVERTED.** The script tries to open `/nix/store`, which, being ~18tb, takes
-      a *long* time to complete. As such, the new `package.json` runner script shouldn't be used.
-
-      # `package.json` runner
-        The runner for bun module has changed for increased flexibility and conformance to standards.
-
-        The new precedence is:
-        - the `replit-dev` script defined in `package.json`
-        - the `dev` script defined in `package.json`
-        - the `main` file defined in `package.json`
-        - the `entrypoint` defined in `.replit`
-      '';
-    };
-    "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
-    "bun-1.0:v3-20230915-80b0f23" = { to = "bun-1.0:v6-20231002-0b7fed5"; auto = true; };
-    "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; changelog = "bun 1.0.6 release"; };
-    "bun-1.0:v7-20231013-71b6704" = {
-      to = "bun-1.0:v8-20231013-f38c84f";
-      auto = true;
-      changelog = ''# `package.json` runner
-        The runner for bun module has changed for increased flexibility and conformance to standards.
-
-        The new precedence is:
-        - the `replit-dev` script defined in `package.json`
-        - the `dev` script defined in `package.json`
-        - the `entrypoint` defined in `.replit`
-        - the `main` file defined in `package.json`
-      '';
-    };
-    "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
-
-    "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
-
-    "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
-    "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };
-    "rust-1.69:v2-20230623-0b7a606" = { to = "rust-1.70:v1-20230724-17660e5"; auto = true; };
-    "rust-1.70:v1-20230724-17660e5" = { to = "rust-1.72:v1-20230911-f253fb1"; auto = true; };
-    "rust-1.72:v1-20230911-f253fb1" = { to = "rust-stable:v1-20231012-19c270f"; auto = true; };
-
-    "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
-  }
-  // (fns.linearUpgrade "c-clang14")
-  // (fns.linearUpgrade "clojure-1.11")
-  // (fns.linearUpgrade "cpp-clang14")
-  // (fns.linearUpgrade "docker")
-  // (fns.linearUpgrade "dotnet-7.0")
-  // (fns.linearUpgrade "go-1.20")
-  // (fns.linearUpgrade "haskell-ghc9.2")
-  // (fns.linearUpgrade "java-graalvm22.3")
-  // (fns.linearUpgrade "lua-5.2")
-  // (fns.linearUpgrade "nodejs-14")
-  // (fns.linearUpgrade "nodejs-16")
-  // (fns.linearUpgrade "nodejs-18")
-  // (fns.linearUpgrade "nodejs-19")
-  // (fns.linearUpgrade "nodejs-20")
-  // (fns.linearUpgrade "nodejs-with-prybar-18")
-  // (fns.linearUpgrade "php-8.1")
-  // (fns.linearUpgrade "pyright-extended")
-  // (fns.linearUpgrade "python-3.10")
-  // (fns.linearUpgrade "python-3.11")
-  // (fns.linearUpgrade "python-3.8")
-  // (fns.linearUpgrade "python-with-prybar-3.10")
-  // (fns.linearUpgrade "qbasic")
-  // (fns.linearUpgrade "r-4.2")
-  // (fns.linearUpgrade "ruby-3.1")
-  // (fns.linearUpgrade "svelte-kit-node-20")
-  // (fns.linearUpgrade "swift-5.8")
-  // (fns.linearUpgrade "web")
-  ;
+  mapping = import ./mapping.nix pkgs;
 
   present-entries = entries: mapAttrs
     (mod: entry:
@@ -121,6 +28,24 @@ let
     text = builtins.toJSON recommend;
     destination = "/recommend-upgrade.json";
   };
+
+  modules = builtins.fromJSON (builtins.readFile ../../modules.json);
+
+  # A module is terminal if it doesn't have an upgrade mapping, or the
+  # upgrade mapping doesn't have auto = true.
+  isTerminal = mod: !((mapping.${mod} or false).auto or false);
+
+  moduleToTerminal =
+    mapAttrs
+    (mod: _: isTerminal mod)
+    modules;
+
+  terminalAndPreviousModuleLocks =
+    filterAttrs
+    # either the module is terminal, or it maps directly to a terminal module
+    (mod: _: moduleToTerminal.${mod} || (moduleToTerminal.${mapping.${mod}.to} or false))
+    modules;
+
 in
 pkgs.symlinkJoin {
   name = "upgrade-maps";
@@ -136,5 +61,6 @@ pkgs.symlinkJoin {
     # nix eval .#upgrade-maps.meta.recommend --json
     inherit auto;
     inherit recommend;
+    inherit terminalAndPreviousModuleLocks;
   };
 }

--- a/pkgs/upgrade-maps/default.nix
+++ b/pkgs/upgrade-maps/default.nix
@@ -37,14 +37,14 @@ let
 
   moduleToTerminal =
     mapAttrs
-    (mod: _: isTerminal mod)
-    modules;
+      (mod: _: isTerminal mod)
+      modules;
 
   terminalAndPreviousModuleLocks =
     filterAttrs
-    # either the module is terminal, or it maps directly to a terminal module
-    (mod: _: moduleToTerminal.${mod} || (moduleToTerminal.${mapping.${mod}.to} or false))
-    modules;
+      # either the module is terminal, or it maps directly to a terminal module
+      (mod: _: moduleToTerminal.${mod} || (moduleToTerminal.${mapping.${mod}.to} or false))
+      modules;
 
 in
 pkgs.symlinkJoin {

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -4,32 +4,32 @@ let
   fns = import ./fns.nix { inherit pkgs; };
 in
 {
-    # Examples:
-    #"bun-0.5:v1-20230522-49470df" = { to = "bun-0.5:v2-20230522-0f45db1"; auto = true; changelog = "A better lsp!"; };
-    #"bun-0.5:v2-20230522-0f45db1" = { to = "bun-0.5:v3-20230522-9e0a3f9"; auto = true; changelog = "bug fix"; };
-    #"nodejs-16:v1-20230522-49470df" = { to = "nodejs-16:v2-20230522-4c01fa0"; auto = true; changelog = "improved your experience"; };
-    #"nodejs-14:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 14 is deprecated. Upgrade to 18!"; };
-    #"nodejs-16:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 16 is deprecated. Upgrade to 18!"; };
-    # // (fns.linearUpgrade "python-3.10")
-    # // (fns.stepUpgrade [
-    #       "bun-0.5:v1-20230525-c48c43c"
-    #       "bun-0.6:v1-20230607-15011da"
-    #       "bun-0.7:v1-20230724-4274858"
-    #     ])
+  # Examples:
+  #"bun-0.5:v1-20230522-49470df" = { to = "bun-0.5:v2-20230522-0f45db1"; auto = true; changelog = "A better lsp!"; };
+  #"bun-0.5:v2-20230522-0f45db1" = { to = "bun-0.5:v3-20230522-9e0a3f9"; auto = true; changelog = "bug fix"; };
+  #"nodejs-16:v1-20230522-49470df" = { to = "nodejs-16:v2-20230522-4c01fa0"; auto = true; changelog = "improved your experience"; };
+  #"nodejs-14:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 14 is deprecated. Upgrade to 18!"; };
+  #"nodejs-16:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 16 is deprecated. Upgrade to 18!"; };
+  # // (fns.linearUpgrade "python-3.10")
+  # // (fns.stepUpgrade [
+  #       "bun-0.5:v1-20230525-c48c43c"
+  #       "bun-0.6:v1-20230607-15011da"
+  #       "bun-0.7:v1-20230724-4274858"
+  #     ])
 
-    "bun" = { to = "bun-0.5:v1-20230525-c48c43c"; auto = true; };
-    "bun-0.5:v1-20230525-c48c43c" = { to = "bun-0.6:v1-20230607-15011da"; auto = true; };
-    "bun-0.6:v1-20230607-15011da" = { to = "bun-0.6:v2-20230608-10cb54c"; auto = true; };
-    "bun-0.6:v2-20230608-10cb54c" = { to = "bun-0.6:v3-20230623-0b7a606"; auto = true; };
-    "bun-0.6:v3-20230623-0b7a606" = { to = "bun-0.6:v4-20230721-719ce58"; auto = true; };
-    "bun-0.6:v4-20230721-719ce58" = { to = "bun-0.7:v1-20230724-4274858"; auto = true; };
-    "bun-0.7:v1-20230724-4274858" = { to = "bun-1.0:v1-20230911-f253fb1"; auto = true; changelog = "bun 1.0.0 release"; };
-    "bun-1.0:v1-20230911-f253fb1" = { to = "bun-1.0:v2-20230913-4d3c541"; auto = true; changelog = "bun 1.0.1 release"; };
-    "bun-1.0:v2-20230913-4d3c541" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; changelog = "bun 1.0.2 release"; };
-    "bun-1.0:v4-20230915-82a14e9" = {
-      to = "bun-1.0:v3-20230915-80b0f23";
-      auto = true;
-      changelog = ''**REVERTED.** The script tries to open `/nix/store`, which, being ~18tb, takes
+  "bun" = { to = "bun-0.5:v1-20230525-c48c43c"; auto = true; };
+  "bun-0.5:v1-20230525-c48c43c" = { to = "bun-0.6:v1-20230607-15011da"; auto = true; };
+  "bun-0.6:v1-20230607-15011da" = { to = "bun-0.6:v2-20230608-10cb54c"; auto = true; };
+  "bun-0.6:v2-20230608-10cb54c" = { to = "bun-0.6:v3-20230623-0b7a606"; auto = true; };
+  "bun-0.6:v3-20230623-0b7a606" = { to = "bun-0.6:v4-20230721-719ce58"; auto = true; };
+  "bun-0.6:v4-20230721-719ce58" = { to = "bun-0.7:v1-20230724-4274858"; auto = true; };
+  "bun-0.7:v1-20230724-4274858" = { to = "bun-1.0:v1-20230911-f253fb1"; auto = true; changelog = "bun 1.0.0 release"; };
+  "bun-1.0:v1-20230911-f253fb1" = { to = "bun-1.0:v2-20230913-4d3c541"; auto = true; changelog = "bun 1.0.1 release"; };
+  "bun-1.0:v2-20230913-4d3c541" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; changelog = "bun 1.0.2 release"; };
+  "bun-1.0:v4-20230915-82a14e9" = {
+    to = "bun-1.0:v3-20230915-80b0f23";
+    auto = true;
+    changelog = ''**REVERTED.** The script tries to open `/nix/store`, which, being ~18tb, takes
       a *long* time to complete. As such, the new `package.json` runner script shouldn't be used.
 
       # `package.json` runner
@@ -41,14 +41,14 @@ in
         - the `main` file defined in `package.json`
         - the `entrypoint` defined in `.replit`
       '';
-    };
-    "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
-    "bun-1.0:v3-20230915-80b0f23" = { to = "bun-1.0:v6-20231002-0b7fed5"; auto = true; };
-    "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; changelog = "bun 1.0.6 release"; };
-    "bun-1.0:v7-20231013-71b6704" = {
-      to = "bun-1.0:v8-20231013-f38c84f";
-      auto = true;
-      changelog = ''# `package.json` runner
+  };
+  "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
+  "bun-1.0:v3-20230915-80b0f23" = { to = "bun-1.0:v6-20231002-0b7fed5"; auto = true; };
+  "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; changelog = "bun 1.0.6 release"; };
+  "bun-1.0:v7-20231013-71b6704" = {
+    to = "bun-1.0:v8-20231013-f38c84f";
+    auto = true;
+    changelog = ''# `package.json` runner
         The runner for bun module has changed for increased flexibility and conformance to standards.
 
         The new precedence is:
@@ -57,43 +57,43 @@ in
         - the `entrypoint` defined in `.replit`
         - the `main` file defined in `package.json`
       '';
-    };
-    "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
+  };
+  "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
 
-    "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
+  "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
 
-    "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
-    "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };
-    "rust-1.69:v2-20230623-0b7a606" = { to = "rust-1.70:v1-20230724-17660e5"; auto = true; };
-    "rust-1.70:v1-20230724-17660e5" = { to = "rust-1.72:v1-20230911-f253fb1"; auto = true; };
-    "rust-1.72:v1-20230911-f253fb1" = { to = "rust-stable:v1-20231012-19c270f"; auto = true; };
+  "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
+  "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };
+  "rust-1.69:v2-20230623-0b7a606" = { to = "rust-1.70:v1-20230724-17660e5"; auto = true; };
+  "rust-1.70:v1-20230724-17660e5" = { to = "rust-1.72:v1-20230911-f253fb1"; auto = true; };
+  "rust-1.72:v1-20230911-f253fb1" = { to = "rust-stable:v1-20231012-19c270f"; auto = true; };
 
-    "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
-  }
-  // (fns.linearUpgrade "c-clang14")
-  // (fns.linearUpgrade "clojure-1.11")
-  // (fns.linearUpgrade "cpp-clang14")
-  // (fns.linearUpgrade "docker")
-  // (fns.linearUpgrade "dotnet-7.0")
-  // (fns.linearUpgrade "go-1.20")
-  // (fns.linearUpgrade "haskell-ghc9.2")
-  // (fns.linearUpgrade "java-graalvm22.3")
-  // (fns.linearUpgrade "lua-5.2")
-  // (fns.linearUpgrade "nodejs-14")
-  // (fns.linearUpgrade "nodejs-16")
-  // (fns.linearUpgrade "nodejs-18")
-  // (fns.linearUpgrade "nodejs-19")
-  // (fns.linearUpgrade "nodejs-20")
-  // (fns.linearUpgrade "nodejs-with-prybar-18")
-  // (fns.linearUpgrade "php-8.1")
-  // (fns.linearUpgrade "pyright-extended")
-  // (fns.linearUpgrade "python-3.10")
-  // (fns.linearUpgrade "python-3.11")
-  // (fns.linearUpgrade "python-3.8")
-  // (fns.linearUpgrade "python-with-prybar-3.10")
-  // (fns.linearUpgrade "qbasic")
-  // (fns.linearUpgrade "r-4.2")
-  // (fns.linearUpgrade "ruby-3.1")
-  // (fns.linearUpgrade "svelte-kit-node-20")
-  // (fns.linearUpgrade "swift-5.8")
+  "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
+}
+// (fns.linearUpgrade "c-clang14")
+// (fns.linearUpgrade "clojure-1.11")
+// (fns.linearUpgrade "cpp-clang14")
+// (fns.linearUpgrade "docker")
+// (fns.linearUpgrade "dotnet-7.0")
+// (fns.linearUpgrade "go-1.20")
+// (fns.linearUpgrade "haskell-ghc9.2")
+// (fns.linearUpgrade "java-graalvm22.3")
+// (fns.linearUpgrade "lua-5.2")
+// (fns.linearUpgrade "nodejs-14")
+// (fns.linearUpgrade "nodejs-16")
+// (fns.linearUpgrade "nodejs-18")
+// (fns.linearUpgrade "nodejs-19")
+// (fns.linearUpgrade "nodejs-20")
+// (fns.linearUpgrade "nodejs-with-prybar-18")
+// (fns.linearUpgrade "php-8.1")
+// (fns.linearUpgrade "pyright-extended")
+// (fns.linearUpgrade "python-3.10")
+// (fns.linearUpgrade "python-3.11")
+// (fns.linearUpgrade "python-3.8")
+// (fns.linearUpgrade "python-with-prybar-3.10")
+// (fns.linearUpgrade "qbasic")
+// (fns.linearUpgrade "r-4.2")
+// (fns.linearUpgrade "ruby-3.1")
+// (fns.linearUpgrade "svelte-kit-node-20")
+// (fns.linearUpgrade "swift-5.8")
   // (fns.linearUpgrade "web")

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -1,0 +1,99 @@
+pkgs:
+
+let
+  fns = import ./fns.nix { inherit pkgs; };
+in
+{
+    # Examples:
+    #"bun-0.5:v1-20230522-49470df" = { to = "bun-0.5:v2-20230522-0f45db1"; auto = true; changelog = "A better lsp!"; };
+    #"bun-0.5:v2-20230522-0f45db1" = { to = "bun-0.5:v3-20230522-9e0a3f9"; auto = true; changelog = "bug fix"; };
+    #"nodejs-16:v1-20230522-49470df" = { to = "nodejs-16:v2-20230522-4c01fa0"; auto = true; changelog = "improved your experience"; };
+    #"nodejs-14:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 14 is deprecated. Upgrade to 18!"; };
+    #"nodejs-16:v3-20230522-36692ed" = { to = "nodejs-18:v3-20230522-36692ed"; changelog = "Node.js 16 is deprecated. Upgrade to 18!"; };
+    # // (fns.linearUpgrade "python-3.10")
+    # // (fns.stepUpgrade [
+    #       "bun-0.5:v1-20230525-c48c43c"
+    #       "bun-0.6:v1-20230607-15011da"
+    #       "bun-0.7:v1-20230724-4274858"
+    #     ])
+
+    "bun" = { to = "bun-0.5:v1-20230525-c48c43c"; auto = true; };
+    "bun-0.5:v1-20230525-c48c43c" = { to = "bun-0.6:v1-20230607-15011da"; auto = true; };
+    "bun-0.6:v1-20230607-15011da" = { to = "bun-0.6:v2-20230608-10cb54c"; auto = true; };
+    "bun-0.6:v2-20230608-10cb54c" = { to = "bun-0.6:v3-20230623-0b7a606"; auto = true; };
+    "bun-0.6:v3-20230623-0b7a606" = { to = "bun-0.6:v4-20230721-719ce58"; auto = true; };
+    "bun-0.6:v4-20230721-719ce58" = { to = "bun-0.7:v1-20230724-4274858"; auto = true; };
+    "bun-0.7:v1-20230724-4274858" = { to = "bun-1.0:v1-20230911-f253fb1"; auto = true; changelog = "bun 1.0.0 release"; };
+    "bun-1.0:v1-20230911-f253fb1" = { to = "bun-1.0:v2-20230913-4d3c541"; auto = true; changelog = "bun 1.0.1 release"; };
+    "bun-1.0:v2-20230913-4d3c541" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; changelog = "bun 1.0.2 release"; };
+    "bun-1.0:v4-20230915-82a14e9" = {
+      to = "bun-1.0:v3-20230915-80b0f23";
+      auto = true;
+      changelog = ''**REVERTED.** The script tries to open `/nix/store`, which, being ~18tb, takes
+      a *long* time to complete. As such, the new `package.json` runner script shouldn't be used.
+
+      # `package.json` runner
+        The runner for bun module has changed for increased flexibility and conformance to standards.
+
+        The new precedence is:
+        - the `replit-dev` script defined in `package.json`
+        - the `dev` script defined in `package.json`
+        - the `main` file defined in `package.json`
+        - the `entrypoint` defined in `.replit`
+      '';
+    };
+    "bun-1.0:v5-20230921-cc7a2dd" = { to = "bun-1.0:v3-20230915-80b0f23"; auto = true; };
+    "bun-1.0:v3-20230915-80b0f23" = { to = "bun-1.0:v6-20231002-0b7fed5"; auto = true; };
+    "bun-1.0:v6-20231002-0b7fed5" = { to = "bun-1.0:v7-20231013-71b6704"; auto = true; changelog = "bun 1.0.6 release"; };
+    "bun-1.0:v7-20231013-71b6704" = {
+      to = "bun-1.0:v8-20231013-f38c84f";
+      auto = true;
+      changelog = ''# `package.json` runner
+        The runner for bun module has changed for increased flexibility and conformance to standards.
+
+        The new precedence is:
+        - the `replit-dev` script defined in `package.json`
+        - the `dev` script defined in `package.json`
+        - the `entrypoint` defined in `.replit`
+        - the `main` file defined in `package.json`
+      '';
+    };
+    "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
+
+    "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
+
+    "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
+    "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };
+    "rust-1.69:v2-20230623-0b7a606" = { to = "rust-1.70:v1-20230724-17660e5"; auto = true; };
+    "rust-1.70:v1-20230724-17660e5" = { to = "rust-1.72:v1-20230911-f253fb1"; auto = true; };
+    "rust-1.72:v1-20230911-f253fb1" = { to = "rust-stable:v1-20231012-19c270f"; auto = true; };
+
+    "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
+  }
+  // (fns.linearUpgrade "c-clang14")
+  // (fns.linearUpgrade "clojure-1.11")
+  // (fns.linearUpgrade "cpp-clang14")
+  // (fns.linearUpgrade "docker")
+  // (fns.linearUpgrade "dotnet-7.0")
+  // (fns.linearUpgrade "go-1.20")
+  // (fns.linearUpgrade "haskell-ghc9.2")
+  // (fns.linearUpgrade "java-graalvm22.3")
+  // (fns.linearUpgrade "lua-5.2")
+  // (fns.linearUpgrade "nodejs-14")
+  // (fns.linearUpgrade "nodejs-16")
+  // (fns.linearUpgrade "nodejs-18")
+  // (fns.linearUpgrade "nodejs-19")
+  // (fns.linearUpgrade "nodejs-20")
+  // (fns.linearUpgrade "nodejs-with-prybar-18")
+  // (fns.linearUpgrade "php-8.1")
+  // (fns.linearUpgrade "pyright-extended")
+  // (fns.linearUpgrade "python-3.10")
+  // (fns.linearUpgrade "python-3.11")
+  // (fns.linearUpgrade "python-3.8")
+  // (fns.linearUpgrade "python-with-prybar-3.10")
+  // (fns.linearUpgrade "qbasic")
+  // (fns.linearUpgrade "r-4.2")
+  // (fns.linearUpgrade "ruby-3.1")
+  // (fns.linearUpgrade "svelte-kit-node-20")
+  // (fns.linearUpgrade "swift-5.8")
+  // (fns.linearUpgrade "web")


### PR DESCRIPTION
Why
===
* CI was failing because it was running out of memory. This uses less memory, only about 13GB.
* Reduces the bundle lock closure size from 51GB to 41GB (19%)

What changed
===
* Moved mapping into its own file
* Added a passthru for upgrade-maps that lists the terminal and previous to terminal modules filtered out from the module lock file
* Use this list of module locks to generate the default module-lock filtering used by the main disk

Test plan
===
* CI passes
* Make sure template tests pass for all templates after deployed to canary

Rollout
=======
_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
