### PR TITLE
fix haskell lsp

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -95,6 +95,10 @@
     "commit": "2eab632aca70d4b8794f7ba474081da7ce86af72",
     "path": "/nix/store/ysn8kiqwk2r9mqncph9ywkr6g1lf2ysb-replit-module-haskell-ghc9.2"
   },
+  "haskell-ghc9.2:v3-20231130-4c6f231": {
+    "commit": "4c6f2315da24b84bd5e9dfedb952e41677724aaa",
+    "path": "/nix/store/5lddnmf36g258sgqbjwbn06ndfpfiyl7-replit-module-haskell-ghc9.2"
+  },
   "java-graalvm22.3:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7zjcdf4z9d0dhwg13cs3xb1rj248m8ri-replit-module-java-graalvm22.3"

--- a/pkgs/modules/haskell/default.nix
+++ b/pkgs/modules/haskell/default.nix
@@ -32,6 +32,6 @@ in
     name = "Haskell Language Server";
     language = "haskell";
 
-    start = "${pkgs.haskell-language-server}/bin/haskell-language-server-wrapper --lsp";
+    start = "${pkgs.haskellPackages.haskell-language-server}/bin/haskell-language-server --lsp";
   };
 }


### PR DESCRIPTION
Why
===

currently the haskell module uses `haskell-language-server-wrapper` which has an infinite spinner in the lsp indicator. i think this is because the wrapper is doing something weird when trying to [pick the right GHC from PATH](https://github.com/NixOS/nixpkgs/blob/0b35753f0128c4a34d6712e60b0a23f893665f31/doc/languages-frameworks/haskell.section.md?plain=1#L769-L771)?

What changed
============

don't use `haskell-language-server-wrapper`, just use `haskell-language-server`

Test plan
=========

1. open haskell repl
2. open `Main.hs`
3. lsp spinner stops spinning eventually

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
