### PR TITLE
[cd] Make sure that govalctl can deploy nixmodules configs

### DIFF
--- a/manifests/service.pvn.yaml
+++ b/manifests/service.pvn.yaml
@@ -28,6 +28,10 @@ service:
     - releaseChannel: canary
       runtimeExtension:
         parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
           - name: json
             string: >-
               {


### PR DESCRIPTION
Why
===

We had a bug where the manifest never overrode the default service name of `pid1`, so we were trying to push the pid1 configuration with nixmodules contents. That was not going to work!

What changed
============

This change correctly overrides the serviec name so that it's `nixmodules`.

Test plan
=========

:eyes: on Prodvana.

Rollout
=======

- [X] This is fully backward and forward compatible