### PR TITLE
[Prettier] Support local prettier

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -259,6 +259,10 @@
     "commit": "ac14ad7d32e0324bb577d9c43bb1bb14d6faf5bf",
     "path": "/nix/store/jdd5f9c6n1pysswnf0qgzs7y8phvmg53-replit-module-nodejs-18"
   },
+  "nodejs-18:v22-20231215-55ca3c2": {
+    "commit": "55ca3c23609b43c5e1fc2aa5e1a9fd46ef8ee327",
+    "path": "/nix/store/m2j90520zk4a76zwdpsq4c6fab4zaray-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -342,6 +346,10 @@
   "nodejs-20:v18-20231211-ac14ad7": {
     "commit": "ac14ad7d32e0324bb577d9c43bb1bb14d6faf5bf",
     "path": "/nix/store/j0iws8rh1nmpc96p74kgxgkf1m3c2qrl-replit-module-nodejs-20"
+  },
+  "nodejs-20:v19-20231215-55ca3c2": {
+    "commit": "55ca3c23609b43c5e1fc2aa5e1a9fd46ef8ee327",
+    "path": "/nix/store/81i7lrycpwm4hdhlf3r8azp55ns4cj4y-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -906,6 +914,10 @@
   "nodejs-with-prybar-18:v12-20231211-ac14ad7": {
     "commit": "ac14ad7d32e0324bb577d9c43bb1bb14d6faf5bf",
     "path": "/nix/store/kcw4n6knglqznm6jg30ji2n6fia7j7bp-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v13-20231215-55ca3c2": {
+    "commit": "55ca3c23609b43c5e1fc2aa5e1a9fd46ef8ee327",
+    "path": "/nix/store/skkcl6dv0fw9daqil594sghkhss4waw5-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -31,8 +31,6 @@ let
     inherit nodejs;
   };
 
-  prettier = nodepkgs.prettier;
-
   npx-wrapper = pkgs.writeShellScriptBin "npx" ''
     mkdir -p ''${XDG_CONFIG_HOME}/npm/node_global/lib
     ${nodejs-wrapped}/bin/npx "$@"
@@ -57,7 +55,7 @@ in
     ];
 
     dev.packages = [
-      prettier
+      nodepkgs.prettier
     ];
 
     dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".mjs" ".cjs" ".es6" ];
@@ -118,7 +116,8 @@ in
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".html" ];
       start = {
-        args = [ "${prettier}/bin/prettier" "--stdin-filepath" "$file" ];
+        # Resolve to first prettier in path
+        args = [ "prettier" "--stdin-filepath" "$file" ];
       };
       stdin = true;
     };


### PR DESCRIPTION
Why
===

If a user has prettier installed locally (npm g or even local npm), we want to use that instead of the nixmodule prettier, incase they are different versions. (Maybe at some point we'll let them pick in the UI, but this is fine for now, we can assume this is correct)

So instead of just running prettier with the nixmodule path we'll run a script to find the right path of prettier, and then run that one.

I suppose this has the downside of making every formatter run a bit slower, as it has to run `which` every time. If you have a better idea than this, I'm all ears. I didn't want to compute it ahead of time, as it seemed like then it would be a challenge to re-calculate whenever the user's environment changed, like if they later installed or uninstalled prettier somewhere.

_Describe what prompted you to make this change, link relevant resources_

What changed
============

Run a script to pick the right prettier binary to run

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

I followed the steps in `docs/nixmodules-disks.md`
* Built a local nix module with my changes
* Ran goval locally with the custom nix module
* Loaded up replit web with a repl using the node js nix module

Then I tested the following sequence:

* Only the prettier nix package installed, which is v3.1. I set up a formatting change that had a behavior change in v3.0.2:
https://github.com/prettier/prettier/blob/main/CHANGELOG.md#302

* it formatted w/ prettier 3.1
* then I npm i -g prettier @ 2.8.4
* then formatted again, and saw it formatted the old way, indicating it ran version 2.8.4

https://github.com/replit/nixmodules/assets/16962017/8f11f71a-612c-4a6a-9ddc-c9068dc4a314


_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
