### PR TITLE
Added pip to PYTHONPATH

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -383,6 +383,10 @@
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/9wv2f51wrd8q1g70halnfifv9xp37xxd-replit-module-python-3.10"
   },
+  "python-3.10:v31-20231130-59c1f61": {
+    "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
+    "path": "/nix/store/m8gn71aym60dqc90vxn4f2jzphz1kn45-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -539,6 +543,10 @@
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/7amwcfydxmp3hc2f7gh8n4c36vhswlpa-replit-module-python-3.11"
   },
+  "python-3.11:v12-20231130-59c1f61": {
+    "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
+    "path": "/nix/store/z7dial30xxmm9w8p3qgb671l932694qj-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -582,6 +590,10 @@
   "python-3.8:v11-20231125-92f4109": {
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/hpsbrv4m18mp30zl75m2cx8fvirrj5ib-replit-module-python-3.8"
+  },
+  "python-3.8:v12-20231130-59c1f61": {
+    "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
+    "path": "/nix/store/zxz6j362h7p272vm045zlx5475a5lq8f-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -662,6 +674,10 @@
   "python-with-prybar-3.10:v9-20231125-92f4109": {
     "commit": "92f410905c0bb4ae9cd74de1068febb28c033a3b",
     "path": "/nix/store/vzjbca3vjs11fgqr4ax57djp101v8pph-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v10-20231130-59c1f61": {
+    "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
+    "path": "/nix/store/587d277k3zwfakwjjyaimw383j6lgsp2-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -17,7 +17,7 @@ let
   pip = import ./pip.nix (pkgs // {
     inherit python pypkgs;
   });
-  pip-wrapper = pythonWrapper { bin = "${pip}/bin/pip"; name = "pip"; };
+  pip-wrapper = pythonWrapper { bin = "${pip.bin}/bin/pip"; name = "pip"; };
 
   poetry = pkgs.callPackage (../../poetry/poetry-py + "${pythonVersion}.nix") {
     inherit python;
@@ -149,7 +149,7 @@ in
     POETRY_PIP_FROM_PATH = "1";
     POETRY_USE_USER_SITE = "1";
     PYTHONUSERBASE = userbase;
-    PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}";
+    PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}:${pip.pip}/${python.sitePackages}";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.

--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -28,13 +28,17 @@ let
     '';
   };
 in
-pkgs.writeShellScriptBin "pip" ''
-  flags=()
-  if [[ -n "$__REPLIT_PIP_CACHE_ENABLE" ]]; then
-    export PIP_CONFIG_FILE=${config-cache-enabled}
-    flags+=("--cache-dir=''${HOME}/.cache/pip")
-  else
-    export PIP_CONFIG_FILE=${config-cache-disabled}
-  fi
-  exec "${pip}/bin/pip" "''${flags[@]}" "$@"
-''
+{
+  bin = pkgs.writeShellScriptBin "pip" ''
+    flags=()
+    if [[ -n "$__REPLIT_PIP_CACHE_ENABLE" ]]; then
+      export PIP_CONFIG_FILE=${config-cache-enabled}
+      flags+=("--cache-dir=''${HOME}/.cache/pip")
+    else
+      export PIP_CONFIG_FILE=${config-cache-disabled}
+    fi
+    exec "${pip}/bin/pip" "''${flags[@]}" "$@"
+  '';
+
+  inherit pip;
+}


### PR DESCRIPTION
Why
===

Some packages call pip via `python -m pip` post install. This makes it available.

What changed
============

Added pip`s site-packages dir to `PYTHONPATH`.

Test plan
=========

should be able to install a package via `python -m pip install <package name>`