### PR TITLE
use typescript-language-server 4.2.0

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -263,6 +263,10 @@
     "commit": "fb57c712f0b9b0c1dd1ce912fc0b8b17855137fe",
     "path": "/nix/store/m2j90520zk4a76zwdpsq4c6fab4zaray-replit-module-nodejs-18"
   },
+  "nodejs-18:v23-20231219-faac932": {
+    "commit": "faac932188739c982a79d5108abeee749b2f445e",
+    "path": "/nix/store/99r0bl3ipfh7v4b77z68zaldf20m0s67-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -350,6 +354,10 @@
   "nodejs-20:v19-20231216-fb57c71": {
     "commit": "fb57c712f0b9b0c1dd1ce912fc0b8b17855137fe",
     "path": "/nix/store/81i7lrycpwm4hdhlf3r8azp55ns4cj4y-replit-module-nodejs-20"
+  },
+  "nodejs-20:v20-20231219-faac932": {
+    "commit": "faac932188739c982a79d5108abeee749b2f445e",
+    "path": "/nix/store/g21xj215fkffp8gd6dyqd4amqbrpi5xv-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -570,6 +578,10 @@
   "web:v3-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/840hs6bdk6y3yix8233y647qj4dhf801-replit-module-web"
+  },
+  "web:v4-20231219-faac932": {
+    "commit": "faac932188739c982a79d5108abeee749b2f445e",
+    "path": "/nix/store/77fdas4c55c45g808s30yxcl0hbqy6v2-replit-module-web"
   },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
@@ -807,6 +819,10 @@
     "commit": "ac14ad7d32e0324bb577d9c43bb1bb14d6faf5bf",
     "path": "/nix/store/8mp4fjbkfhwg412pyrr1c5jzl558yw5y-replit-module-bun-1.0"
   },
+  "bun-1.0:v14-20231219-faac932": {
+    "commit": "faac932188739c982a79d5108abeee749b2f445e",
+    "path": "/nix/store/x68pba4aqr4xfgsqg67pnwvnbjm74flg-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -918,6 +934,10 @@
   "nodejs-with-prybar-18:v13-20231216-fb57c71": {
     "commit": "fb57c712f0b9b0c1dd1ce912fc0b8b17855137fe",
     "path": "/nix/store/skkcl6dv0fw9daqil594sghkhss4waw5-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v14-20231219-faac932": {
+    "commit": "faac932188739c982a79d5108abeee749b2f445e",
+    "path": "/nix/store/13c3sjhc960qd8wxf4230a1qn077sxaw-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -1,8 +1,15 @@
 { nodepkgs }:
 { pkgs, ... }:
 let
-
   typescript-language-server = nodepkgs.typescript-language-server.override {
+    # TODO: we can get rid of this patch once >=4.2.0 is in the nixpkgs-unstable we use.
+    # but we want this version because of https://github.com/typescript-language-server/typescript-language-server/pull/831
+    version = "4.2.0";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-4.2.0.tgz";
+      hash = "sha256-sg0O1uw6L3LDlPKTbXXsXVYwR+c7HH5c89xNIefEov8=";
+    };
+
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postInstall = ''
       wrapProgram "$out/bin/typescript-language-server" \
@@ -17,7 +24,7 @@ in
     start = "${typescript-language-server}/bin/typescript-language-server --stdio";
 
     initializationOptions = {
-      tsserver.path = "${nodepkgs.typescript}/lib/node_modules/typescript/lib";
+      tsserver.fallbackPath = "${nodepkgs.typescript}/lib/node_modules/typescript/lib";
     };
   };
 }


### PR DESCRIPTION
Why
===

ideally typescript-language-server would use `typescript` from the current project's `node_modules` but we haven't been doing that, since it's not guaranteed all repls will have that dep. so instead i submitted a path upstream that allows us to do that by setting `tsserver.fallbackPath` in initializationOptions but that's not in nixpkgs yet (it comes with 4.2.0, nixpkgs currently only has 4.1.2)

What changed
============

- override the `typescript-language-server` drv with the 4.2.0 bundle
- use `tsserver.fallbackPath` in initialization options instead of `tsserver.path`

Test plan
=========

- js completions work in a js-only project without the `typescript` dependency anywhere
- ^ but with `typescript` devDependency (`kill 1` after adding the dep to restart the lsp with the right tsserver)
- verify that the node_modules tsserver is actually being used by using a tsserver older than 5.1 (probably just do `"typescript": "^4.0.0"` and observing this code:
```ts
function foo(): undefined {}
```

if there's no error, then you're using nixpkgs-defined typescript. if there is an error (and you're correctly using the outdated version of `typescript`) then you're using the node_modules typescript!

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
