### PR TITLE
deno module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1026,5 +1026,9 @@
   "bash:v1-20231215-e6d471c": {
     "commit": "e6d471c9fd81b6ca469e1c42692953146c7cfb20",
     "path": "/nix/store/0j5kz53myr8kycfc4w1vkfccz4m5rsyv-replit-module-bash"
+  },
+  "deno-1:v1-20231215-5d427a8": {
+    "commit": "5d427a83eae4fc1be41c3842b294c98f41271462",
+    "path": "/nix/store/z02na0yx2xlnrkaaf1k515ddnib8hd2h-replit-module-deno-1"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -50,6 +50,7 @@ let
     (import ./c)
     (import ./cpp)
     (import ./dart)
+    (import ./deno)
     (import ./docker)
     (import ./gcloud)
     (import ./clojure)

--- a/pkgs/modules/deno/default.nix
+++ b/pkgs/modules/deno/default.nix
@@ -1,0 +1,32 @@
+{ pkgs, lib, ... }:
+
+let
+  inherit (pkgs) deno;
+  version = lib.versions.major deno.version;
+
+  extensions = [ ".json" ".jsonc" ".js" ".jsx" ".ts" ".tsx" ];
+in
+
+{
+  id = "deno-${version}";
+  name = "Deno Tools";
+
+  replit.packages = [
+    deno
+  ];
+
+  replit.runners.deno-script-runner = {
+    name = "deno";
+    language = "javascript";
+    inherit extensions;
+    fileParam = true;
+    start = "${deno}/bin/deno run --allow-all $file";
+  };
+
+  replit.dev.languageServers.deno = {
+    name = "deno";
+    language = "javascript";
+    inherit extensions;
+    start = "${deno}/bin/deno lsp --quiet";
+  };
+}

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -83,6 +83,7 @@ in
 // (fns.linearUpgrade "c-clang14")
 // (fns.linearUpgrade "clojure-1.11")
 // (fns.linearUpgrade "cpp-clang14")
+// (fns.linearUpgrade "deno-1")
 // (fns.linearUpgrade "docker")
 // (fns.linearUpgrade "dotnet-7.0")
 // (fns.linearUpgrade "gcloud")


### PR DESCRIPTION
supercedes #207 

Why
===

denosaur says hello, world!

What changed
============

added new deno module (which is a lot simpler than #207 which was using a wrapper script which is kinda unnecessary now because deno now has support for `tasks.json` file)

Test plan
=========

- lsp works
- run button works

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
