### PR TITLE
[docker] Make `docker-compose` work

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -698,5 +698,9 @@
   "docker:v4-20231112-413d16d": {
     "commit": "413d16d05197abaa66bfdfa6ecd35a1e04abbdd3",
     "path": "/nix/store/yn9bbinj75dq2nxhd4dwdv4bh8q7m3bx-replit-module-docker"
+  },
+  "docker:v5-20231126-c101ba9": {
+    "commit": "c101ba914d5a42467781a681cf4561e952cd1627",
+    "path": "/nix/store/kq5zvhmmvnd9fnmad7rr8wj0wqkxydqc-replit-module-docker"
   }
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -75,7 +75,7 @@ rec {
     # publish your feature branch first and make sure modules.json is current, then
     # in goval dir (next to nixmodules), run `make custom-nixmodules-disk` to use this disk in conman
     # There is no need to check in changes to this.
-    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" ];
+    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" ];
     diskName = "disk.sqsh";
   };
 

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -157,6 +157,7 @@ let
       "exclude_graphdriver_devicemapper"
       "exclude_graphdriver_fuseoverlayfs"
       "exclude_graphdriver_overlay2"
+      "replit"
     ];
   };
 in

--- a/pkgs/modules/docker/replit-moby.patch
+++ b/pkgs/modules/docker/replit-moby.patch
@@ -55,28 +55,178 @@ index cd5ad761c9..090e09835e 100644
  		}
  
  		sb.osSbox = c.defOsSbox
+diff --git a/libnetwork/osl/interface_linux.go b/libnetwork/osl/interface_linux.go
+index ee1b4ab842..85d4896b5b 100644
+--- a/libnetwork/osl/interface_linux.go
++++ b/libnetwork/osl/interface_linux.go
+@@ -1,3 +1,6 @@
++//go:build !replit
++// +build !replit
++
+ package osl
+ 
+ import (
 diff --git a/libnetwork/osl/namespace_linux.go b/libnetwork/osl/namespace_linux.go
-index d7d2fe2d63..aaa312fa8b 100644
+index d7d2fe2d63..f6d4bb9672 100644
 --- a/libnetwork/osl/namespace_linux.go
 +++ b/libnetwork/osl/namespace_linux.go
-@@ -13,7 +13,6 @@ import (
- 	"syscall"
- 	"time"
+@@ -1,3 +1,6 @@
++//go:build !replit
++// +build !replit
++
+ package osl
  
--	"github.com/docker/docker/internal/unshare"
- 	"github.com/docker/docker/libnetwork/ns"
- 	"github.com/docker/docker/libnetwork/osl/kernel"
- 	"github.com/docker/docker/libnetwork/types"
-@@ -303,7 +302,8 @@ func createNetworkNamespace(path string, osCreate bool) error {
- 		return mountNetworkNamespace(fmt.Sprintf("/proc/self/task/%d/ns/net", unix.Gettid()), path)
- 	}
- 	if osCreate {
--		return unshare.Go(unix.CLONE_NEWNET, do, nil)
-+		// Replit mod: We don't create network namespaces
-+		return do()
- 	}
- 	return do()
- }
+ import (
+diff --git a/libnetwork/osl/neigh_linux.go b/libnetwork/osl/neigh_linux.go
+index e46b12a89f..c7d88651f2 100644
+--- a/libnetwork/osl/neigh_linux.go
++++ b/libnetwork/osl/neigh_linux.go
+@@ -1,3 +1,6 @@
++//go:build !replit
++// +build !replit
++
+ package osl
+ 
+ import (
+diff --git a/libnetwork/osl/options_linux.go b/libnetwork/osl/options_linux.go
+index 818669647f..e3507dd69e 100644
+--- a/libnetwork/osl/options_linux.go
++++ b/libnetwork/osl/options_linux.go
+@@ -1,3 +1,6 @@
++//go:build !replit
++// +build !replit
++
+ package osl
+ 
+ import "net"
+diff --git a/libnetwork/osl/route_linux.go b/libnetwork/osl/route_linux.go
+index c2a6390956..d04f07f376 100644
+--- a/libnetwork/osl/route_linux.go
++++ b/libnetwork/osl/route_linux.go
+@@ -1,3 +1,6 @@
++//go:build !replit
++// +build !replit
++
+ package osl
+ 
+ import (
+diff --git a/libnetwork/osl/sandbox_replit.go b/libnetwork/osl/sandbox_replit.go
+new file mode 100644
+index 0000000000..589ae12aaa
+--- /dev/null
++++ b/libnetwork/osl/sandbox_replit.go
+@@ -0,0 +1,111 @@
++//go:build replit
++// +build replit
++
++package osl
++
++import (
++	"fmt"
++	"net"
++
++	"github.com/docker/docker/libnetwork/types"
++)
++
++type sandboxNoOp struct {
++	key string
++}
++
++type nwIface struct{}
++
++type neigh struct{}
++
++// NewSandbox provides a new sandbox instance created in an os specific way
++// provided a key which uniquely identifies the sandbox
++func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
++	return &sandboxNoOp{key: key}, nil
++}
++
++// GenerateKey generates a sandbox key based on the passed
++// container id.
++func GenerateKey(containerID string) string { return containerID }
++
++// GC triggers garbage collection of namespace path right away
++// and waits for it.
++func GC() {}
++
++// GetSandboxForExternalKey returns sandbox object for the supplied path
++func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
++	return nil, nil
++}
++
++// SetBasePath sets the base url prefix for the ns path
++func SetBasePath(path string) {}
++
++// NeighborSearchError indicates that the neighbor is already present
++type NeighborSearchError struct {
++	ip      net.IP
++	mac     net.HardwareAddr
++	present bool
++}
++
++func (n NeighborSearchError) Error() string {
++	return fmt.Sprintf("Search neighbor failed for IP %v, mac %v, present in db:%t", n.ip, n.mac, n.present)
++}
++
++func (s *sandboxNoOp) Key() string { return s.key }
++func (*sandboxNoOp) AddInterface(SrcName string, DstPrefix string, options ...IfaceOption) error {
++	return nil
++}
++func (*sandboxNoOp) SetGateway(gw net.IP) error                       { return nil }
++func (*sandboxNoOp) SetGatewayIPv6(gw net.IP) error                   { return nil }
++func (*sandboxNoOp) UnsetGateway() error                              { return nil }
++func (*sandboxNoOp) UnsetGatewayIPv6() error                          { return nil }
++func (*sandboxNoOp) GetLoopbackIfaceName() string                     { return "lo" }
++func (*sandboxNoOp) AddAliasIP(ifName string, ip *net.IPNet) error    { return nil }
++func (*sandboxNoOp) RemoveAliasIP(ifName string, ip *net.IPNet) error { return nil }
++func (*sandboxNoOp) DisableARPForVIP(ifName string) error             { return nil }
++func (*sandboxNoOp) AddStaticRoute(*types.StaticRoute) error          { return nil }
++func (*sandboxNoOp) RemoveStaticRoute(*types.StaticRoute) error       { return nil }
++func (*sandboxNoOp) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, force bool, option ...NeighOption) error {
++	return nil
++}
++func (*sandboxNoOp) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr, osDelete bool) error {
++	return nil
++}
++func (*sandboxNoOp) NeighborOptions() NeighborOptionSetter { return &neighborOptionSetterNoOp{} }
++func (*sandboxNoOp) InterfaceOptions() IfaceOptionSetter   { return &ifaceOptionSetterNoOp{} }
++func (*sandboxNoOp) InvokeFunc(func()) error               { return nil }
++func (*sandboxNoOp) Info() Info                            { return &infoNoOp{} }
++func (*sandboxNoOp) Destroy() error                        { return nil }
++func (*sandboxNoOp) Restore(ifsopt map[Iface][]IfaceOption, routes []*types.StaticRoute, gw net.IP, gw6 net.IP) error {
++	return nil
++}
++func (*sandboxNoOp) ApplyOSTweaks([]SandboxType) {}
++
++type infoNoOp struct{}
++
++func (*infoNoOp) Interfaces() []Interface { return nil }
++func (*infoNoOp) Gateway() net.IP {
++	// This is the hardcoded IPv4 gateway in Repls.
++	return net.IPv4(172, 31, 196, 1)
++}
++func (*infoNoOp) GatewayIPv6() net.IP                { return nil }
++func (*infoNoOp) StaticRoutes() []*types.StaticRoute { return nil }
++
++type neighborOptionSetterNoOp struct{}
++
++func neighOptionNoOp(nh *neigh) {}
++
++func (*neighborOptionSetterNoOp) LinkName(string) NeighOption { return neighOptionNoOp }
++func (*neighborOptionSetterNoOp) Family(int) NeighOption      { return neighOptionNoOp }
++
++type ifaceOptionSetterNoOp struct{}
++
++func ifaceOptionNoOp(i *nwIface) {}
++
++func (*ifaceOptionSetterNoOp) Bridge(bool) IfaceOption                     { return ifaceOptionNoOp }
++func (*ifaceOptionSetterNoOp) MacAddress(net.HardwareAddr) IfaceOption     { return ifaceOptionNoOp }
++func (*ifaceOptionSetterNoOp) Address(*net.IPNet) IfaceOption              { return ifaceOptionNoOp }
++func (*ifaceOptionSetterNoOp) AddressIPv6(*net.IPNet) IfaceOption          { return ifaceOptionNoOp }
++func (*ifaceOptionSetterNoOp) LinkLocalAddresses([]*net.IPNet) IfaceOption { return ifaceOptionNoOp }
++func (*ifaceOptionSetterNoOp) Master(string) IfaceOption                   { return ifaceOptionNoOp }
++func (*ifaceOptionSetterNoOp) Routes([]*net.IPNet) IfaceOption             { return ifaceOptionNoOp }
 diff --git a/pkg/archive/archive.go b/pkg/archive/archive.go
 index 34361a24ac..6154b7a65c 100644
 --- a/pkg/archive/archive.go

--- a/pkgs/modules/docker/replit-runc.patch
+++ b/pkgs/modules/docker/replit-runc.patch
@@ -1,15 +1,12 @@
 diff --git a/init.go b/init.go
-index 79336306..1b4675ba 100644
+index 79336306..ec47f694 100644
 --- a/init.go
 +++ b/init.go
-@@ -1,16 +1,90 @@
- package main
+@@ -2,15 +2,46 @@ package main
  
  import (
-+	"bytes"
  	"os"
-+	"os/exec"
-+	"strconv"
++	"syscall"
 +	"time"
  
 -	"github.com/opencontainers/runc/libcontainer"
@@ -33,66 +30,25 @@ index 79336306..1b4675ba 100644
 +		logrus.Info("running roci")
 +
 +		// In Replit, we just ask roci to initialize the container for us.
-+		args := []string{"runc", "init"}
-+		cmd := exec.Command("/usr/bin/roci", args...)
-+		cmd.Stdin = os.Stdin
-+		cmd.Stdout = os.Stdout
-+		var stderr bytes.Buffer
-+		cmd.Stderr = &stderr
-+		fds := make(map[int]*os.File)
-+		maxFd := 0
-+		for _, name := range []string{
-+			"_LIBCONTAINER_INITPIPE",
-+			"_LIBCONTAINER_LOGPIPE",
-+			"_LIBCONTAINER_CONSOLE",
-+			"_LIBCONTAINER_FIFOFD",
-+		} {
-+			value := os.Getenv(name)
-+			if value == "" {
-+				continue
-+			}
-+			fd, err := strconv.Atoi(os.Getenv(name))
-+			if err != nil {
-+				logrus.
-+					WithError(err).
-+					WithField("source", "runc").
-+					Errorf("roci %q: %q", args, stderr.String())
-+				os.Exit(1)
-+			}
-+			fds[fd] = os.NewFile(uintptr(fd), name)
-+			if maxFd < fd {
-+				maxFd = fd
-+			}
-+		}
-+		null, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
++
++		args := []string{"/usr/bin/roci", "runc", "init"}
++		env := os.Environ()
++		err = syscall.Exec(
++			args[0],
++			args,
++			env,
++		)
 +		if err != nil {
 +			logrus.
 +				WithError(err).
 +				WithField("source", "runc").
-+				Errorf("roci %q: open /dev/null", args)
-+			os.Exit(1)
-+		}
-+		defer null.Close()
-+		for fd := 3; fd <= maxFd; fd++ {
-+			cmd.ExtraFiles = append(cmd.ExtraFiles, null)
-+		}
-+		for fd, f := range fds {
-+			cmd.ExtraFiles[fd - 3] = f
-+		}
-+		cmd.ExtraFiles = append(cmd.ExtraFiles, os.Stderr)
-+		cmd.Env = append(os.Environ(), "_ROCI_STDERR_FD=" + strconv.Itoa(len(cmd.ExtraFiles) + 2))
-+		err = cmd.Run()
-+		if err != nil {
-+			logrus.
-+				WithError(err).
-+				WithField("source", "runc").
-+				WithField("env", cmd.Env).
++				WithField("env", env).
 +				Error("roci failed, chilling a bit")
 +			time.Sleep(1 * time.Second)
 +			logrus.
 +				WithError(err).
 +				WithField("source", "runc").
-+				Errorf("roci %q: %q", args, stderr.String())
++				Errorf("roci %q", args)
 +			os.Exit(1)
 +		}
 +		os.Exit(0)
@@ -323,8 +279,192 @@ index 8785d657..328b27f8 100644
  
  			// generate a timestamp indicating when the container was started
  			p.container.created = time.Now().UTC()
+diff --git a/signals.go b/signals.go
+index e0bc7c61..19401ac2 100644
+--- a/signals.go
++++ b/signals.go
+@@ -1,8 +1,12 @@
+ package main
+ 
+ import (
++	"encoding/json"
++	"fmt"
++	"net"
+ 	"os"
+ 	"os/signal"
++	"path"
+ 
+ 	"github.com/opencontainers/runc/libcontainer"
+ 	"github.com/opencontainers/runc/libcontainer/system"
+@@ -18,8 +22,31 @@ const signalBufferSize = 2048
+ // while still forwarding all other signals to the process.
+ // If notifySocket is present, use it to read systemd notifications from the container and
+ // forward them to notifySocketHost.
+-func newSignalHandler(enableSubreaper bool, notifySocket *notifySocket) *signalHandler {
++func newSignalHandler(enableSubreaper bool, notifySocket *notifySocket, id string) *signalHandler {
++	// Replit mod: since we can't be a subreaper because the containers are not our
++	// children, we install an external subreaper.
++	var reaperSocket *net.UnixListener
+ 	if enableSubreaper {
++		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
++		if runtimeDir == "" {
++			runtimeDir = "/run"
++		}
++		// Even if containerd had set up its own reaper socket, the
++		// intention by setting the subreaper is that this process
++		// will get the signal that the process has died. When that
++		// happens, we'll completely overwrite the reaper socket.
++		reaperPath := path.Join(runtimeDir, fmt.Sprintf("containerd/s/%s-reaper.sock", id))
++		os.MkdirAll(path.Dir(reaperPath), 0o700)
++		os.Remove(reaperPath)
++		var err error
++		reaperSocket, err = net.ListenUnix("unix", &net.UnixAddr{
++			Name: reaperPath,
++			Net:  "unix",
++		})
++		if err != nil {
++			logrus.WithError(err).Warn("failed to listen on subreaper socket")
++		}
++
+ 		// set us as the subreaper before registering the signal handler for the container
+ 		if err := system.SetSubreaper(1); err != nil {
+ 			logrus.Warn(err)
+@@ -33,6 +60,7 @@ func newSignalHandler(enableSubreaper bool, notifySocket *notifySocket) *signalH
+ 	return &signalHandler{
+ 		signals:      s,
+ 		notifySocket: notifySocket,
++		reaperSocket: reaperSocket,
+ 	}
+ }
+ 
+@@ -46,6 +74,7 @@ type exit struct {
+ type signalHandler struct {
+ 	signals      chan os.Signal
+ 	notifySocket *notifySocket
++	reaperSocket *net.UnixListener
+ }
+ 
+ // forward handles the main signal event loop forwarding, resizing, or reaping depending
+@@ -71,43 +100,86 @@ func (h *signalHandler) forward(process *libcontainer.Process, tty *tty, detach
+ 		go func() { _ = h.notifySocket.run(0) }()
+ 	}
+ 
++	// Replit mod: listen to children exiting.
++	type reaperStatus struct {
++		Pid    int `json:"pid"`
++		Status int `json:"status"`
++	}
++	reaperChan := make(chan reaperStatus, 1)
++	if h.reaperSocket != nil {
++		go func() {
++			for {
++				sock, err := h.reaperSocket.Accept()
++				if err != nil {
++					logrus.WithError(err).Error("failed to accept reaper socket")
++					return
++				}
++				var st reaperStatus
++				if err := json.NewDecoder(sock).Decode(&st); err != nil {
++					logrus.WithError(err).Error("failed to decode reaper message")
++					continue
++				}
++				reaperChan <- st
++			}
++		}()
++	}
++
+ 	// Perform the initial tty resize. Always ignore errors resizing because
+ 	// stdout might have disappeared (due to races with when SIGHUP is sent).
+ 	_ = tty.resize()
+ 	// Handle and forward signals.
+-	for s := range h.signals {
+-		switch s {
+-		case unix.SIGWINCH:
+-			// Ignore errors resizing, as above.
+-			_ = tty.resize()
+-		case unix.SIGCHLD:
+-			exits, err := h.reap()
+-			if err != nil {
+-				logrus.Error(err)
++L:
++	for {
++		select {
++		case st := <-reaperChan:
++			logrus.WithFields(logrus.Fields{
++				"pid":    st.Pid,
++				"status": st.Status,
++			}).Debug("process exited")
++			if st.Pid == pid1 {
++				// call Wait() on the process even though we already have the exit
++				// status because we must ensure that any of the go specific process
++				// fun such as flushing pipes are complete before we return.
++				_, _ = process.Wait()
++				return st.Status, nil
+ 			}
+-			for _, e := range exits {
+-				logrus.WithFields(logrus.Fields{
+-					"pid":    e.pid,
+-					"status": e.status,
+-				}).Debug("process exited")
+-				if e.pid == pid1 {
+-					// call Wait() on the process even though we already have the exit
+-					// status because we must ensure that any of the go specific process
+-					// fun such as flushing pipes are complete before we return.
+-					_, _ = process.Wait()
+-					return e.status, nil
+-				}
++		case s, ok := <-h.signals:
++			if !ok {
++				break L
+ 			}
+-		case unix.SIGURG:
+-			// SIGURG is used by go runtime for async preemptive
+-			// scheduling, so runc receives it from time to time,
+-			// and it should not be forwarded to the container.
+-			// Do nothing.
+-		default:
+-			us := s.(unix.Signal)
+-			logrus.Debugf("forwarding signal %d (%s) to %d", int(us), unix.SignalName(us), pid1)
+-			if err := unix.Kill(pid1, us); err != nil {
+-				logrus.Error(err)
++			switch s {
++			case unix.SIGWINCH:
++				// Ignore errors resizing, as above.
++				_ = tty.resize()
++			case unix.SIGCHLD:
++				exits, err := h.reap()
++				if err != nil {
++					logrus.Error(err)
++				}
++				for _, e := range exits {
++					logrus.WithFields(logrus.Fields{
++						"pid":    e.pid,
++						"status": e.status,
++					}).Debug("process exited")
++					if e.pid == pid1 {
++						// call Wait() on the process even though we already have the exit
++						// status because we must ensure that any of the go specific process
++						// fun such as flushing pipes are complete before we return.
++						_, _ = process.Wait()
++						return e.status, nil
++					}
++				}
++			case unix.SIGURG:
++				// SIGURG is used by go runtime for async preemptive
++				// scheduling, so runc receives it from time to time,
++				// and it should not be forwarded to the container.
++				// Do nothing.
++			default:
++				us := s.(unix.Signal)
++				logrus.Debugf("forwarding signal %d (%s) to %d", int(us), unix.SignalName(us), pid1)
++				if err := unix.Kill(pid1, us); err != nil {
++					logrus.Error(err)
++				}
+ 			}
+ 		}
+ 	}
 diff --git a/utils_linux.go b/utils_linux.go
-index 0f787cb3..9ffde63b 100644
+index 0f787cb3..9e5ba318 100644
 --- a/utils_linux.go
 +++ b/utils_linux.go
 @@ -180,6 +180,15 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (*libcon
@@ -343,3 +483,14 @@ index 0f787cb3..9ffde63b 100644
  
  	root := context.GlobalString("root")
  	return libcontainer.Create(root, id, config)
+@@ -243,7 +252,9 @@ func (r *runner) run(config *specs.Process) (int, error) {
+ 	// Setting up IO is a two stage process. We need to modify process to deal
+ 	// with detaching containers, and then we get a tty after the container has
+ 	// started.
+-	handler := newSignalHandler(r.enableSubreaper, r.notifySocket)
++	// Replit mod: Pass the container ID to the signal handler so that it can
++	// create the reaper socket if needed.
++	handler := newSignalHandler(r.enableSubreaper, r.notifySocket, r.container.ID())
+ 	tty, err := setupIO(process, rootuid, rootgid, config.Terminal, detach, r.consoleSocket)
+ 	if err != nil {
+ 		return -1, err

--- a/pkgs/modules/docker/replit-runc.patch
+++ b/pkgs/modules/docker/replit-runc.patch
@@ -188,6 +188,26 @@ index c941239b..c329c89f 100644
  
  	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
  	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason
+diff --git a/libcontainer/factory_linux.go b/libcontainer/factory_linux.go
+index 4cb4a88b..299316e2 100644
+--- a/libcontainer/factory_linux.go
++++ b/libcontainer/factory_linux.go
+@@ -165,6 +165,15 @@ func loadState(root string) (*State, error) {
+ 	if err := json.NewDecoder(f).Decode(&state); err != nil {
+ 		return nil, err
+ 	}
++	// Replit mod: prevent adding net namespaces.
++	for i := 0; i < len(state.Config.Namespaces); i++ {
++		if state.Config.Namespaces[i].Type == configs.NEWNET {
++			state.Config.Namespaces = append(state.Config.Namespaces[:i], state.Config.Namespaces[i+1:]...)
++			i--
++		}
++	}
++	state.Config.Networks = nil
++	state.Config.Routes = nil
+ 	return state, nil
+ }
+ 
 diff --git a/libcontainer/process_linux.go b/libcontainer/process_linux.go
 index 8785d657..328b27f8 100644
 --- a/libcontainer/process_linux.go
@@ -296,3 +316,23 @@ index 8785d657..328b27f8 100644
  
  			// generate a timestamp indicating when the container was started
  			p.container.created = time.Now().UTC()
+diff --git a/utils_linux.go b/utils_linux.go
+index 0f787cb3..9ffde63b 100644
+--- a/utils_linux.go
++++ b/utils_linux.go
+@@ -180,6 +180,15 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (*libcon
+ 	if err != nil {
+ 		return nil, err
+ 	}
++	// Replit mod: prevent adding net namespaces.
++	for i := 0; i < len(config.Namespaces); i++ {
++		if config.Namespaces[i].Type == configs.NEWNET {
++			config.Namespaces = append(config.Namespaces[:i], config.Namespaces[i+1:]...)
++			i--
++		}
++	}
++	config.Networks = nil
++	config.Routes = nil
+ 
+ 	root := context.GlobalString("root")
+ 	return libcontainer.Create(root, id, config)

--- a/pkgs/modules/docker/replit-runc.patch
+++ b/pkgs/modules/docker/replit-runc.patch
@@ -170,10 +170,10 @@ index 6d32704a..b00e4533 100644
  	return nil
  }
 diff --git a/libcontainer/container_linux.go b/libcontainer/container_linux.go
-index c941239b..c329c89f 100644
+index c941239b..e58468e4 100644
 --- a/libcontainer/container_linux.go
 +++ b/libcontainer/container_linux.go
-@@ -500,6 +500,14 @@ func (c *Container) commandTemplate(p *Process, childInitPipe *os.File, childLog
+@@ -500,6 +500,21 @@ func (c *Container) commandTemplate(p *Process, childInitPipe *os.File, childLog
  	if p.LogLevel != "" {
  		cmd.Env = append(cmd.Env, "_LIBCONTAINER_LOGLEVEL="+p.LogLevel)
  	}
@@ -185,6 +185,13 @@ index c941239b..c329c89f 100644
 +	if err == nil {
 +		cmd.Env = append(cmd.Env, "_REPLIT_CONFIG_JSON="+path.Join(wd, "config.json"))
 +	}
++	// Replit mod: replit-shim-runc starts one reaper socket per instance.
++	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
++	if runtimeDir == "" {
++			runtimeDir = "/run"
++	}
++	externalReapsSocketPath := path.Join(runtimeDir, fmt.Sprintf("containerd/s/%s-reaper.sock", c.id))
++	cmd.Env = append(cmd.Env, "_REPLIT_REAPER_SOCKET="+externalReapsSocketPath)
  
  	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
  	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason

--- a/pkgs/modules/docker/replit-shim-runc.patch
+++ b/pkgs/modules/docker/replit-shim-runc.patch
@@ -34,7 +34,7 @@ index 43dfdf941..9105879c1 100644
  
  		s.send(&eventstypes.TaskStart{
 diff --git a/runtime/v2/shim/shim.go b/runtime/v2/shim/shim.go
-index cf006d805..54791a433 100644
+index cf006d805..60316fa8d 100644
 --- a/runtime/v2/shim/shim.go
 +++ b/runtime/v2/shim/shim.go
 @@ -37,6 +37,7 @@ import (
@@ -45,18 +45,27 @@ index cf006d805..54791a433 100644
  	"github.com/containerd/containerd/version"
  	"github.com/containerd/ttrpc"
  	"github.com/sirupsen/logrus"
-@@ -518,6 +519,9 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
+@@ -477,6 +478,8 @@ func run(ctx context.Context, manager Manager, initFunc Init, name string, confi
+ 	if address, err := ReadAddress("address"); err == nil {
+ 		_ = RemoveSocket(address)
+ 	}
++	// Replit mod: clean up the reaper socket.
++	reaper.CleanExternalReaps()
+ 
+ 	select {
+ 	case <-publisher.Done():
+@@ -518,6 +521,9 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
  		}
  	}()
  
 +	// Replit mod: Containers are not our direct descendants, so
 +	// we need to have an external listener for child death events.
-+	reaper.ListenExternalReaps()
++	reaper.ListenExternalReaps(id)
  	go handleExitSignals(ctx, logger, shutdown)
  	return reap(ctx, logger, signals)
  }
 diff --git a/sys/reaper/reaper_unix.go b/sys/reaper/reaper_unix.go
-index 8172f224e..a4c5941fd 100644
+index 8172f224e..58663681e 100644
 --- a/sys/reaper/reaper_unix.go
 +++ b/sys/reaper/reaper_unix.go
 @@ -21,10 +21,16 @@ package reaper
@@ -76,7 +85,7 @@ index 8172f224e..a4c5941fd 100644
  	runc "github.com/containerd/go-runc"
  	exec "golang.org/x/sys/execabs"
  	"golang.org/x/sys/unix"
-@@ -58,6 +64,67 @@ func (s *subscriber) do(fn func()) {
+@@ -58,6 +64,85 @@ func (s *subscriber) do(fn func()) {
  	s.Unlock()
  }
  
@@ -84,22 +93,31 @@ index 8172f224e..a4c5941fd 100644
 +// of the shim (like they are in a regular containerd system), we need
 +// a way to let the various places where the shim waits for the
 +// various processes involved in container creation to exit.
-+var externalReapsOnce sync.Once
++var (
++	externalReapsOnce       sync.Once
++	externalReapsSocketPath string
++)
 +
 +// ListenExternalReaps installs a UNIX domain socket that listens
 +// for roci's notifications of when the container process dies.
-+func ListenExternalReaps() {
++func ListenExternalReaps(id string) {
 +	externalReapsOnce.Do(func() {
-+		go listenExternalReaps()
++		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
++		if runtimeDir == "" {
++			runtimeDir = "/run"
++		}
++
++		// Register one listener specific to this this shim.
++		externalReapsSocketPath = path.Join(runtimeDir, fmt.Sprintf("containerd/s/%s-reaper.sock", id))
++		go listenExternalReaps(externalReapsSocketPath)
++
++		// TODO: Once roci has been upgraded fully, we can remove this.
++		sharedSocketPath := path.Join(runtimeDir, "containerd/containerd-reaper.sock")
++		go listenExternalReaps(sharedSocketPath)
 +	})
 +}
 +
-+func listenExternalReaps() {
-+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-+	if runtimeDir == "" {
-+		runtimeDir = "/run"
-+	}
-+	socketPath := path.Join(runtimeDir, "containerd/containerd-reaper.sock")
++func listenExternalReaps(socketPath string) {
 +	os.Remove(socketPath)
 +	addr, err := net.ResolveUnixAddr("unix", socketPath)
 +	if err != nil {
@@ -139,6 +157,15 @@ index 8172f224e..a4c5941fd 100644
 +			}
 +		}()
 +	}
++}
++
++// CleanExternalReaps removes the UNIX domain socket that listens
++// for roci's notifications of when the container process dies.
++func CleanExternalReaps() {
++	if externalReapsSocketPath == "" {
++		return
++	}
++	os.Remove(externalReapsSocketPath)
 +}
 +
  // Reap should be called when the process receives an SIGCHLD.  Reap will reap


### PR DESCRIPTION
Why
===

`docker-compose` is fun!

What changed
============

Two main changes:

* Modified `moby` to fully prevent _any_ network sandbox operations and `runc` to ignore any request for net namespacing.
* Modified `runc` and `replit-shim-runc` to create a socket per shim instance, so that the runc instance can talk to its parent correctly.

Test plan
=========

`docker-compose up` finally works!

Rollout
=======

- [X] This is fully backward and forward compatible