### PR TITLE
update nodejs defaults for dev/ci

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -66,7 +66,7 @@ rec {
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };
 
   bundle-squashfs = bundle-squashfs-fn {
-    moduleIds = [ "python-3.10" "nodejs-18" "docker" ];
+    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" ];
     diskName = "disk.sqsh";
   };
 
@@ -75,7 +75,7 @@ rec {
     # publish your feature branch first and make sure modules.json is current, then
     # in goval dir (next to nixmodules), run `make custom-nixmodules-disk` to use this disk in conman
     # There is no need to check in changes to this.
-    moduleIds = [ "python-3.10" "nodejs-18" ];
+    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" ];
     diskName = "disk.sqsh";
   };
 
@@ -88,7 +88,7 @@ rec {
       flake.modules.${shortModuleId})
     all-modules;
 
-  custom-bundle-phony-ocis = mkPhonyOCIs { moduleIds = [ "nodejs-18" ]; };
+  custom-bundle-phony-ocis = mkPhonyOCIs { moduleIds = [ "nodejs-18" "nodejs-20" ]; };
 
   all-phony-oci-bundles = mapAttrs
     (moduleId: module:

--- a/pkgs/filter-modules-locks/default.nix
+++ b/pkgs/filter-modules-locks/default.nix
@@ -7,7 +7,7 @@
   # mapping, and their immediate predecessors in the graph.
 
   # fully resolved module ID ex: ["php-8.1:v1-20230525-c48c43c" "python-3.10:v10-20230711-6807d41"]
-  # partially resolved module ID ex: ["python-3.10" "nodejs-18"]
+  # partially resolved module ID ex: ["python-3.10" "nodejs-20"]
   #   - when a partially resolved ID is used, the latest 2 versions of that module will be built
 , moduleIds ? null
 


### PR DESCRIPTION
Why
===
* nodejs 20 is the new stable verison so we should use that as the default

What changed
===
* Add nodejs-20 wherever we had nodejs-20, later we'll remove
nodejs-18 after we stop referring to it in CI

Test plan
===
* Build the custom squashfs and confirm CI passes with it

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
