### PR TITLE
Added npx wrapper that would ensure .config/npm/node_global/lib exists

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -203,6 +203,10 @@
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/3jnfz8ad929wz8lpgll3wlmzhnas5mvn-replit-module-nodejs-18"
   },
+  "nodejs-18:v15-20231130-57acee0": {
+    "commit": "57acee003abb495ba1495f7c0f12fce02ee1a1b1",
+    "path": "/nix/store/1xaw2yx37325rcz2lnxm14rsdhxqlhmx-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -258,6 +262,10 @@
   "nodejs-20:v11-20231122-8e4093b": {
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/8hcddx7wafg406c3nifm0p2ygprfg7v2-replit-module-nodejs-20"
+  },
+  "nodejs-20:v12-20231130-57acee0": {
+    "commit": "57acee003abb495ba1495f7c0f12fce02ee1a1b1",
+    "path": "/nix/store/qxmfrhx1ghyxzm2n5273dm6b4203j7va-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -698,6 +706,10 @@
   "nodejs-with-prybar-18:v5-20231122-8e4093b": {
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/969wddvl49bzffhpp0sndcyr8dxsw436-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v6-20231130-57acee0": {
+    "commit": "57acee003abb495ba1495f7c0f12fce02ee1a1b1",
+    "path": "/nix/store/8lprg1xbs4nmicnx2z3vv803p5lpijhi-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -11,6 +11,11 @@ let
   };
 
   prettier = nodepkgs.prettier;
+
+  npx-wrapper = pkgs.writeShellScriptBin "npx" ''
+    mkdir -p ''${XDG_CONFIG_HOME}/npm/node_global/lib
+    ${nodejs}/bin/npx "$@"
+  '';
 in
 
 {
@@ -110,7 +115,7 @@ in
     env = {
       XDG_CONFIG_HOME = "$REPL_HOME/.config";
       npm_config_prefix = "$REPL_HOME/.config/npm/node_global";
-      PATH = "$REPL_HOME/.config/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
+      PATH = "${npx-wrapper}/bin:$XDG_CONFIG_HOME/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
     };
 
   };


### PR DESCRIPTION
Why
===

If you start with an empty repl and add the nodejs module, then run `npx create-react-app`, npx would try to install executables globally in `$REPL_HOME/.config/npm/node_global/lib` and would fail if it didn't exist. This ensures that directory exists.

What changed
============

Created a wrapper for npx that would ensure that directory.

Test plan
=========

1. create blank repl
2. add nodejs module
3. `npx create-react-app` and see it work