### PR TITLE
keep all package managers in prod env

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -187,6 +187,10 @@
     "commit": "a3526c9c9fa746df4f7b733d2ca4eb487fb8ae1c",
     "path": "/nix/store/shq2nm1dmzkag17g9yqb4kzny5wqzr1c-replit-module-nodejs-18"
   },
+  "nodejs-18:v13-20231103-2b03dda": {
+    "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
+    "path": "/nix/store/nvqn75ich279mskqnzr2vylqd82rp91v-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -234,6 +238,10 @@
   "nodejs-20:v9-20231020-a3526c9": {
     "commit": "a3526c9c9fa746df4f7b733d2ca4eb487fb8ae1c",
     "path": "/nix/store/h47lk59kdj5hidq79dlbzcly7z5nzswz-replit-module-nodejs-20"
+  },
+  "nodejs-20:v10-20231103-2b03dda": {
+    "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
+    "path": "/nix/store/bwlrjb3cgwjqgm2b7qvhzihnbimzpgk2-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -583,6 +591,10 @@
     "commit": "3dd69ae594a9e2ca5bdf33582e036c0788d0e804",
     "path": "/nix/store/31qxlfiz89z76d8hsxi47cvwa86ydk5r-replit-module-python-with-prybar-3.10"
   },
+  "python-with-prybar-3.10:v6-20231103-2b03dda": {
+    "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
+    "path": "/nix/store/nabafx6r70ln5vgfzgw1vc4ldsm0ava9-replit-module-python-with-prybar-3.10"
+  },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",
     "path": "/nix/store/8v3laig35f30bvgw8mwjcsznk06l7vf3-replit-module-nodejs-with-prybar-18"
@@ -595,6 +607,10 @@
     "commit": "a3526c9c9fa746df4f7b733d2ca4eb487fb8ae1c",
     "path": "/nix/store/m8rs0v4766zq51hmmrr7x3gxisag210v-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v4-20231103-2b03dda": {
+    "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
+    "path": "/nix/store/lrhj3a24mhskxaj5y88jwvdy3yq1pgfz-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -602,6 +618,10 @@
   "rust-stable:v1-20231012-19c270f": {
     "commit": "19c270f8c0c3147800ada35d9a0755fe10905344",
     "path": "/nix/store/3hw6spngfg758gz8ygla1458phpdi6x5-replit-module-rust-stable"
+  },
+  "rust-stable:v2-20231103-2b03dda": {
+    "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
+    "path": "/nix/store/1wbmhhf77wpnagflz7p2wjscrgdilc7l-replit-module-rust-stable"
   },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -33,9 +33,6 @@ in
 
   replit.packages = [
     graalvm
-  ];
-
-  replit.dev.packages = [
     pkgs.maven
   ];
 

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -25,13 +25,13 @@ in
   replit = {
     packages = [
       nodejs
+      bun
+      nodepkgs.pnpm
+      nodepkgs.yarn
     ];
 
     dev.packages = [
-      bun
       prettier
-      nodepkgs.pnpm
-      nodepkgs.yarn
     ];
 
     dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".mjs" ".cjs" ".es6" ];

--- a/pkgs/modules/php/default.nix
+++ b/pkgs/modules/php/default.nix
@@ -8,9 +8,6 @@ in
 
   replit.packages = with pkgs; [
     php
-  ];
-
-  replit.dev.packages = [
     pkgs.phpPackages.composer
   ];
 

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -121,9 +121,6 @@ in
 
   replit.packages = [
     python3-wrapper
-  ];
-
-  replit.dev.packages = [
     pip-wrapper
     poetry-wrapper
   ];

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -1,16 +1,26 @@
-{ pkgs, lib, ... }:
+{ pkgs, ... }:
 let
-  inherit (pkgs.fenix.stable) toolchain;
+  inherit (pkgs.fenix) stable;
 in
 {
   id = "rust-stable";
   name = "Rust Tools";
 
-  replit.dev.packages = with toolchain; [
-    toolchain
+  replit.packages = [
+    (stable.withComponents [
+      "cargo"
+      "llvm-tools"
+      "rust-src"
+      "rust-std"
+      "rustc"
+    ])
 
     pkgs.clang
     pkgs.pkg-config
+  ];
+
+  replit.dev.packages = [
+    stable.toolchain
   ];
 
   # TODO: should compile a binary to use in deployment and not include the runtime
@@ -18,7 +28,7 @@ in
     name = "cargo run";
     language = "rust";
 
-    start = "${toolchain}/bin/cargo run";
+    start = "${stable.toolchain}/bin/cargo run";
     fileParam = false;
   };
 
@@ -26,10 +36,10 @@ in
     name = "rust-analyzer";
     language = "rust";
 
-    start = "${toolchain}/bin/rust-analyzer";
+    start = "${stable.toolchain}/bin/rust-analyzer";
 
     initializationOptions = {
-      cargo.sysroot = "${toolchain}";
+      cargo.sysroot = "${stable.toolchain}";
     };
   };
 

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -5,9 +5,10 @@
   name = "SvelteKit with Node.js 20 Tools";
 
   replit = {
-    dev.packages = with pkgs-unstable; [
+    packages = with pkgs-unstable; [
       nodejs
     ];
+
     # Nothing required for deployment because app compiles to a static site
     dev.runners.dev-server = {
       name = "package.json dev script";

--- a/pkgs/modules/zig/default.nix
+++ b/pkgs/modules/zig/default.nix
@@ -15,6 +15,10 @@ in
   name = "zig";
 
   replit = {
+    packages = [
+      zig
+    ];
+
     runners.zig-build-run = {
       name = "zig build run";
       inherit language extensions;
@@ -32,10 +36,6 @@ in
     # };
 
     dev = {
-      packages = [
-        zig
-      ];
-
       formatters.zig-fmt = {
         name = "zig fmt";
         inherit language extensions;

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -94,6 +94,7 @@ in
 // (fns.linearUpgrade "qbasic")
 // (fns.linearUpgrade "r-4.2")
 // (fns.linearUpgrade "ruby-3.1")
+// (fns.linearUpgrade "rust-stable")
 // (fns.linearUpgrade "svelte-kit-node-20")
 // (fns.linearUpgrade "swift-5.8")
   // (fns.linearUpgrade "web")


### PR DESCRIPTION
Why
===

see https://replit.slack.com/archives/C03KS2B221W/p1699033526063659

users should be able to eg `yarn run prod` in their deployments

What changed
============

- took all package managers out of `dev.packages` and into `packages` directly
- this was a bit more involved for rust due to rust tooling making assumptions about the colocation of library/sources and tools

Test plan
=========

only rust needs to be tested, since the other changes were just removing restrictions on the PATH

since `rust-std`, `rustc`, and `cargo` are the only components necessary to get a basic hello world out, and the other components are for very, *very* specific scenarios (the only notable exception being cross-compiling, which we don't support [yet]), i think it's fine to restrict rust nixmodule to only testing:

- in the workspace:
- run button works
- lsp works
- format works
- `cargo fmt` works
- `clippy` works
- `cargo doc` works

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
