### PR TITLE
[Prodvana] Allow different runtime for test-templates

### DIFF
--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -1,5 +1,8 @@
 application:
   name: nixmodules
+  notifications:
+    slack:
+      channel: audit
   releaseChannels:
     - name: canary
       constants:
@@ -31,15 +34,15 @@ application:
           lifecycle:
             - postDeployment:
                 checkDuration: 600s
-    - name: test_templates
+    - name: test-templates
       preconditions:
         - releaseChannelStable:
-          releaseChannel: canary
+            releaseChannel: canary
       runtimes:
           - runtime: marine-cycle-160323--goval
-          containerOrchestration:
-            k8s:
-              namespace: nixmodules
+            containerOrchestration:
+              k8s:
+                namespace: nixmodules
     - name: tarpit
       constants:
         - name: name
@@ -60,7 +63,7 @@ application:
       preconditions:
         - manualApproval: {}
         - releaseChannelStable:
-            releaseChannel: test_templates
+            releaseChannel: test-templates
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw

--- a/manifests/service.pvn.yaml
+++ b/manifests/service.pvn.yaml
@@ -24,21 +24,6 @@ service:
       description: duration to wait between pulls of new configs
       string:
         defaultValue: "3600s"
-  runtimeConnection: config-raw
-  runtimeExtension:
-    parameterValues:
-      - name: image
-        string: "{{.Params.image_govalctl}}"
-      - name: service
-        string: "nixmodules"
-      - name: name
-        string: "{{.Constants.name}}"
-      - name: json
-        string: >-
-          {
-            "version":"{{.Params.nixmodules_version}}",
-            "configPullJitter":"{{.Params.jitter}}"
-          }
   perReleaseChannel:
     - releaseChannel: canary
       runtimeExtension:
@@ -49,8 +34,266 @@ service:
                 "version":"{{.Params.nixmodules_version}}",
                 "configPullJitter":"1s"
               }
-    - releaseChannel: test_templates
+    - releaseChannel: test-templates
       externalConfig:
         type: KUBERNETES
         local:
-          path: manifests/test_templates.yml
+          path: test_templates.yaml
+
+
+    - releaseChannel: tarpit
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: global
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: hacker
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: teams
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: asia-a
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: asia-b
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: staging
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: picard
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: riker
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: kirk
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: spock
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: worf
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: janeway
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: sisko
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: pike
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
+    - releaseChannel: wesley
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }


### PR DESCRIPTION
Why
===

The current manifest was invalid, if you need one channel to not use the runtime extension, you cant define a global runtimeextension, you need to define it for every release channel

What changed
============

set service config for each release channel

Test plan
=========

`pvnctl config validate manifests` 

Rollout
=======


- [X] This is fully backward and forward compatible
