### PR TITLE
initial replit module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -954,5 +954,9 @@
   "r-4.3:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/naz6n9b9fd8swy5yb2i9sn4haw4h3c48-replit-module-r-4.3"
+  },
+  "replit:v1-20231211-d5ddcff": {
+    "commit": "d5ddcff9419456ecf54d2582c4b1cc4242198ac0",
+    "path": "/nix/store/lljp25m1lvjs4kvz24rpdfifx4qn2jrj-replit-module-replit"
   }
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -66,7 +66,7 @@ rec {
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };
 
   bundle-squashfs = bundle-squashfs-fn {
-    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" ];
+    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" ];
     diskName = "disk.sqsh";
   };
 
@@ -75,7 +75,7 @@ rec {
     # publish your feature branch first and make sure modules.json is current, then
     # in goval dir (next to nixmodules), run `make custom-nixmodules-disk` to use this disk in conman
     # There is no need to check in changes to this.
-    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" ];
+    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" ];
     diskName = "disk.sqsh";
   };
 

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -62,6 +62,7 @@ let
     (import ./php)
     (import ./qbasic)
     (import ./R)
+    (import ./replit)
     (import ./ruby {
       ruby = pkgs.ruby_3_1;
       rubyPackages = pkgs.rubyPackages_3_1;

--- a/pkgs/modules/replit/default.nix
+++ b/pkgs/modules/replit/default.nix
@@ -1,0 +1,51 @@
+{ lib, pkgs, ... }:
+
+let
+  # use changes from https://github.com/tamasfe/taplo/pull/510
+  # the above PR adds the `-c` flag to the `taplo lsp` command, which is
+  # necessary to support our schema. There are a couple of paths forward
+  # for replacing this derivation:
+  # option 1:
+  # - the above pr is merged
+  # - new taplo version is released https://github.com/tamasfe/taplo/pull/502 (with my change)
+  # - nixpkgs-unstable gets the updated version
+  # - we update to nixpkgs-unstable that contains the updated taplo version
+  # option 2:
+  # - given that taplo currently consumes >1 mb of memory, it'd be nice to have
+  #   a custom bin that wraps taplo-lsp crate that *only* provides lsp for .replit
+  #   files. this should reduce the amount of consumed memory by a good amount.
+  # - use the above custom bin
+  taplo = pkgs.rustPlatform.buildRustPackage rec {
+    pname = "taplo";
+    version = "0.patched";
+    src = pkgs.fetchFromGitHub {
+      owner = "cdmistman";
+      repo = "taplo";
+      rev = "22eff1f7775e48eee8b50518c67f992b4595ab61";
+      hash = "sha256-63fm8pH03TJd4QBuhIxtttoEAaBnc9TuHGKCMK4YGP0=";
+    };
+
+    cargoHash = "sha256-4OSCN2zCrlBHihZn7TCNZp4mCREpvrpKsfMSNP95GNc=";
+    buildFeatures = [ "lsp" ];
+  };
+
+  taplo-config = pkgs.writeText "taplo-config.toml" ''
+    include = ["**/.replit"]
+
+    [schema]
+    enabled = true
+    path = "${./dotreplit-schema.json}"
+  '';
+in
+
+{
+  id = "replit";
+  name = "Base Replit Tools";
+
+  replit.dev.languageServers.dotreplit-lsp = {
+    name = ".replit LSP";
+    language = "dotreplit";
+    start = "${taplo}/bin/taplo lsp -c ${taplo-config} stdio";
+  };
+}
+

--- a/pkgs/modules/replit/dotreplit-schema.json
+++ b/pkgs/modules/replit/dotreplit-schema.json
@@ -1,0 +1,661 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/DotReplit",
+  "definitions": {
+    "DotReplit": {
+      "title": ".replit file",
+      "description": "Configuration for your Replit Repl.",
+      "type": "object",
+      "properties": {
+        "onBoot": {
+          "$ref": "#/definitions/Command"
+        },
+        "run": {
+          "$ref": "#/definitions/Command"
+        },
+        "compile": {
+          "$ref": "#/definitions/Command"
+        },
+        "language": {
+          "type": "string"
+        },
+        "audio": {
+          "type": "boolean"
+        },
+        "entrypoint": {
+          "type": "string"
+        },
+        "disableInstallBeforeRun": {
+          "type": "boolean"
+        },
+        "disableGuessImports": {
+          "type": "boolean"
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "debugger": {
+          "$ref": "#/definitions/DebuggerConfig"
+        },
+        "packager": {
+          "$ref": "#/definitions/PackagerConfig"
+        },
+        "interp": {
+          "$ref": "#/definitions/InterpConfig"
+        },
+        "unitTest": {
+          "$ref": "#/definitions/UnitTestConfig"
+        },
+        "hidden": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nix": {
+          "$ref": "#/definitions/NixConfig"
+        },
+        "languages": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/LanguageConfig"
+          }
+        },
+        "hosting": {
+          "$ref": "#/definitions/HostingConfig"
+        },
+        "auth": {
+          "$ref": "#/definitions/AuthConfig"
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HintConfig"
+          }
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortConfig"
+          }
+        },
+        "githubImport": {
+          "$ref": "#/definitions/GitHubImportConfig"
+        },
+        "refreshWebViewOnFileChange": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deployment": {
+          "$ref": "#/definitions/DeploymentConfig"
+        },
+        "modules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+	  }
+        },
+        "inotifyDebounceDuration": {
+          "type": "string"
+        },
+        "extension": {
+          "$ref": "#/definitions/ExtensionConfig"
+        },
+        "rules": {
+          "$ref": "#/definitions/RulesConfig"
+        },
+        "suggestions": {
+          "$ref": "#/definitions/SuggestionsConfig"
+        }
+      }
+    },
+
+    "Command": {
+      "title": "Replit Command",
+      "description": "The command to run",
+      "anyOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } },
+        {
+          "type": "object",
+          "properties": {
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "AuthConfig": {
+      "title": "ReplAuth Configuration",
+      "description": "Configure ReplAuth for your Repl.",
+      "type": "object",
+      "properties": {
+        "pageEnabled": {
+          "type": "boolean"
+        },
+        "pageTitle": {
+          "type": "string"
+        },
+        "pageDescription": {
+          "type": "string"
+        },
+        "pageColor": {
+          "type": "string"
+        },
+        "pageImage": {
+          "type": "string"
+        },
+        "buttonEnabled": {
+          "type": "boolean"
+        }
+      }
+    },
+
+    "DebuggerConfig": {
+      "title": "Debugger Configuration",
+      "description": "DAP Configuration for debugging support",
+      "type": "object",
+      "properties": {
+        "support": {
+          "type": "boolean"
+        },
+        "compile": {
+          "$ref": "#/definitions/DebuggerCompileConfig"
+        },
+        "interactive": {
+          "$ref": "#/definitions/DebuggerDAPConfig"
+        },
+        "dapTransport": {
+          "enum": [ "stdio" ]
+        },
+        "dapConnectTimeout": {
+          "type": "number"
+        },
+        "dapIntegratedAdapter": {
+          "$ref": "#/definitions/DebuggerDAPIntegratedAdapterConfig"
+        },
+        "dapStartCommand": {
+          "$ref": "#/definitions/Command"
+        },
+        "dapInitializeMessage": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "dapLaunchMessage": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "DebuggerCompileConfig": {
+      "title": "Debugger Compile Config",
+      "description": "The command to use to compile your project before starting the debugger.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "$ref": "#/definitions/Command"
+        },
+        "onlyMain": {
+          "type": "boolean"
+        },
+        "noFileArgs": {
+          "type": "boolean"
+        }
+      }
+    },
+
+    "DebuggerDAPConfig": {
+      "title": "Debugger DAP Config",
+      "description": "Configuration for the debugger DAP.",
+      "type": "object",
+      "properties": {
+        "transport": {
+          "enum": ["stdio"]
+        },
+        "connectTimeout": {
+          "type": "number"
+        },
+        "integratedAdapter": {
+          "$ref": "#/definitions/DebuggerDAPIntegratedAdapterConfig"
+        },
+        "startCommand": {
+          "$ref": "#/definitions/Command"
+        },
+        "initializeMessage": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "launchMessage": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "DebuggerDAPIntegratedAdapterConfig": {
+      "title": "Debugger DAP Integrated Adapter Config",
+      "description": "Configuration for integrated DAP adapters (debugger and adapter in same process).",
+      "type": "object",
+      "properties": {
+        "dapTcpAddress": {
+          "type": "string"
+        }
+      }
+    },
+
+    "DeploymentConfig": {
+      "title": "Deployment Config",
+      "description": "Configuration for deploying your Repl.",
+      "type": "object",
+      "properties": {
+        "build": {
+          "$ref": "#/definitions/Command"
+        },
+        "run": {
+          "$ref": "#/definitions/Command"
+        },
+        "ignorePorts": {
+          "type": "boolean"
+        },
+        "deploymentTarget": {
+          "enum": ["cloudrun", "gce", "static"]
+        },
+        "publicDir": {
+          "type": "string"
+        },
+        "ignore": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "preservedSymlinks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "health": {
+          "$ref": "#/definitions/DeploymentHealthConfig"
+        },
+        "responseHeaders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeploymentHeaderConfig"
+          }
+        },
+        "rewrites": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeploymentRewriteRule"
+          }
+        }
+      }
+    },
+
+    "DeploymentHeaderConfig": {
+      "title": "Static Deployment Headers",
+      "description": "Headers to apply to responses for static deployments.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+
+    "DeploymentHealthConfig": {
+      "title": "Deployment HealthChecks Configuration",
+      "description": "Configuration for specifying healthchecks in deployments.",
+      "type": "object",
+      "properties": {
+        "startup": {
+          "$ref": "#/definitions/DeploymentCheckConfig"
+        },
+        "liveness": {
+          "$ref": "#/definitions/DeploymentCheckConfig"
+        }
+      }
+    },
+
+    "DeploymentCheckConfig": {
+      "title": "Deployment HealthCheck Configuration",
+      "description": "Configuration for a single healthcheck in deployments.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "DeploymentRewriteRule": {
+      "title": "Deployment Rewrite Rule",
+      "description": "Path rewrite rules for static deployments.",
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      }
+    },
+
+    "ExtensionConfig": {
+      "title": "Extensions Configuration",
+      "description": "Configuration of your Repl as an extension.",
+      "type": "object",
+      "properties": {
+        "isExtension": {
+          "type": "boolean"
+        },
+        "extensionId": {
+          "type": "string"
+        },
+        "buildCommand": {
+          "type": "string"
+        },
+        "outputDirectory": {
+          "type": "string"
+        },
+        "staticDirectory": {
+          "type": "string"
+        }
+      }
+    },
+
+    "GitHubImportConfig": {
+      "title": "GitHub Imports Configuration",
+      "description": "Template files that are necessary to use as a base for GitHub imports.",
+      "type": "object",
+      "properties": {
+        "requiredFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "HintConfig": {
+      "title": "Hints configuration",
+      "description": "Hint that shows in the Console based on stderr.",
+      "type": "object",
+      "properties": {
+        "regex": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+
+    "HostingConfig": {
+      "title": "Static Repl Hosting Configuration",
+      "description": "Configure which route and directory to use for static Repl hosting.",
+      "type": "object",
+      "properties": {
+        "route": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "string"
+        }
+      }
+    },
+
+    "InterpConfig": {
+      "title": "Interpreter Configuration",
+      "description": "Configure the interpreter to use in the Console.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "$ref": "#/definitions/Command"
+        },
+        "prompt": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "noFileArgs": {
+          "type": "boolean"
+        }
+      }
+    },
+
+    "LanguageConfig": {
+      "title": "Language Configuration",
+      "description": "Per-language configurations.",
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string"
+        },
+        "syntax": {
+          "type": "string"
+        },
+        "languageServer": {
+          "$ref": "#/definitions/LanguageServerConfig"
+        }
+      }
+    },
+
+    "LanguageServerConfig": {
+      "title": "Language Server Configuration",
+      "description": "LSP server configurations.",
+      "type": "object",
+      "properties": {
+        "start": {
+          "$ref": "#/definitions/Command"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "initializationOptions": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "NixConfig": {
+      "title": "Nix Configuration",
+      "description": "Configure Nix on Replit.",
+      "type": "object",
+      "properties": {
+        "channel": {
+          "enum": ["unstable", "stable-21_11", "stable-22_05", "stable-22_11", "stable-23_05"]
+        }
+      }
+    },
+
+    "PackagerConfig": {
+      "title": "Packager Configuration",
+      "description": "Configure UPM",
+      "type": "object",
+      "properties": {
+        "afterInstall": {
+          "$ref": "#/definitions/Command"
+        },
+        "language": {
+          "type": "string"
+        },
+        "features": {
+          "type": "object",
+          "properties": {
+            "packageSearch": {
+              "type": "boolean"
+            },
+            "guessImports": {
+              "type": "boolean"
+            },
+            "enabledForHosting": {
+              "type": "boolean"
+            }
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "ignoredPackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignoredPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "PortConfig": {
+      "title": "Port Configuration",
+      "description": "Port mapping for developing in your Repl.",
+      "type": "object",
+      "properties": {
+        "localPort": {
+          "type": "number"
+        },
+        "externalPort": {
+          "type": "number"
+        },
+        "exposeLocalhost": {
+          "type": "boolean"
+        },
+        "allowHttpConnectMethod": {
+          "type": "string"
+        }
+      }
+    },
+
+    "RulesConfig": {
+      "title": "Rules configuration",
+      "description": "Rules-based configuration for various services.",
+      "type": "object",
+      "properties": {
+        "formatter": {
+          "$ref": "#/definitions/FormatterRulesConfig"
+        }
+      }
+    },
+
+    "FormatterRulesConfig": {
+      "title": "Formatter configuration",
+      "description": "Configuration for formatter",
+      "type": "object",
+      "properties": {
+        "patterns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FormatterConfigWithPattern"
+          }
+        },
+        "fileExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/FormatterConfig"
+          }
+        },
+        "languages": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/FormatterConfig"
+          }
+        }
+      }
+    },
+
+    "FormatterConfig": {
+      "title": "Formatter Configuration",
+      "description": "Formatter configuration.",
+      "type": "object",
+      "properties": {
+        "ID": {
+          "type": "string"
+        }
+      }
+    },
+
+    "FormatterConfigWithPattern": {
+      "title": "Pattern Formatter Configuration",
+      "description": "Formatter configuration applied to a pattern",
+      "type": "object",
+      "properties": {
+        "ID": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
+
+    "SuggestionsConfig": {
+      "title": "Suggestions Configuration",
+      "description": "Configure your template to suggest resources for the user to action on.",
+      "type": "object",
+      "properties": {
+        "extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "UnitTestConfig": {
+      "title": "Unit Test Configuration",
+      "description": "Configure unit testing.",
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -65,6 +65,11 @@ in
 
   "go" = { to = "go-1.19:v1-20230525-c48c43c"; auto = true; };
 
+  # IMPORTANT: DO NOT REMOVE THIS. ***ONLY*** change it.
+  # pid1 auto-loads the replit module by attempting to resolve `replit`. If this line is
+  # removed, then the `replit` module will fail to resolve in pid1.
+  "replit" = { to = "replit:v1-20231211-d5ddcff"; auto = true; };
+
   "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
   "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };
   "rust-1.69:v2-20230623-0b7a606" = { to = "rust-1.70:v1-20230724-17660e5"; auto = true; };

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -99,6 +99,7 @@ in
 // (fns.linearUpgrade "python-with-prybar-3.10")
 // (fns.linearUpgrade "qbasic")
 // (fns.linearUpgrade "r-4.2")
+// (fns.linearUpgrade "replit")
 // (fns.linearUpgrade "ruby-3.1")
 // (fns.linearUpgrade "ruby-3.2")
 // (fns.linearUpgrade "rust-stable")


### PR DESCRIPTION
Why
===

we want LSP support for `.replit` and we want it now!

note: unfortunately taplo uses a lot of memory :/ 
<img width="668" alt="image" src="https://github.com/replit/nixmodules/assets/23486351/b03f3649-e0a4-4b94-94be-b3decd4cdc74">

it's my intention to keep this feature-gated for staff only for now. i have a suspicion i can get this memory usage lower by making a custom binary that consumes only taplo's lsp crate and only loads the configuration for `.replit` into memory

another optimization that will come: before rolling this nixmodule out to GA, I plan on implementing lazy-loaded LSP servers. ideally this lsp config is only used when a user opens a `.replit` file

What changed
============

- added JSON schema for `.replit` file
- added novel `replit` nixmodule
- added LSP configuration for `replit` module to use `taplo` from [my PR](https://github.com/tamasfe/taplo/pull/510) for `.replit` files

Test plan
=========

- add `replit` nixmodule to a repl
- open `.replit` file
- lsp works

Rollout
=======

- [x] This is fully backward and forward compatible
