### PR TITLE
only use replit pip when __REPLIT_PIP_CACHE_ENABLE is set

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -359,6 +359,10 @@
     "commit": "d0fd0d762ab9adb644819e1974387ff37564b456",
     "path": "/nix/store/jvnsc9r7fzdxslwzsfzjmz34gagf1lzw-replit-module-python-3.10"
   },
+  "python-3.10:v29-20231107-a9f4961": {
+    "commit": "a9f4961fdc6584798e2e9f51219c1251e1e06e1e",
+    "path": "/nix/store/nakd40inhqrn4ivpnmsyikv41dbqyrjr-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -507,6 +511,10 @@
     "commit": "d0fd0d762ab9adb644819e1974387ff37564b456",
     "path": "/nix/store/2dy4yq8b2ns4wfb609mh7mhhg6mxcwg6-replit-module-python-3.11"
   },
+  "python-3.11:v10-20231107-a9f4961": {
+    "commit": "a9f4961fdc6584798e2e9f51219c1251e1e06e1e",
+    "path": "/nix/store/paf6s0202glbgjhv1fqwyq2rqqp0v5bm-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -542,6 +550,10 @@
   "python-3.8:v9-20231031-d0fd0d7": {
     "commit": "d0fd0d762ab9adb644819e1974387ff37564b456",
     "path": "/nix/store/7ffj12n7i3g0dqc0cq5i3ypdp6sfhfn7-replit-module-python-3.8"
+  },
+  "python-3.8:v10-20231107-a9f4961": {
+    "commit": "a9f4961fdc6584798e2e9f51219c1251e1e06e1e",
+    "path": "/nix/store/6rlx70ygynl9cy7qj0rgzm2ckhzwgn1p-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -610,6 +622,10 @@
   "python-with-prybar-3.10:v7-20231031-d0fd0d7": {
     "commit": "d0fd0d762ab9adb644819e1974387ff37564b456",
     "path": "/nix/store/xqqv4qy79xn3chjhhb9yy3c409qv77j6-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v8-20231107-a9f4961": {
+    "commit": "a9f4961fdc6584798e2e9f51219c1251e1e06e1e",
+    "path": "/nix/store/h0m6kfkww8prhl3nd0skwv8hmvs7i9fs-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -138,7 +138,7 @@ in
     };
   };
 
-  replit.dev.env = {
+  replit.env = {
     POETRY_CONFIG_DIR = poetry-config.outPath;
     POETRY_CACHE_DIR = "$REPL_HOME/.cache/pypoetry";
     POETRY_VIRTUALENVS_CREATE = "0";
@@ -149,9 +149,6 @@ in
     POETRY_PIP_FROM_PATH = "1";
     POETRY_USE_USER_SITE = "1";
     PYTHONUSERBASE = userbase;
-  };
-
-  replit.env = {
     PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -1,23 +1,12 @@
 { python, pypkgs }:
 { pkgs, lib, ... }:
 let
-  inherit (pypkgs) pip;
-
   pythonVersion = lib.versions.majorMinor python.version;
 
   pylibs-dir = ".pythonlibs";
 
   userbase = "$REPL_HOME/${pylibs-dir}";
 
-  pip-config = pkgs.writeTextFile {
-    name = "pip.conf";
-    text = ''
-      [global]
-      user = yes
-      disable-pip-version-check = yes
-      index-url = https://package-proxy.replit.com/pypi/simple/
-    '';
-  };
 
   pythonUtils = import ../../python-utils {
     inherit pkgs python pypkgs;
@@ -25,6 +14,9 @@ let
   pythonWrapper = pythonUtils.pythonWrapper;
   python-ld-library-path = pythonUtils.python-ld-library-path;
 
+  pip = import ./pip.nix (pkgs // {
+    inherit python pypkgs;
+  });
   pip-wrapper = pythonWrapper { bin = "${pip}/bin/pip"; name = "pip"; };
 
   poetry = pkgs.callPackage (../../poetry/poetry-py + "${pythonVersion}.nix") {
@@ -147,7 +139,6 @@ in
   };
 
   replit.dev.env = {
-    PIP_CONFIG_FILE = pip-config.outPath;
     POETRY_CONFIG_DIR = poetry-config.outPath;
     POETRY_CACHE_DIR = "$REPL_HOME/.cache/pypoetry";
     POETRY_VIRTUALENVS_CREATE = "0";

--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -1,0 +1,39 @@
+pkgs @ { pypkgs, ... }:
+
+let
+  pip = import ../../pip {
+    inherit pkgs pypkgs;
+  };
+
+  config-cache-enabled = pkgs.writeTextFile {
+    name = "pip.conf";
+    text = ''
+      [global]
+      user = yes
+      disable-pip-version-check = yes
+      index-url = https://package-proxy.replit.com/pypi/simple/
+
+      [install]
+      use-feature = content-addressable-pool
+      content-addressable-pool-symlink = yes
+    '';
+  };
+
+  config-cache-disabled = pkgs.writeTextFile {
+    name = "pip.conf";
+    text = ''
+      [global]
+      user = yes
+      disable-pip-version-check = yes
+    '';
+  };
+in
+pkgs.writeShellScriptBin "pip" ''
+  if [[ -n "$__REPLIT_PIP_CACHE_ENABLE" ]]; then
+    export PIP_CONFIG_FILE=${config-cache-enabled}
+  else
+    export PIP_CONFIG_FILE=${config-cache-disabled}
+  fi
+
+  exec "${pip}/bin/pip" "$@"
+''


### PR DESCRIPTION
Why
===

today during sync we decided that disabling the pip caching stuff should be flagged.

What changed
============

- always invoke our fork of pip
- if the env var `__REPLIT_PIP_CACHE_ENABLE` is set, then use a `pip.conf` file that enables our cacache symlinking behavior
- if the env var `__REPLIT_PIP_CACHE_ENABLE` isn't set, then use a `pip.conf` file that doesn't enable our cacache symlinking behavior

Test plan
=========

1. in a django repl, use this nixmodule and make sure things are installed etc etc
1. in `.replit` add `env.__REPLIT_PIP_ENABLE_CACHE_WRAPPER = "1"`
1. `poetry install`
1. `python3 manage.py migrate`
1. `python3 manage.py createsuperuser`
1. error!
1. remove the env var from step 2
1. repeat steps 3-5
1. no error!

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
