### PR TITLE
[docker] Build `replit-moby`

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -678,5 +678,9 @@
   "docker:v3-20231108-335cb39": {
     "commit": "335cb39c44207fa72a763bc774dd6ce52ceaeca8",
     "path": "/nix/store/8p82myx603if629085ymf5pwm3qxlag4-replit-module-docker"
+  },
+  "docker:v4-20231112-413d16d": {
+    "commit": "413d16d05197abaa66bfdfa6ecd35a1e04abbdd3",
+    "path": "/nix/store/yn9bbinj75dq2nxhd4dwdv4bh8q7m3bx-replit-module-docker"
   }
 }

--- a/pkgs/modules/docker/etc/buildkitd.toml
+++ b/pkgs/modules/docker/etc/buildkitd.toml
@@ -3,7 +3,7 @@
 
 [worker.containerd]
   enabled = true
-  namespace = "docker"
+  namespace = "buildkit"
   platforms = ["linux/amd64", "linux/amd64/v2", "linux/amd64/v3"]
 
   [worker.containerd.runtime]

--- a/pkgs/modules/docker/etc/dockerd.json
+++ b/pkgs/modules/docker/etc/dockerd.json
@@ -1,0 +1,16 @@
+{
+  "default-runtime": "replit-shim-runc",
+  "containerd": "/run/containerd/containerd.sock",
+  "containerd-namespace": "moby",
+  "init": false,
+  "iptables": false,
+  "runtimes": {
+    "replit-shim-runc": {
+      "runtimeType": "@replitShimRunc@/bin/replit-shim-runc"
+    }
+  },
+  "features": {
+    "containerd-snapshotter": true,
+    "buildkit": false
+  }
+}

--- a/pkgs/modules/docker/replit-containerd.patch
+++ b/pkgs/modules/docker/replit-containerd.patch
@@ -1,0 +1,301 @@
+diff --git a/cmd/containerd/command/main.go b/cmd/containerd/command/main.go
+index 3b8e9739e..0979fff85 100644
+--- a/cmd/containerd/command/main.go
++++ b/cmd/containerd/command/main.go
+@@ -36,6 +36,7 @@ import (
+ 	srvconfig "github.com/containerd/containerd/services/server/config"
+ 	"github.com/containerd/containerd/sys"
+ 	"github.com/containerd/containerd/version"
++	"github.com/coreos/go-systemd/v22/activation"
+ 	"github.com/urfave/cli"
+ 	"google.golang.org/grpc/grpclog"
+ )
+@@ -257,9 +258,17 @@ can be used and modified as necessary as a custom configuration.`
+ 		serve(ctx, tl, server.ServeTTRPC)
+ 
+ 		if config.GRPC.TCPAddress != "" {
+-			l, err := net.Listen("tcp", config.GRPC.TCPAddress)
+-			if err != nil {
+-				return fmt.Errorf("failed to get listener for TCP grpc endpoint: %w", err)
++			// Replit mod: allow systemd-style activation sockets.
++			al, _ := activation.Listeners()
++			var l net.Listener
++			if len(al) == 1 {
++				l = al[0]
++			} else {
++				var err error
++				l, err = net.Listen("tcp", config.GRPC.TCPAddress)
++				if err != nil {
++					return fmt.Errorf("failed to get listener for TCP grpc endpoint: %w", err)
++				}
+ 			}
+ 			serve(ctx, l, server.ServeTCP)
+ 		}
+diff --git a/vendor/github.com/coreos/go-systemd/v22/activation/files_unix.go b/vendor/github.com/coreos/go-systemd/v22/activation/files_unix.go
+new file mode 100644
+index 000000000..bf7671dd2
+--- /dev/null
++++ b/vendor/github.com/coreos/go-systemd/v22/activation/files_unix.go
+@@ -0,0 +1,70 @@
++// Copyright 2015 CoreOS, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++//go:build !windows
++// +build !windows
++
++// Package activation implements primitives for systemd socket activation.
++package activation
++
++import (
++	"os"
++	"strconv"
++	"strings"
++	"syscall"
++)
++
++const (
++	// listenFdsStart corresponds to `SD_LISTEN_FDS_START`.
++	listenFdsStart = 3
++)
++
++// Files returns a slice containing a `os.File` object for each
++// file descriptor passed to this process via systemd fd-passing protocol.
++//
++// The order of the file descriptors is preserved in the returned slice.
++// `unsetEnv` is typically set to `true` in order to avoid clashes in
++// fd usage and to avoid leaking environment flags to child processes.
++func Files(unsetEnv bool) []*os.File {
++	if unsetEnv {
++		defer os.Unsetenv("LISTEN_PID")
++		defer os.Unsetenv("LISTEN_FDS")
++		defer os.Unsetenv("LISTEN_FDNAMES")
++	}
++
++	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
++	if err != nil || pid != os.Getpid() {
++		return nil
++	}
++
++	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
++	if err != nil || nfds == 0 {
++		return nil
++	}
++
++	names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
++
++	files := make([]*os.File, 0, nfds)
++	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
++		syscall.CloseOnExec(fd)
++		name := "LISTEN_FD_" + strconv.Itoa(fd)
++		offset := fd - listenFdsStart
++		if offset < len(names) && len(names[offset]) > 0 {
++			name = names[offset]
++		}
++		files = append(files, os.NewFile(uintptr(fd), name))
++	}
++
++	return files
++}
+diff --git a/vendor/github.com/coreos/go-systemd/v22/activation/files_windows.go b/vendor/github.com/coreos/go-systemd/v22/activation/files_windows.go
+new file mode 100644
+index 000000000..d391bf00c
+--- /dev/null
++++ b/vendor/github.com/coreos/go-systemd/v22/activation/files_windows.go
+@@ -0,0 +1,21 @@
++// Copyright 2015 CoreOS, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package activation
++
++import "os"
++
++func Files(unsetEnv bool) []*os.File {
++	return nil
++}
+diff --git a/vendor/github.com/coreos/go-systemd/v22/activation/listeners.go b/vendor/github.com/coreos/go-systemd/v22/activation/listeners.go
+new file mode 100644
+index 000000000..3dbe2b087
+--- /dev/null
++++ b/vendor/github.com/coreos/go-systemd/v22/activation/listeners.go
+@@ -0,0 +1,103 @@
++// Copyright 2015 CoreOS, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package activation
++
++import (
++	"crypto/tls"
++	"net"
++)
++
++// Listeners returns a slice containing a net.Listener for each matching socket type
++// passed to this process.
++//
++// The order of the file descriptors is preserved in the returned slice.
++// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
++// corresponding with "udp, tcp, tcp", then the slice would contain {nil, net.Listener, net.Listener}
++func Listeners() ([]net.Listener, error) {
++	files := Files(true)
++	listeners := make([]net.Listener, len(files))
++
++	for i, f := range files {
++		if pc, err := net.FileListener(f); err == nil {
++			listeners[i] = pc
++			f.Close()
++		}
++	}
++	return listeners, nil
++}
++
++// ListenersWithNames maps a listener name to a set of net.Listener instances.
++func ListenersWithNames() (map[string][]net.Listener, error) {
++	files := Files(true)
++	listeners := map[string][]net.Listener{}
++
++	for _, f := range files {
++		if pc, err := net.FileListener(f); err == nil {
++			current, ok := listeners[f.Name()]
++			if !ok {
++				listeners[f.Name()] = []net.Listener{pc}
++			} else {
++				listeners[f.Name()] = append(current, pc)
++			}
++			f.Close()
++		}
++	}
++	return listeners, nil
++}
++
++// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
++// passed to this process.
++// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
++func TLSListeners(tlsConfig *tls.Config) ([]net.Listener, error) {
++	listeners, err := Listeners()
++
++	if listeners == nil || err != nil {
++		return nil, err
++	}
++
++	if tlsConfig != nil {
++		for i, l := range listeners {
++			// Activate TLS only for TCP sockets
++			if l.Addr().Network() == "tcp" {
++				listeners[i] = tls.NewListener(l, tlsConfig)
++			}
++		}
++	}
++
++	return listeners, err
++}
++
++// TLSListenersWithNames maps a listener name to a net.Listener with
++// the associated TLS configuration.
++func TLSListenersWithNames(tlsConfig *tls.Config) (map[string][]net.Listener, error) {
++	listeners, err := ListenersWithNames()
++
++	if listeners == nil || err != nil {
++		return nil, err
++	}
++
++	if tlsConfig != nil {
++		for _, ll := range listeners {
++			// Activate TLS only for TCP sockets
++			for i, l := range ll {
++				if l.Addr().Network() == "tcp" {
++					ll[i] = tls.NewListener(l, tlsConfig)
++				}
++			}
++		}
++	}
++
++	return listeners, err
++}
+diff --git a/vendor/github.com/coreos/go-systemd/v22/activation/packetconns.go b/vendor/github.com/coreos/go-systemd/v22/activation/packetconns.go
+new file mode 100644
+index 000000000..a97206785
+--- /dev/null
++++ b/vendor/github.com/coreos/go-systemd/v22/activation/packetconns.go
+@@ -0,0 +1,38 @@
++// Copyright 2015 CoreOS, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package activation
++
++import (
++	"net"
++)
++
++// PacketConns returns a slice containing a net.PacketConn for each matching socket type
++// passed to this process.
++//
++// The order of the file descriptors is preserved in the returned slice.
++// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
++// corresponding with "udp, tcp, udp", then the slice would contain {net.PacketConn, nil, net.PacketConn}
++func PacketConns() ([]net.PacketConn, error) {
++	files := Files(true)
++	conns := make([]net.PacketConn, len(files))
++
++	for i, f := range files {
++		if pc, err := net.FilePacketConn(f); err == nil {
++			conns[i] = pc
++			f.Close()
++		}
++	}
++	return conns, nil
++}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 8faad70b6..db44b4e96 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -187,6 +187,7 @@ github.com/containers/ocicrypt/utils
+ github.com/containers/ocicrypt/utils/keyprovider
+ # github.com/coreos/go-systemd/v22 v22.5.0
+ ## explicit; go 1.12
++github.com/coreos/go-systemd/v22/activation
+ github.com/coreos/go-systemd/v22/daemon
+ github.com/coreos/go-systemd/v22/dbus
+ # github.com/cpuguy83/go-md2man/v2 v2.0.2

--- a/pkgs/modules/docker/replit-moby.patch
+++ b/pkgs/modules/docker/replit-moby.patch
@@ -1,0 +1,152 @@
+diff --git a/builder/builder-next/executor_unix.go b/builder/builder-next/executor_unix.go
+index 4a1d93c25f..dbaa48f3f6 100644
+--- a/builder/builder-next/executor_unix.go
++++ b/builder/builder-next/executor_unix.go
+@@ -53,8 +53,9 @@ func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfi
+ 	}
+ 
+ 	return runcexecutor.New(runcexecutor.Opt{
+-		Root:                filepath.Join(root, "executor"),
+-		CommandCandidates:   []string{"runc"},
++		Root: filepath.Join(root, "executor"),
++		// Replit mod: Use Replit's version of runc
++		CommandCandidates:   []string{"replit-runc"},
+ 		DefaultCgroupParent: cgroupParent,
+ 		Rootless:            rootless,
+ 		NoPivot:             os.Getenv("DOCKER_RAMDISK") != "",
+diff --git a/cmd/dockerd/daemon.go b/cmd/dockerd/daemon.go
+index 50193d5f97..d8f43e60d7 100644
+--- a/cmd/dockerd/daemon.go
++++ b/cmd/dockerd/daemon.go
+@@ -8,7 +8,6 @@ import (
+ 	"net/http"
+ 	"os"
+ 	"path/filepath"
+-	"runtime"
+ 	"sort"
+ 	"strings"
+ 	"sync"
+@@ -123,10 +122,11 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
+ 		}
+ 	}
+ 
++	// Replit mod: don't error out when running in rootless mode.
+ 	// return human-friendly error before creating files
+-	if runtime.GOOS == "linux" && os.Geteuid() != 0 {
+-		return fmt.Errorf("dockerd needs to be started with root privileges. To run dockerd in rootless mode as an unprivileged user, see https://docs.docker.com/go/rootless/")
+-	}
++	// if runtime.GOOS == "linux" && os.Geteuid() != 0 {
++	// 	return fmt.Errorf("dockerd needs to be started with root privileges. To run dockerd in rootless mode as an unprivileged user, see https://docs.docker.com/go/rootless/")
++	// }
+ 
+ 	if err := setDefaultUmask(); err != nil {
+ 		return err
+diff --git a/libnetwork/controller.go b/libnetwork/controller.go
+index cd5ad761c9..090e09835e 100644
+--- a/libnetwork/controller.go
++++ b/libnetwork/controller.go
+@@ -929,7 +929,8 @@ func (c *Controller) NewSandbox(containerID string, options ...SandboxOption) (*
+ 
+ 		if err != nil {
+ 			c.sboxOnce = sync.Once{}
+-			return nil, fmt.Errorf("failed to create default sandbox: %v", err)
++			// Replit mod: we don't have network sandboxing.
++			logrus.WithError(err).Warn("failed to create default sandbox")
+ 		}
+ 
+ 		sb.osSbox = c.defOsSbox
+diff --git a/libnetwork/osl/namespace_linux.go b/libnetwork/osl/namespace_linux.go
+index d7d2fe2d63..aaa312fa8b 100644
+--- a/libnetwork/osl/namespace_linux.go
++++ b/libnetwork/osl/namespace_linux.go
+@@ -13,7 +13,6 @@ import (
+ 	"syscall"
+ 	"time"
+ 
+-	"github.com/docker/docker/internal/unshare"
+ 	"github.com/docker/docker/libnetwork/ns"
+ 	"github.com/docker/docker/libnetwork/osl/kernel"
+ 	"github.com/docker/docker/libnetwork/types"
+@@ -303,7 +302,8 @@ func createNetworkNamespace(path string, osCreate bool) error {
+ 		return mountNetworkNamespace(fmt.Sprintf("/proc/self/task/%d/ns/net", unix.Gettid()), path)
+ 	}
+ 	if osCreate {
+-		return unshare.Go(unix.CLONE_NEWNET, do, nil)
++		// Replit mod: We don't create network namespaces
++		return do()
+ 	}
+ 	return do()
+ }
+diff --git a/pkg/archive/archive.go b/pkg/archive/archive.go
+index 34361a24ac..6154b7a65c 100644
+--- a/pkg/archive/archive.go
++++ b/pkg/archive/archive.go
+@@ -13,6 +13,7 @@ import (
+ 	"io"
+ 	"os"
+ 	"os/exec"
++	"path"
+ 	"path/filepath"
+ 	"runtime"
+ 	"strconv"
+@@ -70,6 +71,8 @@ type (
+ 		// replaced with the matching name from this map.
+ 		RebaseNames map[string]string
+ 		InUserNS    bool
++		// Replit mod: we don't have access to chroot, so make the protection in a best-effort fashion.
++		Root string
+ 	}
+ )
+ 
+@@ -1092,6 +1095,10 @@ loop:
+ 		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
+ 		// This keeps "..\" as-is, but normalizes "\..\" to "\".
+ 		hdr.Name = filepath.Clean(hdr.Name)
++		// Replit mod: we don't chroot, so always make sure this is normalized to be within the chroot.
++		if options.Root != "" {
++			hdr.Name = path.Join(options.Root, path.Clean(path.Join("/", hdr.Name))[1:])
++		}
+ 
+ 		for _, exclude := range options.ExcludePatterns {
+ 			if strings.HasPrefix(hdr.Name, exclude) {
+diff --git a/pkg/chrootarchive/archive_unix.go b/pkg/chrootarchive/archive_unix.go
+index 1e0e2382ec..28ba0e1737 100644
+--- a/pkg/chrootarchive/archive_unix.go
++++ b/pkg/chrootarchive/archive_unix.go
+@@ -27,12 +27,10 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
+ 		return err
+ 	}
+ 
+-	done := make(chan error)
+-	err = goInChroot(root, func() { done <- archive.Unpack(decompressedArchive, relDest, options) })
+-	if err != nil {
+-		return err
+-	}
+-	return <-done
++	// Replit mod: we don't have access to chroot.
++	newOptions := *options
++	newOptions.Root = root
++	return archive.Unpack(decompressedArchive, relDest, &newOptions)
+ }
+ 
+ func invokePack(srcPath string, options *archive.TarOptions, root string) (io.ReadCloser, error) {
+@@ -46,14 +44,14 @@ func invokePack(srcPath string, options *archive.TarOptions, root string) (io.Re
+ 		relSrc += "/"
+ 	}
+ 
+-	tb, err := archive.NewTarballer(relSrc, options)
++	// Replit mod: we don't have access to chroot.
++	newOptions := *options
++	newOptions.Root = root
++	tb, err := archive.NewTarballer(srcPath, &newOptions)
+ 	if err != nil {
+ 		return nil, errors.Wrap(err, "error processing tar file")
+ 	}
+-	err = goInChroot(root, tb.Do)
+-	if err != nil {
+-		return nil, errors.Wrap(err, "could not chroot")
+-	}
++	tb.Do()
+ 	return tb.Reader(), nil
+ }
+ 

--- a/pkgs/modules/docker/replit-runc.patch
+++ b/pkgs/modules/docker/replit-runc.patch
@@ -169,6 +169,25 @@ index 6d32704a..b00e4533 100644
 +	// Replit mod: This is handled outside of the container.
  	return nil
  }
+diff --git a/libcontainer/container_linux.go b/libcontainer/container_linux.go
+index c941239b..c329c89f 100644
+--- a/libcontainer/container_linux.go
++++ b/libcontainer/container_linux.go
+@@ -500,6 +500,14 @@ func (c *Container) commandTemplate(p *Process, childInitPipe *os.File, childLog
+ 	if p.LogLevel != "" {
+ 		cmd.Env = append(cmd.Env, "_LIBCONTAINER_LOGLEVEL="+p.LogLevel)
+ 	}
++	// Replit mod: we want to be able to get the configuration from roci. So we
++	// pass the current directory as an extra environment variable so that it can
++	// find it: Normally libcontainer will have the rootfs as a sibling of the
++	// config.json, but Docker does not believe in that level of uniformity.
++	wd, err := os.Getwd()
++	if err == nil {
++		cmd.Env = append(cmd.Env, "_REPLIT_CONFIG_JSON="+path.Join(wd, "config.json"))
++	}
+ 
+ 	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
+ 	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason
 diff --git a/libcontainer/process_linux.go b/libcontainer/process_linux.go
 index 8785d657..328b27f8 100644
 --- a/libcontainer/process_linux.go


### PR DESCRIPTION
Why
===

We want more packages being built here.

What changed
============

This change:

* Adds a patch for `replit-containerd` so that we can use systemd
  activation sockets with it.
* Now that we have a patched version of `containerd`, coalesces all
  binaries compiled from that repository into a single package.
* Adds `replit-moby`, which builds the Docker daemon with a couple of
  patches and a configuration file that can be used in Repls.

Test plan
=========

```shell
$ replit-dockerd --config-file {...} --data-root ${XDG_DATA_HOME}/docker --bridge=none
```

in a Repl works, surprisingly!

Rollout
=======

- [X] This is fully backward and forward compatible