### PR TITLE
Add html to prettier node module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -239,6 +239,10 @@
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/i2mjh2jv0409y9ypqmprhsargjyl7r0b-replit-module-nodejs-18"
   },
+  "nodejs-18:v17-20231206-9a12353": {
+    "commit": "9a12353905c85260e57f6533f3f38b8e304a3087",
+    "path": "/nix/store/lj77k1jq6igdm7iz5fav95f7r9dvb53k-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -302,6 +306,10 @@
   "nodejs-20:v13-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/9ng3nyfp4q336b96hl05sqrdi44z51cy-replit-module-nodejs-20"
+  },
+  "nodejs-20:v14-20231206-9a12353": {
+    "commit": "9a12353905c85260e57f6533f3f38b8e304a3087",
+    "path": "/nix/store/xzfjgf2svr4vwa237s67y0cvv940c4hb-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -806,6 +814,10 @@
   "nodejs-with-prybar-18:v7-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/l0f79r9g4927sm2md0hl7533h2cgs72r-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v8-20231206-9a12353": {
+    "commit": "9a12353905c85260e57f6533f3f38b8e304a3087",
+    "path": "/nix/store/pl651b4mwsrmq1x6yxpxpcvrhi60razm-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -95,7 +95,7 @@ in
     dev.formatters.prettier = {
       name = "Prettier";
       language = "javascript";
-      extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ];
+      extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".html" ];
       start = {
         args = [ "${prettier}/bin/prettier" "--stdin-filepath" "$file" ];
       };


### PR DESCRIPTION
Why
===

See thread https://replit.slack.com/archives/C85MLAXU2/p1701883039006899

_Describe what prompted you to make this change, link relevant resources_

What changed
============

We can let prettier support formatting HTML files when the user has the node nixmodule installed. This is the case in things like our "react javascript" template today.

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

Try formatting an HTML file after this rolls out.

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
