### PR TITLE
Improve ruby support

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -427,6 +427,10 @@
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/1qlvg6wh8wg7il1njmsspr6fhda9bdgj-replit-module-ruby-3.1"
   },
+  "ruby-3.1:v3-20231130-c16dd76": {
+    "commit": "c16dd76d69047cb0cccdd37b39c6163b130368a6",
+    "path": "/nix/store/0nlckd8698v5cr1nlkmdr2bqh82xipvh-replit-module-ruby-3.1"
+  },
   "rust-1.69:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/xkp307fdmgwn8dnbqadzlrb8fr0bvkx4-replit-module-rust-1.69"
@@ -758,5 +762,9 @@
   "docker:v7-20231129-8a00f4c": {
     "commit": "8a00f4c802548dd05d00ecc3a04589d442e917f9",
     "path": "/nix/store/yq9n8rm0spjxcq9407fh756vjl06p44a-replit-module-docker"
+  },
+  "ruby-3.2:v1-20231130-c16dd76": {
+    "commit": "c16dd76d69047cb0cccdd37b39c6163b130368a6",
+    "path": "/nix/store/2n9kykvlhk9h1xp6d99839wqf6bd7hl6-replit-module-ruby-3.2"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -62,7 +62,14 @@ let
     (import ./php)
     (import ./qbasic)
     (import ./R)
-    (import ./ruby)
+    (import ./ruby {
+      ruby = pkgs.ruby_3_1;
+      rubyPackages = pkgs.rubyPackages_3_1;
+    })
+    (import ./ruby {
+      ruby = pkgs.ruby_3_2;
+      rubyPackages = pkgs.rubyPackages_3_2;
+    })
     (import ./svelte-kit)
     (import ./web)
   ];

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -95,6 +95,7 @@ in
 // (fns.linearUpgrade "qbasic")
 // (fns.linearUpgrade "r-4.2")
 // (fns.linearUpgrade "ruby-3.1")
+// (fns.linearUpgrade "ruby-3.2")
 // (fns.linearUpgrade "rust-stable")
 // (fns.linearUpgrade "svelte-kit-node-20")
 // (fns.linearUpgrade "swift-5.8")


### PR DESCRIPTION
Why
===

When executables are included with a ruby Gem, they are not made available on the path. Also, initially if you don't have a ruby Gem file, bundle install will fail.

What changed
============

1. added bundle wrapper to automatically create a `Gemfile` if needed
2. added ruby executable path to PATH
3. added ruby 3.2

Test plan
=========

1. create blank repl
2. add ruby module
3. add a dependency like `whenever` in Gemfile
4. bundle install
5. be able to execute `whenever`