### PR TITLE
fix moduleit test

### DIFF
--- a/scripts/moduleit_test.sh
+++ b/scripts/moduleit_test.sh
@@ -1,10 +1,10 @@
 #! /usr/bin/env bash
 
-nixpkgs_rev=$(nix run --inputs-from . nixpkgs#jq -- -r '.nodes.nixpkgs.locked.rev' flake.lock)
+nixpkgs_rev=$(nix run --inputs-from . nixpkgs#jq -- -r '.nodes."nixpkgs-unstable".locked.rev' flake.lock)
 cd /tmp
 curl "https://github.com/nixos/nixpkgs/archive/${nixpkgs_rev}.tar.gz" -L -o nixpkgs.tar.gz
 tar xzf "nixpkgs.tar.gz"
-export NIX_PATH="nixpkgs=$PWD/nixpkgs-${nixpkgs_rev}"
+export NIX_PATH="nixpkgs-unstable=$PWD/nixpkgs-${nixpkgs_rev}"
 cd -
 cd pkgs/moduleit
 ./moduleit.sh example.nix


### PR DESCRIPTION
Why
===

CI is failing. The moduleit test errors due to switching everything to nixpkgs-unstable.

What changed
============

Modified refs to nixpkgs-unstable.

Test plan
=========

CI passses.