### PR TITLE
comment out template-tests release-channel

### DIFF
--- a/manifests/service.pvn.yaml
+++ b/manifests/service.pvn.yaml
@@ -38,11 +38,11 @@ service:
                 "version":"{{.Params.nixmodules_version}}",
                 "configPullJitter":"1s"
               }
-    - releaseChannel: test-templates
-      externalConfig:
-        type: KUBERNETES
-        local:
-          path: test_templates.yaml
+    # - releaseChannel: test-templates
+    #   externalConfig:
+    #     type: KUBERNETES
+    #     local:
+    #       path: test_templates.yaml
 
 
     - releaseChannel: tarpit


### PR DESCRIPTION
Why
===

we're temp disabling template tests and this failed the ci build

What changed
============

commented out `template-tests` releaseChannel from the service config

Test plan
=========

ci build passes

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
