### PR TITLE
vendorSha256 is deprecated

### DIFF
--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -21,7 +21,7 @@ let
 
     subPackages = [ "./" ];
 
-    vendorSha256 = null;
+    vendorHash = null;
 
     doCheck = false;
 
@@ -47,7 +47,7 @@ let
 
     subPackages = [ "./cmd/containerd" "./cmd/ctr" "./cmd/containerd-shim-runc-v2" ];
 
-    vendorSha256 = null;
+    vendorHash = null;
 
     doCheck = false;
 
@@ -81,7 +81,7 @@ let
 
     subPackages = [ "./cmd/buildkitd" "./cmd/buildctl" ];
 
-    vendorSha256 = null;
+    vendorHash = null;
 
     doCheck = false;
 


### PR DESCRIPTION
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead

Why
===

When evaluating nix, this warning is displayed

What changed
============

Replaced `vendorSha256` with `vendorHash` directly

Test plan
=========

- Verify that tests pass
- Listen for PagerDuty

Rollout
=======

- [ ] This is fully backward and forward compatible