### PR TITLE
everything is unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1697437401,
-        "narHash": "sha256-f4XpURQ8OxZV7txHkbJKcFj2sJJAvuk0p8SkNYitIkQ=",
+        "lastModified": 1701066187,
+        "narHash": "sha256-WP2sUVcjM4uuCBnw2r++6Rnuqzd4iZ7oh/o7AarPjIM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ff913e22a14fd9728318997f2694ab2275ab1ad0",
+        "rev": "bec77b7f219319a49dc1885490236714b023d19c",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688568849,
-        "narHash": "sha256-3oOgfV0T9tD3RyXUc/miXcXoNt9JkYkL1Jdg+rl+2lg=",
+        "lastModified": 1697466147,
+        "narHash": "sha256-3AhaAwFYglnvtv4Cyeq3/cooQUIVTE+vID+TSZsFAfQ=",
         "owner": "replit",
         "repo": "java-language-server",
-        "rev": "a8429dbed50f2de324e44a1b81dc2b94a248adc6",
+        "rev": "ba33f337ad1967f2b1b0990801701c2c531369f6",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693052712,
-        "narHash": "sha256-7wrP6s4OEuR7BUasy76n7j+c09rp7wyOq7YVYviXw9s=",
+        "lastModified": 1699966122,
+        "narHash": "sha256-zEN3ET7jfXpIKYeYh/z4xekOBOoaFS+n0q3oL3sVh+0=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "f88accc8a8231efdae900ff6a14cb6301a73cff9",
+        "rev": "b3bb9ea7cd3c2f07c89779a474d6468b2c11e303",
         "type": "github"
       },
       "original": {
@@ -183,11 +183,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687466461,
-        "narHash": "sha256-oupXI7g7RPzlpGUfAu1xG4KBK53GrZH8/xeKgKDB4+Q=",
+        "lastModified": 1700989516,
+        "narHash": "sha256-oKbmPa2wpTHh9XB3+zIx97uMZGNnp97GPliKKG2/plo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ecb441f22067ba1d6312f4932a7c64efa8d19a7b",
+        "rev": "d2e4de209881b38392933fabf303cde3454b0b4c",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "lastModified": 1701040486,
+        "narHash": "sha256-vawYwoHA5CwvjfqaT3A5CT9V36Eq43gxdwpux32Qkjw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "45827faa2132b8eade424f6bdd48d8828754341a",
         "type": "github"
       },
       "original": {
@@ -266,11 +266,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1696546231,
-        "narHash": "sha256-gueDbtDnrGP6fhI6j17vaImGETi/3aYFVQ6591l0YsI=",
+        "lastModified": 1700997114,
+        "narHash": "sha256-pOz99NESIGosyt19tqNw7gfS6NQJtFY0kGF3rFV0bZ0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "03c56030350decb7f1c13c27eb7547ba5ed6b201",
+        "rev": "237712fa314237e428e7ef2ab83b979f928a43a1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,7 +43,7 @@
     "fenix": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-unstable"
         ],
         "rust-analyzer-src": "rust-analyzer-src"
       },
@@ -143,7 +143,7 @@
     "java-language-server": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
@@ -164,7 +164,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
@@ -178,22 +178,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixd",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1700989516,
-        "narHash": "sha256-oKbmPa2wpTHh9XB3+zIx97uMZGNnp97GPliKKG2/plo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d2e4de209881b38392933fabf303cde3454b0b4c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -235,7 +219,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
@@ -257,7 +241,6 @@
         "fenix": "fenix",
         "java-language-server": "java-language-server",
         "nixd": "nixd",
-        "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar",
         "ztoc-rs": "ztoc-rs"
@@ -313,7 +296,7 @@
         "crane": "crane",
         "flake-utils": "flake-utils_3",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,18 @@
 {
   description = "Nix expressions for defining Replit development environments";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.fenix.url = "github:nix-community/fenix";
-  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs-unstable";
   inputs.nixd.url = "github:nix-community/nixd";
-  inputs.nixd.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.nixd.inputs.nixpkgs.follows = "nixpkgs-unstable";
   inputs.prybar.url = "github:replit/prybar";
-  inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.prybar.inputs.nixpkgs.follows = "nixpkgs-unstable";
   inputs.java-language-server.url = "github:replit/java-language-server";
-  inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs-unstable";
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
-  inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs-unstable";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, fenix, ... }:
+  outputs = { self, nixpkgs-unstable, prybar, java-language-server, nixd, fenix, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -25,14 +24,12 @@
           fenix.overlays.default
         ];
         # replbox has an unfree license
-        config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+        config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs-unstable.lib.getName pkg) [
           "@replit/replbox"
         ];
       };
 
-      pkgs = mkPkgs nixpkgs "x86_64-linux";
-
-      pkgs-unstable = mkPkgs nixpkgs-unstable "x86_64-linux";
+      pkgs = mkPkgs nixpkgs-unstable "x86_64-linux";
     in
     {
       overlays.default = final: prev: {
@@ -56,7 +53,6 @@
     } // (
       import ./pkgs/modules {
         inherit pkgs;
-        inherit pkgs-unstable;
       }
     );
 }

--- a/modules.json
+++ b/modules.json
@@ -35,6 +35,10 @@
     "commit": "f6dc97c19cbc64d2a271be3ba829b87fd5237328",
     "path": "/nix/store/62vlf5i47d5d60181w31n6zf1xfy2s0y-replit-module-c-clang14"
   },
+  "c-clang14:v4-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/v01i01qw2flhznwhwdkghwng6f4xcqqx-replit-module-c-clang14"
+  },
   "clojure-1.11:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/giqq76fl3yphzsm6rkl1qxqh4mszknpl-replit-module-clojure-1.11"
@@ -42,6 +46,10 @@
   "clojure-1.11:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/jvz8pm6gj0h58x1r0c19ypkcpswriq5a-replit-module-clojure-1.11"
+  },
+  "clojure-1.11:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/axlx5zj2ialp7c5fsh77b7j55w98aw0y-replit-module-clojure-1.11"
   },
   "cpp-clang14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -54,6 +62,10 @@
   "cpp-clang14:v3-20231025-f6dc97c": {
     "commit": "f6dc97c19cbc64d2a271be3ba829b87fd5237328",
     "path": "/nix/store/mllwdnixmcd6qxy1aw1pxqqjj2wknvpc-replit-module-cpp-clang14"
+  },
+  "cpp-clang14:v4-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/3r1ghq42va9d5k5x4q3r8iss3pmjnsvm-replit-module-cpp-clang14"
   },
   "dart-2.18:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -70,6 +82,10 @@
   "dotnet-7.0:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/rim896frw7wg1qg8bwihgr3yhdn17clx-replit-module-dotnet-7.0"
+  },
+  "dotnet-7.0:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/nram3jmamk50p89l1apwd8yqfiiw1gmm-replit-module-dotnet-7.0"
   },
   "go-1.19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -122,6 +138,10 @@
   "lua-5.2:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/r9lznvivd7idrx3skvazs64lv99m00l7-replit-module-lua-5.2"
+  },
+  "lua-5.2:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/zrjzfrbssh51j5086iyl51k471k1rhjn-replit-module-lua-5.2"
   },
   "nodejs-14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -203,6 +223,10 @@
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/3jnfz8ad929wz8lpgll3wlmzhnas5mvn-replit-module-nodejs-18"
   },
+  "nodejs-18:v15-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/xd72iq2aj3mad4d25ia71s9bg52kcmfv-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -258,6 +282,10 @@
   "nodejs-20:v11-20231122-8e4093b": {
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/8hcddx7wafg406c3nifm0p2ygprfg7v2-replit-module-nodejs-20"
+  },
+  "nodejs-20:v12-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/bl2iia4ccb12agh360hlypddbhv7d86r-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -383,6 +411,10 @@
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/9wv2f51wrd8q1g70halnfifv9xp37xxd-replit-module-python-3.10"
   },
+  "python-3.10:v31-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/sj8dvkl57qh7nl0rw87zxcyax18g8xa8-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -390,6 +422,10 @@
   "qbasic:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/kb4nnw1mggda2xagy3r5g83v3gkpl7rs-replit-module-qbasic"
+  },
+  "qbasic:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/nnmhhbfhhqh7jph149wp6395p1zbf8kv-replit-module-qbasic"
   },
   "r-4.2:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -410,6 +446,10 @@
   "ruby-3.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/1qlvg6wh8wg7il1njmsspr6fhda9bdgj-replit-module-ruby-3.1"
+  },
+  "ruby-3.1:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/2nmm5bgjrx023wy3wmlqbqvxb8zh9kjc-replit-module-ruby-3.1"
   },
   "rust-1.69:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -443,6 +483,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/53vn26l79zj17g28xlfki4d3j3ra7nbi-replit-module-web"
   },
+  "web:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/wpch2kd2926vad2hz2mgm06gxwkwinbf-replit-module-web"
+  },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
     "path": "/nix/store/naqna9imw62bi543fnlpg8r7rd79bf2b-replit-module-pyright-extended"
@@ -475,6 +519,10 @@
     "commit": "d4ad2e4453adf8dc310fe700f38d125361906606",
     "path": "/nix/store/5w2h6ynxsq16i4qxqa8cb5d5k362zd9l-replit-module-pyright-extended"
   },
+  "pyright-extended:v9-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/wp41hrrcl7jf05mdqp3aag7wz9vahcsj-replit-module-pyright-extended"
+  },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
@@ -491,9 +539,17 @@
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/xnl830xrhx5s121q12j5dyyjn8rx9f7v-replit-module-svelte-kit-node-20"
   },
+  "svelte-kit-node-20:v5-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/0nnxfl8lw1icmikv7sqai1lxh9ayqnp0-replit-module-svelte-kit-node-20"
+  },
   "gcloud:v1-20230815-e6e4431": {
     "commit": "e6e4431a8f1d71ec0664ce97828bede1608dcfd1",
     "path": "/nix/store/q67zzk6y4zzw7k6nc2plql97z1yv7xwx-replit-module-gcloud"
+  },
+  "gcloud:v2-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/yrn99f1xjv5ngz688z0d3ja8vckrmyrq-replit-module-gcloud"
   },
   "python-3.11:v1-20230828-e4baa21": {
     "commit": "e4baa21ed52b51e2a4963fc8136f211a2b277455",
@@ -538,6 +594,10 @@
   "python-3.11:v11-20231125-92f4109": {
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/7amwcfydxmp3hc2f7gh8n4c36vhswlpa-replit-module-python-3.11"
+  },
+  "python-3.11:v12-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/b17dipjwlqjxrx9iphnijdzilv82141v-replit-module-python-3.11"
   },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
@@ -623,6 +683,10 @@
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/pwwa3b8dhfxmrn7s2qhl676x5la51yx0-replit-module-bun-1.0"
   },
+  "bun-1.0:v11-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/6r96d0ng4vr3j0xw8y9f0z1m58ds0ih4-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -630,6 +694,10 @@
   "nix:v1-20230906-ff49114": {
     "commit": "ff491143e779453de50b979dc7dd35ac0f2ef40a",
     "path": "/nix/store/4lhzsk1lq4hirb9fp6hv43w56cq88lpi-replit-module-nix"
+  },
+  "nix:v2-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/cw5z783brhnjbxrxvkdfl7fbvyvvidws-replit-module-nix"
   },
   "python-with-prybar-3.10:v2-20230925-77b13e4": {
     "commit": "77b13e434deb254c3792ddd97191586c193a83a6",
@@ -663,6 +731,10 @@
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/vzjbca3vjs11fgqr4ax57djp101v8pph-replit-module-python-with-prybar-3.10"
   },
+  "python-with-prybar-3.10:v10-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/jshrdcf6fqgp278w33713bn1jbk3hw90-replit-module-python-with-prybar-3.10"
+  },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",
     "path": "/nix/store/8v3laig35f30bvgw8mwjcsznk06l7vf3-replit-module-nodejs-with-prybar-18"
@@ -683,6 +755,10 @@
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/969wddvl49bzffhpp0sndcyr8dxsw436-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v6-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/glx0hpwdphm7rdzlx47qiq55swknki9j-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -695,9 +771,17 @@
     "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
     "path": "/nix/store/1wbmhhf77wpnagflz7p2wjscrgdilc7l-replit-module-rust-stable"
   },
+  "rust-stable:v3-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/lfwf0vbvsr1yjidvj0r06l3dg0928q60-replit-module-rust-stable"
+  },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
+  },
+  "go-1.21:v2-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/k1r5v290m5q2daypz9j073ywk72cssac-replit-module-go-1.21"
   },
   "docker:v1-20231026-3990bf0": {
     "commit": "3990bf05353ec3cffd54b8376616fdf6165d4580",
@@ -722,5 +806,25 @@
   "docker:v6-20231128-8cef170": {
     "commit": "8cef17041b553bad202c306e5d9b726ddd007544",
     "path": "/nix/store/mb6v56in36xplrs8783q9923cdimdgvd-replit-module-docker"
+  },
+  "docker:v7-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/zw2cczaql8awhcp0c69si1ib9vidxbjb-replit-module-docker"
+  },
+  "dart-3.1:v1-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/ra46cfdhzrp1gn6rh4l5nnycn3vjv18l-replit-module-dart-3.1"
+  },
+  "haskell-ghc9.4:v1-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/1h4yw5k3iz7fmszp94mmpngkr5nh3ydx-replit-module-haskell-ghc9.4"
+  },
+  "php-8.2:v1-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/8whfz8mxysaz299a54kvpm0a96gc89v3-replit-module-php-8.2"
+  },
+  "r-4.3:v1-20231128-1e033d9": {
+    "commit": "1e033d9d59a9bf041a2c24e96eb281d1decdc6b4",
+    "path": "/nix/store/naz6n9b9fd8swy5yb2i9sn4haw4h3c48-replit-module-r-4.3"
   }
 }

--- a/pkgs/jdt-language-server/default.nix
+++ b/pkgs/jdt-language-server/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  jdk = if pkgs ? graalvm17-ce then pkgs.graalvm17-ce else pkgs.jdk;
+  jdk = pkgs.graalvm-ce;
 
 in
 stdenv.mkDerivation rec {

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,5 +1,4 @@
 { pkgs ? import <nixpkgs> { }
-, pkgs-unstable ? import <nixpkgs-unstable> { }
 , configPath
 , deployment ? false
 }:
@@ -10,7 +9,7 @@ let
       (import ./module-definition.nix)
     ];
     specialArgs = {
-      inherit pkgs pkgs-unstable;
+      inherit pkgs;
       modulesPath = builtins.toString ./.;
     };
   });

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -1,7 +1,7 @@
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 
 let
-  bun = pkgs-unstable.callPackage ../../bun { };
+  bun = pkgs.callPackage ../../bun { };
 
   extensions = [ ".json" ".js" ".jsx" ".ts" ".tsx" ];
 

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -40,7 +40,8 @@ let
     })
 
     (import ./rust)
-    (import ./swift)
+    # TODO: re-enable when building swift is fixed in nixpkgs
+    # (import ./swift)
     (import ./bun)
     (import ./c)
     (import ./cpp)
@@ -50,6 +51,7 @@ let
     (import ./clojure)
     (import ./dotnet)
     (import ./haskell)
+    # TODO: re-enable when java-debug and java-language-server are fixed, other unknowns
     # (import ./java)
     (import ./lua)
     (import ./nix)

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,20 +1,14 @@
-{ pkgs, pkgs-unstable }:
+{ pkgs }:
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-unstable;
   };
   mkDeploymentModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-unstable;
     deployment = true;
   };
 
   modulesList = [
-    (import ./python {
-      python = pkgs.python38Full;
-      pypkgs = pkgs.python38Packages;
-    })
     (import ./python {
       python = pkgs.python310Full;
       pypkgs = pkgs.python310Packages;
@@ -39,9 +33,9 @@ let
       inherit (pkgs) go gopls;
     })
     (import ./go {
-      go = pkgs-unstable.go_1_21;
-      gopls = pkgs-unstable.gopls.override {
-        buildGoModule = pkgs-unstable.buildGo121Module;
+      go = pkgs.go_1_21;
+      gopls = pkgs.gopls.override {
+        buildGoModule = pkgs.buildGo121Module;
       };
     })
 

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -50,7 +50,7 @@ let
     (import ./clojure)
     (import ./dotnet)
     (import ./haskell)
-    (import ./java)
+    # (import ./java)
     (import ./lua)
     (import ./nix)
     (import ./php)

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -1,10 +1,10 @@
-{ pkgs, pkgs-unstable, ... }:
+{ pkgs, ... }:
 
 let
 
   configFiles = pkgs.copyPathToStore ./etc;
 
-  replit-runc = pkgs-unstable.buildGo121Module {
+  replit-runc = pkgs.buildGo121Module {
     pname = "replit-runc";
     version = "1.1.9+replit";
 
@@ -30,7 +30,7 @@ let
     '';
   };
 
-  replit-containerd = pkgs-unstable.buildGo121Module {
+  replit-containerd = pkgs.buildGo121Module {
     pname = "replit-containerd";
     version = "1.7.5+replit";
 
@@ -65,7 +65,7 @@ let
     replitShimRunc = replit-containerd;
   };
 
-  replit-buildkit = pkgs-unstable.buildGo121Module {
+  replit-buildkit = pkgs.buildGo121Module {
     pname = "replit-buildkit";
     version = "v0.13.0-beta1+replit";
 

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -1,9 +1,11 @@
+# TODO: fix this
+# there's maven issues with java-debug and java-language-server
 { pkgs, lib, ... }:
 
 let
   graalvm = pkgs.graalvm-ce;
 
-  graalvm-version = lib.versions.majorMinor graalvm.version;
+  graalvm-version = lib.versions.major graalvm.version;
 
   graal-compile-command = "${graalvm}/bin/javac -classpath .:target/dependency/* -d . $(find . -type f -name '*.java')";
 
@@ -13,10 +15,13 @@ let
     jdk = pkgs.graalvm-ce;
   };
 
-  java-debug = pkgs.callPackage ../../java-debug {
-    inherit jdt-language-server;
-    jdk = pkgs.graalvm-ce;
-  };
+  # TODO: java-debug doesn't work with java 21 :( gotta either update the repo or
+  # use a different graalvm version, which i'm not 100% convinced will work off
+  # the bat but also this nixmodule is currently unused so just kicking cans i guess
+  # java-debug = pkgs.callPackage ../../java-debug {
+  #   inherit jdt-language-server;
+  #   jdk = pkgs.graalvm-ce;
+  # };
 
   run-lsp = pkgs.writeShellScriptBin "run-lsp" ''
     # Allow setting this env var to diagnose the lsp
@@ -30,7 +35,7 @@ let
 in
 
 {
-  id = "java-graalvm${graalvm-version}";
+  id = "java-${graalvm-version}-graalvm";
   name = "Java Tools (with Graal VM)";
 
   replit.packages = [
@@ -56,41 +61,41 @@ in
     };
   };
 
-  replit.dev.debuggers.java-debug = {
-    name = "Jave Debug";
-    language = "java";
-    extensions = [ ".java" ];
+  # replit.dev.debuggers.java-debug = {
+  # name = "Jave Debug";
+  # language = "java";
+  # extensions = [ ".java" ];
 
-    transport = "localhost:0";
-    compile = graal-compile-command;
-    start = "${java-debug}/bin/java-debug";
+  # transport = "localhost:0";
+  # compile = graal-compile-command;
+  # start = "${java-debug}/bin/java-debug";
 
-    initializeMessage = {
-      command = "initialize";
-      arguments = {
-        adapterID = "cppdbg";
-        clientID = "replit";
-        clientName = "replit.com";
-        columnsStartAt1 = true;
-        linesStartAt1 = true;
-        locale = "en-us";
-        pathFormat = "path";
-        supportsInvalidatedEvent = true;
-        supportsProgressReporting = true;
-        supportsRunInTerminalRequest = true;
-        supportsVariablePaging = true;
-        supportsVariableType = true;
-      };
-    };
+  # initializeMessage = {
+  # command = "initialize";
+  # arguments = {
+  # adapterID = "cppdbg";
+  # clientID = "replit";
+  # clientName = "replit.com";
+  # columnsStartAt1 = true;
+  # linesStartAt1 = true;
+  # locale = "en-us";
+  # pathFormat = "path";
+  # supportsInvalidatedEvent = true;
+  # supportsProgressReporting = true;
+  # supportsRunInTerminalRequest = true;
+  # supportsVariablePaging = true;
+  # supportsVariableType = true;
+  # };
+  # };
 
-    launchMessage = {
-      command = "launch";
-      arguments = {
-        classPaths = [ "." ];
-        mainClass = "Main";
-      };
-    };
-  };
+  # launchMessage = {
+  # command = "launch";
+  # arguments = {
+  # classPaths = [ "." ];
+  # mainClass = "Main";
+  # };
+  # };
+  # };
 
   replit.dev.languageServers.java-language-server = {
     name = "Java Language Server";

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, ... }:
 
 let
-  graalvm = pkgs.graalvm19-ce;
+  graalvm = pkgs.graalvm-ce;
 
   graalvm-version = lib.versions.majorMinor graalvm.version;
 
@@ -9,11 +9,13 @@ let
 
   jdt-language-server = pkgs.callPackage ../../jdt-language-server { };
 
-  java-language-server = pkgs.java-language-server;
+  java-language-server = pkgs.java-language-server.override {
+    jdk = pkgs.graalvm-ce;
+  };
 
   java-debug = pkgs.callPackage ../../java-debug {
     inherit jdt-language-server;
-    jdk = pkgs.graalvm11-ce;
+    jdk = pkgs.graalvm-ce;
   };
 
   run-lsp = pkgs.writeShellScriptBin "run-lsp" ''

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 let
   nodejs = pkgs.nodejs-18_x;
 

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -1,10 +1,10 @@
 { nodejs }:
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 
 let
   community-version = lib.versions.major nodejs.version;
 
-  bun = pkgs-unstable.callPackage ../../bun { };
+  bun = pkgs.callPackage ../../bun { };
 
   nodepkgs = pkgs.nodePackages.override {
     inherit nodejs;

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 let
   python = pkgs.python310Full;
 

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -1,11 +1,11 @@
-{ pkgs-unstable, ... }:
+{ pkgs, ... }:
 
 {
   id = "svelte-kit-node-20";
   name = "SvelteKit with Node.js 20 Tools";
 
   replit = {
-    packages = with pkgs-unstable; [
+    packages = with pkgs; [
       nodejs
     ];
 
@@ -19,14 +19,14 @@
         ".ts"
       ];
 
-      start = "${pkgs-unstable.nodejs}/bin/npm run dev";
+      start = "${pkgs.nodejs}/bin/npm run dev";
     };
 
     dev.languageServers.svelte-language-server = {
       name = "Svelte Language Server";
       language = "svelte";
       extensions = [ ".svelte" ".js" ".ts" ];
-      start = "${pkgs-unstable.nodePackages.svelte-language-server}/bin/svelteserver --stdio";
+      start = "${pkgs.nodePackages.svelte-language-server}/bin/svelteserver --stdio";
     };
   };
 }

--- a/pkgs/pip/default.nix
+++ b/pkgs/pip/default.nix
@@ -26,7 +26,7 @@ pypkgs.buildPythonPackage rec {
     name = "${pname}-${version}-source";
   };
 
-  nativeBuildInputs = [ pypkgs.bootstrapped-pip ];
+  nativeBuildInputs = [ pypkgs.pip ];
 
   # pip detects that we already have bootstrapped_pip "installed", so we need
   # to force it a little.

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -60,6 +60,7 @@ in
   };
   "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
   "bun-1.0:v9-20231024-b3ba53c" = { to = "bun-1.0:v10-20231122-8e4093b"; auto = true; };
+  "bun-1.0:v10-20231122-8e4093b" = { to = "bun-1.0:v11-20231128-1e033d9"; auto = true; };
 
   "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
 
@@ -76,10 +77,13 @@ in
 // (fns.linearUpgrade "cpp-clang14")
 // (fns.linearUpgrade "docker")
 // (fns.linearUpgrade "dotnet-7.0")
+// (fns.linearUpgrade "gcloud")
 // (fns.linearUpgrade "go-1.20")
+// (fns.linearUpgrade "go-1.21")
 // (fns.linearUpgrade "haskell-ghc9.2")
 // (fns.linearUpgrade "java-graalvm22.3")
 // (fns.linearUpgrade "lua-5.2")
+// (fns.linearUpgrade "nix")
 // (fns.linearUpgrade "nodejs-14")
 // (fns.linearUpgrade "nodejs-16")
 // (fns.linearUpgrade "nodejs-18")


### PR DESCRIPTION
Why
===

it's annoying having multiple nix channels that affect some modules but not others. also it's a lot easier to keep things up-to-date and consistent when we're only using 1 channel. also 23.05 is almost deprecated, and our choices were to either:
- upgrade to 23.11
- stick with 23.05 as it becomes more and more out-of-date (things aren't always backported to the stable channel!)

What changed
============

- removed `nixos-23.05` channel input
- changed everything to rely on `nixpkgs-unstable` instead
- update usage of graalvm due to [upstream changes in how graalvm is versioned](https://github.com/NixOS/nixpkgs/pull/257433)
  - this is ok because afaict we're not using the java nixmodule anywhere anyways! will need to test more extensively once we move java templates over though
- removed the python 3.8 nixmodule from the current modules list due to a version incompatibility with `sphinx` (which i guess is somewhere in the dep tree)

Test plan
=========

- template tests still pass :)

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
