### PR TITLE
make things unstable again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "lastModified": 1701336116,
+        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,9 @@
         ];
       };
 
-      pkgs = mkPkgs nixpkgs "x86_64-linux";
+      pkgs-23_05 = mkPkgs nixpkgs "x86_64-linux";
 
-      pkgs-unstable = mkPkgs nixpkgs-unstable "x86_64-linux";
+      pkgs = mkPkgs nixpkgs-unstable "x86_64-linux";
     in
     {
       overlays.default = final: prev: {
@@ -56,7 +56,7 @@
     } // (
       import ./pkgs/modules {
         inherit pkgs;
-        inherit pkgs-unstable;
+        inherit pkgs-23_05;
       }
     );
 }

--- a/modules.json
+++ b/modules.json
@@ -35,6 +35,10 @@
     "commit": "f6dc97c19cbc64d2a271be3ba829b87fd5237328",
     "path": "/nix/store/62vlf5i47d5d60181w31n6zf1xfy2s0y-replit-module-c-clang14"
   },
+  "c-clang14:v4-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/v01i01qw2flhznwhwdkghwng6f4xcqqx-replit-module-c-clang14"
+  },
   "clojure-1.11:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/giqq76fl3yphzsm6rkl1qxqh4mszknpl-replit-module-clojure-1.11"
@@ -42,6 +46,10 @@
   "clojure-1.11:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/jvz8pm6gj0h58x1r0c19ypkcpswriq5a-replit-module-clojure-1.11"
+  },
+  "clojure-1.11:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/axlx5zj2ialp7c5fsh77b7j55w98aw0y-replit-module-clojure-1.11"
   },
   "cpp-clang14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -54,6 +62,10 @@
   "cpp-clang14:v3-20231025-f6dc97c": {
     "commit": "f6dc97c19cbc64d2a271be3ba829b87fd5237328",
     "path": "/nix/store/mllwdnixmcd6qxy1aw1pxqqjj2wknvpc-replit-module-cpp-clang14"
+  },
+  "cpp-clang14:v4-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/3r1ghq42va9d5k5x4q3r8iss3pmjnsvm-replit-module-cpp-clang14"
   },
   "dart-2.18:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -70,6 +82,10 @@
   "dotnet-7.0:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/rim896frw7wg1qg8bwihgr3yhdn17clx-replit-module-dotnet-7.0"
+  },
+  "dotnet-7.0:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/rhzck8k02swffyv8xw5dfiglnj7xndbs-replit-module-dotnet-7.0"
   },
   "go-1.19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -119,6 +135,10 @@
     "commit": "e90307852a07b902d59416d439fcb8a07b44abae",
     "path": "/nix/store/dzdibp0r2y4b4rzvz9yrivjjn2vk5v0d-replit-module-java-graalvm22.3"
   },
+  "java-graalvm22.3:v6-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/awjzprg822p6dfjd46gixwgig1jjl137-replit-module-java-graalvm22.3"
+  },
   "lua-5.2:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/d6a5wl9pyla9si60plaxzmhqggywkcxy-replit-module-lua-5.2"
@@ -126,6 +146,10 @@
   "lua-5.2:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/r9lznvivd7idrx3skvazs64lv99m00l7-replit-module-lua-5.2"
+  },
+  "lua-5.2:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/zrjzfrbssh51j5086iyl51k471k1rhjn-replit-module-lua-5.2"
   },
   "nodejs-14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -211,6 +235,10 @@
     "commit": "57acee003abb495ba1495f7c0f12fce02ee1a1b1",
     "path": "/nix/store/1xaw2yx37325rcz2lnxm14rsdhxqlhmx-replit-module-nodejs-18"
   },
+  "nodejs-18:v16-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/i2mjh2jv0409y9ypqmprhsargjyl7r0b-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -270,6 +298,10 @@
   "nodejs-20:v12-20231130-57acee0": {
     "commit": "57acee003abb495ba1495f7c0f12fce02ee1a1b1",
     "path": "/nix/store/qxmfrhx1ghyxzm2n5273dm6b4203j7va-replit-module-nodejs-20"
+  },
+  "nodejs-20:v13-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/9ng3nyfp4q336b96hl05sqrdi44z51cy-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -399,6 +431,10 @@
     "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
     "path": "/nix/store/m8gn71aym60dqc90vxn4f2jzphz1kn45-replit-module-python-3.10"
   },
+  "python-3.10:v32-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/slhans49675zm6qawq00kddvnxg8anba-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -406,6 +442,10 @@
   "qbasic:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/kb4nnw1mggda2xagy3r5g83v3gkpl7rs-replit-module-qbasic"
+  },
+  "qbasic:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/nnmhhbfhhqh7jph149wp6395p1zbf8kv-replit-module-qbasic"
   },
   "r-4.2:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -431,6 +471,10 @@
     "commit": "c16dd76d69047cb0cccdd37b39c6163b130368a6",
     "path": "/nix/store/0nlckd8698v5cr1nlkmdr2bqh82xipvh-replit-module-ruby-3.1"
   },
+  "ruby-3.1:v4-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/lpiq8qi19dkfypwk36bdnmnis95iq5hh-replit-module-ruby-3.1"
+  },
   "rust-1.69:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/xkp307fdmgwn8dnbqadzlrb8fr0bvkx4-replit-module-rust-1.69"
@@ -455,6 +499,10 @@
     "commit": "5c14992744871ffcb60fe619b0314b4e92195948",
     "path": "/nix/store/hmzl37s9mykls9rdcfahdpk3k87dyv05-replit-module-swift-5.8"
   },
+  "swift-5.8:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/zn5hcn3a9hc6wjkh84y6r33qx0nn5p3x-replit-module-swift-5.8"
+  },
   "web:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7lhwlqy8nmrmc27n68ia16q6bn27cwk5-replit-module-web"
@@ -462,6 +510,10 @@
   "web:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
     "path": "/nix/store/53vn26l79zj17g28xlfki4d3j3ra7nbi-replit-module-web"
+  },
+  "web:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/840hs6bdk6y3yix8233y647qj4dhf801-replit-module-web"
   },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
@@ -495,6 +547,10 @@
     "commit": "d4ad2e4453adf8dc310fe700f38d125361906606",
     "path": "/nix/store/5w2h6ynxsq16i4qxqa8cb5d5k362zd9l-replit-module-pyright-extended"
   },
+  "pyright-extended:v9-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/wp41hrrcl7jf05mdqp3aag7wz9vahcsj-replit-module-pyright-extended"
+  },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
@@ -511,9 +567,17 @@
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/xnl830xrhx5s121q12j5dyyjn8rx9f7v-replit-module-svelte-kit-node-20"
   },
+  "svelte-kit-node-20:v5-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/0nnxfl8lw1icmikv7sqai1lxh9ayqnp0-replit-module-svelte-kit-node-20"
+  },
   "gcloud:v1-20230815-e6e4431": {
     "commit": "e6e4431a8f1d71ec0664ce97828bede1608dcfd1",
     "path": "/nix/store/q67zzk6y4zzw7k6nc2plql97z1yv7xwx-replit-module-gcloud"
+  },
+  "gcloud:v2-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/yrn99f1xjv5ngz688z0d3ja8vckrmyrq-replit-module-gcloud"
   },
   "python-3.11:v1-20230828-e4baa21": {
     "commit": "e4baa21ed52b51e2a4963fc8136f211a2b277455",
@@ -563,6 +627,10 @@
     "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
     "path": "/nix/store/z7dial30xxmm9w8p3qgb671l932694qj-replit-module-python-3.11"
   },
+  "python-3.11:v13-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/41sag25dccvpsfn7s352c3d5yl73dfs4-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -611,6 +679,10 @@
     "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
     "path": "/nix/store/zxz6j362h7p272vm045zlx5475a5lq8f-replit-module-python-3.8"
   },
+  "python-3.8:v13-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/garcxs0d33hqsqc2waq1bbirghkw0wjz-replit-module-python-3.8"
+  },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/qf9aiylryg8lq5q4z7fcj11824k9rf17-replit-module-bun-1.0"
@@ -651,6 +723,10 @@
     "commit": "8e4093b04ee2ee229214e76f65cf4cb595b1983f",
     "path": "/nix/store/pwwa3b8dhfxmrn7s2qhl676x5la51yx0-replit-module-bun-1.0"
   },
+  "bun-1.0:v11-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/12wfwfqlzw3k4lw2qrk3nv9vxqwi35w1-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -658,6 +734,10 @@
   "nix:v1-20230906-ff49114": {
     "commit": "ff491143e779453de50b979dc7dd35ac0f2ef40a",
     "path": "/nix/store/4lhzsk1lq4hirb9fp6hv43w56cq88lpi-replit-module-nix"
+  },
+  "nix:v2-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/i5d4f6kqrcvhyyl6si55yx6l16k3dn8p-replit-module-nix"
   },
   "python-with-prybar-3.10:v2-20230925-77b13e4": {
     "commit": "77b13e434deb254c3792ddd97191586c193a83a6",
@@ -695,6 +775,10 @@
     "commit": "59c1f618081855afeb1d860d347fde86b3c55285",
     "path": "/nix/store/587d277k3zwfakwjjyaimw383j6lgsp2-replit-module-python-with-prybar-3.10"
   },
+  "python-with-prybar-3.10:v11-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/h7h46r4vhhmpq759q86cc04bwf3nwnra-replit-module-python-with-prybar-3.10"
+  },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",
     "path": "/nix/store/8v3laig35f30bvgw8mwjcsznk06l7vf3-replit-module-nodejs-with-prybar-18"
@@ -719,6 +803,10 @@
     "commit": "57acee003abb495ba1495f7c0f12fce02ee1a1b1",
     "path": "/nix/store/8lprg1xbs4nmicnx2z3vv803p5lpijhi-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v7-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/l0f79r9g4927sm2md0hl7533h2cgs72r-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -731,9 +819,17 @@
     "commit": "2b03dda306d47934f45b8a2402fecc6944a6f956",
     "path": "/nix/store/1wbmhhf77wpnagflz7p2wjscrgdilc7l-replit-module-rust-stable"
   },
+  "rust-stable:v3-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/3mlmwa3s1xpd6mi0gqbj7vdmqprv8cry-replit-module-rust-stable"
+  },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
+  },
+  "go-1.21:v2-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/k1r5v290m5q2daypz9j073ywk72cssac-replit-module-go-1.21"
   },
   "docker:v1-20231026-3990bf0": {
     "commit": "3990bf05353ec3cffd54b8376616fdf6165d4580",
@@ -763,8 +859,32 @@
     "commit": "8a00f4c802548dd05d00ecc3a04589d442e917f9",
     "path": "/nix/store/yq9n8rm0spjxcq9407fh756vjl06p44a-replit-module-docker"
   },
+  "docker:v8-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/26g4nkrndbf2bf50fp17cp8rl5xdz1gi-replit-module-docker"
+  },
   "ruby-3.2:v1-20231130-c16dd76": {
     "commit": "c16dd76d69047cb0cccdd37b39c6163b130368a6",
     "path": "/nix/store/2n9kykvlhk9h1xp6d99839wqf6bd7hl6-replit-module-ruby-3.2"
+  },
+  "ruby-3.2:v2-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/n7z1p1kx7bad52bzam4jwgs6jhdhirdm-replit-module-ruby-3.2"
+  },
+  "dart-3.1:v1-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/ra46cfdhzrp1gn6rh4l5nnycn3vjv18l-replit-module-dart-3.1"
+  },
+  "haskell-ghc9.4:v1-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/fiqw30g509xf59k0f26ashjbvd91zphs-replit-module-haskell-ghc9.4"
+  },
+  "php-8.2:v1-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/8whfz8mxysaz299a54kvpm0a96gc89v3-replit-module-php-8.2"
+  },
+  "r-4.3:v1-20231201-3b22c78": {
+    "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
+    "path": "/nix/store/naz6n9b9fd8swy5yb2i9sn4haw4h3c48-replit-module-r-4.3"
   }
 }

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,5 +1,5 @@
-{ pkgs ? import <nixpkgs> { }
-, pkgs-unstable ? import <nixpkgs-unstable> { }
+{ pkgs ? import <nixpkgs-unstable> { }
+, pkgs-23_05 ? import <nixpkgs-stable-23_05> { }
 , configPath
 , deployment ? false
 }:
@@ -10,7 +10,7 @@ let
       (import ./module-definition.nix)
     ];
     specialArgs = {
-      inherit pkgs pkgs-unstable;
+      inherit pkgs pkgs-23_05;
       modulesPath = builtins.toString ./.;
     };
   });

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -1,7 +1,7 @@
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 
 let
-  bun = pkgs-unstable.callPackage ../../bun { };
+  bun = pkgs.callPackage ../../bun { };
 
   extensions = [ ".json" ".js" ".jsx" ".ts" ".tsx" ];
 

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,27 +1,27 @@
-{ pkgs, pkgs-unstable }:
+{ pkgs, pkgs-23_05 }:
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-unstable;
+    inherit pkgs-23_05;
   };
   mkDeploymentModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-unstable;
+    inherit pkgs-23_05;
     deployment = true;
   };
 
   modulesList = [
     (import ./python {
-      python = pkgs.python38Full;
-      pypkgs = pkgs.python38Packages;
+      python = pkgs-23_05.python38Full;
+      pypkgs = pkgs-23_05.python38Packages;
     })
     (import ./python {
-      python = pkgs.python310Full;
-      pypkgs = pkgs.python310Packages;
+      python = pkgs-23_05.python310Full;
+      pypkgs = pkgs-23_05.python310Packages;
     })
     (import ./python {
-      python = pkgs.python311Full;
-      pypkgs = pkgs.python311Packages;
+      python = pkgs-23_05.python311Full;
+      pypkgs = pkgs-23_05.python311Packages;
     })
     (import ./python-with-prybar)
 
@@ -39,9 +39,9 @@ let
       inherit (pkgs) go gopls;
     })
     (import ./go {
-      go = pkgs-unstable.go_1_21;
-      gopls = pkgs-unstable.gopls.override {
-        buildGoModule = pkgs-unstable.buildGo121Module;
+      go = pkgs.go_1_21;
+      gopls = pkgs.gopls.override {
+        buildGoModule = pkgs.buildGo121Module;
       };
     })
 

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -1,10 +1,10 @@
-{ pkgs, pkgs-unstable, ... }:
+{ pkgs, ... }:
 
 let
 
   configFiles = pkgs.copyPathToStore ./etc;
 
-  replit-runc = pkgs-unstable.buildGo121Module {
+  replit-runc = pkgs.buildGo121Module {
     pname = "replit-runc";
     version = "1.1.9+replit";
 
@@ -30,7 +30,7 @@ let
     '';
   };
 
-  replit-containerd = pkgs-unstable.buildGo121Module {
+  replit-containerd = pkgs.buildGo121Module {
     pname = "replit-containerd";
     version = "1.7.5+replit";
 
@@ -65,7 +65,7 @@ let
     replitShimRunc = replit-containerd;
   };
 
-  replit-buildkit = pkgs-unstable.buildGo121Module {
+  replit-buildkit = pkgs.buildGo121Module {
     pname = "replit-buildkit";
     version = "v0.13.0-beta1+replit";
 

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -1,6 +1,8 @@
-{ pkgs, lib, ... }:
+{ pkgs-23_05, lib, ... }:
 
 let
+  pkgs = pkgs-23_05;
+
   graalvm = pkgs.graalvm19-ce;
 
   graalvm-version = lib.versions.majorMinor graalvm.version;

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 let
   nodejs = pkgs.nodejs-18_x;
 

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -1,10 +1,10 @@
 { nodejs }:
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, lib, ... }:
 
 let
   community-version = lib.versions.major nodejs.version;
 
-  bun = pkgs-unstable.callPackage ../../bun { };
+  bun = pkgs.callPackage ../../bun { };
 
   nodepkgs = pkgs.nodePackages.override {
     inherit nodejs;

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -1,22 +1,23 @@
-{ pkgs, pkgs-unstable, lib, ... }:
+{ pkgs, pkgs-23_05, lib, ... }:
 let
-  python = pkgs.python310Full;
+  python = pkgs-23_05.python310Full;
 
-  pypkgs = pkgs.python310Packages;
+  pypkgs = pkgs-23_05.python310Packages;
 
   pythonVersion = lib.versions.majorMinor python.version;
 
   pythonUtils = import ../../python-utils {
-    inherit pkgs python pypkgs;
+    inherit python pypkgs;
+    pkgs = pkgs-23_05;
   };
 
   pythonWrapper = pythonUtils.pythonWrapper;
 
   prybar-python-version = lib.strings.concatStrings (lib.strings.splitString "." pythonVersion);
 
-  stderred = pkgs.callPackage ../../stderred { };
+  stderred = pkgs-23_05.callPackage ../../stderred { };
 
-  run-prybar-bin = pkgs.writeShellScriptBin "run-prybar" ''
+  run-prybar-bin = pkgs-23_05.writeShellScriptBin "run-prybar" ''
     ${stderred}/bin/stderred -- ${pkgs.prybar."prybar-python${prybar-python-version}"}/bin/prybar-python${prybar-python-version} -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i ''$1
   '';
 

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -1,6 +1,8 @@
 { python, pypkgs }:
-{ pkgs, lib, ... }:
+{ pkgs-23_05, lib, ... }:
 let
+  pkgs = pkgs-23_05;
+
   pythonVersion = lib.versions.majorMinor python.version;
 
   pylibs-dir = ".pythonlibs";

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -1,11 +1,11 @@
-{ pkgs-unstable, ... }:
+{ pkgs, ... }:
 
 {
   id = "svelte-kit-node-20";
   name = "SvelteKit with Node.js 20 Tools";
 
   replit = {
-    packages = with pkgs-unstable; [
+    packages = with pkgs; [
       nodejs
     ];
 
@@ -19,14 +19,14 @@
         ".ts"
       ];
 
-      start = "${pkgs-unstable.nodejs}/bin/npm run dev";
+      start = "${pkgs.nodejs}/bin/npm run dev";
     };
 
     dev.languageServers.svelte-language-server = {
       name = "Svelte Language Server";
       language = "svelte";
       extensions = [ ".svelte" ".js" ".ts" ];
-      start = "${pkgs-unstable.nodePackages.svelte-language-server}/bin/svelteserver --stdio";
+      start = "${pkgs.nodePackages.svelte-language-server}/bin/svelteserver --stdio";
     };
   };
 }

--- a/pkgs/modules/swift/default.nix
+++ b/pkgs/modules/swift/default.nix
@@ -1,5 +1,6 @@
-{ pkgs, lib, ... }:
+{ pkgs-23_05, lib, ... }:
 let
+  pkgs = pkgs-23_05;
   swift-version = lib.versions.majorMinor pkgs.swift.version;
 
   swiftc-wrapper = pkgs.stdenv.mkDerivation {

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -6,8 +6,7 @@ let
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postInstall = ''
       wrapProgram "$out/bin/typescript-language-server" \
-        --suffix PATH : ${pkgs.lib.makeBinPath [ nodepkgs.typescript ]} \
-        --add-flags "--tsserver-path ${nodepkgs.typescript}/lib/node_modules/typescript/lib/"
+        --suffix PATH : ${pkgs.lib.makeBinPath [ nodepkgs.typescript ]}
     '';
   };
 in
@@ -16,5 +15,9 @@ in
     name = "TypeScript Language Server";
     language = "javascript";
     start = "${typescript-language-server}/bin/typescript-language-server --stdio";
+
+    initializationOptions = {
+      tsserver.path = "${nodepkgs.typescript}/lib/node_modules/typescript/lib";
+    };
   };
 }

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -60,6 +60,7 @@ in
   };
   "bun-1.0:v8-20231013-f38c84f" = { to = "bun-1.0:v9-20231024-b3ba53c"; auto = true; };
   "bun-1.0:v9-20231024-b3ba53c" = { to = "bun-1.0:v10-20231122-8e4093b"; auto = true; };
+  "bun-1.0:v10-20231122-8e4093b" = { to = "bun-1.0:v11-20231201-3b22c78"; auto = true; };
 
   "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
 
@@ -76,10 +77,13 @@ in
 // (fns.linearUpgrade "cpp-clang14")
 // (fns.linearUpgrade "docker")
 // (fns.linearUpgrade "dotnet-7.0")
+// (fns.linearUpgrade "gcloud")
 // (fns.linearUpgrade "go-1.20")
+// (fns.linearUpgrade "go-1.21")
 // (fns.linearUpgrade "haskell-ghc9.2")
 // (fns.linearUpgrade "java-graalvm22.3")
 // (fns.linearUpgrade "lua-5.2")
+// (fns.linearUpgrade "nix")
 // (fns.linearUpgrade "nodejs-14")
 // (fns.linearUpgrade "nodejs-16")
 // (fns.linearUpgrade "nodejs-18")


### PR DESCRIPTION
Why
===

we want to move towards always having the latest and greatest instead of pinning to a convenient nixpkgs channel. this is a more moderate attempt at #184 that doesn't attempt to remove all of `nixos-23.05` but instead makes `nixpkgs-unstable` the default pkgs channel to us in modules.

as such, we'll be able to maintain `java` and (more importantly) all python nixmodules until we find a way to build them with unstable

What changed
============

- updated `nixpkgs-unstable` input
- set `pkgs` to `nixpkgs-unstable` for all nixmodules
- set `pkgs-23_05` to `nixos-23.05`

Test plan
=========

- node/python tests pass

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
