### PR TITLE
[docker] A few updates

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -666,5 +666,9 @@
   "docker:v2-20231030-4e03966": {
     "commit": "4e039665f4a42d5c180e527d58cc4632aa42ec4c",
     "path": "/nix/store/xawdvwwg946rpkwzyimipsp2krw5ad4i-replit-module-docker"
+  },
+  "docker:v3-20231108-335cb39": {
+    "commit": "335cb39c44207fa72a763bc774dd6ce52ceaeca8",
+    "path": "/nix/store/8p82myx603if629085ymf5pwm3qxlag4-replit-module-docker"
   }
 }

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -106,6 +106,7 @@ in
 
   replit.dev.packages = [
     pkgs.docker-client
+    pkgs.docker-compose
     containerd
     replit-shim-runc
     replit-runc

--- a/pkgs/modules/docker/etc/containerd.toml
+++ b/pkgs/modules/docker/etc/containerd.toml
@@ -4,6 +4,7 @@ state = "/run/containerd"
 
 [grpc]
   address = "/run/containerd/containerd.sock"
+  uid = 1000
   gid = 1000
   max_recv_message_size = 16777216
   max_send_message_size = 16777216

--- a/pkgs/modules/docker/replit-buildkit.patch
+++ b/pkgs/modules/docker/replit-buildkit.patch
@@ -15,3 +15,20 @@ index 3375c438a..5c8b018ff 100644
  		ctx, cancel := context.WithCancel(appcontext.Context())
  		defer cancel()
  
+diff --git a/solver/cachemanager.go b/solver/cachemanager.go
+index e5e7e4fb9..1b92f969b 100644
+--- a/solver/cachemanager.go
++++ b/solver/cachemanager.go
+@@ -176,7 +176,11 @@ func (c *cacheManager) Load(ctx context.Context, rec *CacheRecord) (rres Result,
+ 		"stack":         bklog.TraceLevelOnlyStack(),
+ 	})
+ 	defer func() {
+-		lg.WithError(rerr).WithField("return_result", rres.ID()).Trace("cache manager")
++		rresID := "<nil>"
++		if rres != nil {
++			rresID = rres.ID()
++		}
++		lg.WithError(rerr).WithField("return_result", rresID).Trace("cache manager")
+ 	}()
+ 
+ 	c.mu.RLock()


### PR DESCRIPTION
Why
===

There are a few things that don't quite work today for `docker-compose`.

What changed
============

This change:

* Cherry-picks a `buildkitd` panic that was fixed in
  https://github.com/moby/buildkit/commit/9a8bd9fde84da8190b9bb1cbdbe72ec843780e64
* The `containerd.toml` accidentally skipped the uid setting for the
  socket.
* Adds `docker-compose` to the bundle.
* Makes `replit-runc` resolve the `roci` binary: it's useful to be able
  to override it in Replspace.

Test plan
=========

Build custom modules in conman, see it work more.

Rollout
=======

- [X] This is fully backward and forward compatible