### PR TITLE
Run tests but nonblocking

### DIFF
--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -34,6 +34,15 @@ application:
           lifecycle:
             - postDeployment:
                 checkDuration: 600s
+    - name: test-templates
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: canary
+      runtimes:
+          - runtime: marine-cycle-160323--goval
+            containerOrchestration:
+              k8s:
+                namespace: nixmodules
     - name: tarpit
       constants:
         - name: name


### PR DESCRIPTION
Why
===

Still run template tests but don't block the deploy based on suggestion in https://github.com/replit/nixmodules/pull/178

What changed
============

Added test-templates channel back.
