### PR TITLE
vue nixmodule

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1030,5 +1030,9 @@
   "deno-1:v1-20231215-5d427a8": {
     "commit": "5d427a83eae4fc1be41c3842b294c98f41271462",
     "path": "/nix/store/z02na0yx2xlnrkaaf1k515ddnib8hd2h-replit-module-deno-1"
+  },
+  "vue-node-20:v1-20231220-a18bbd4": {
+    "commit": "a18bbd4b3508bf0c247a67f407cbd9023b8d2ebb",
+    "path": "/nix/store/lmk3sapswzjx1clighaxdaw7c0hp411x-replit-module-vue-node-20"
   }
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -108,6 +108,4 @@ rec {
 
   deploymentModules = self.deploymentModules;
 
-  vls = pkgs.callPackage ./vls {};
-
 } // modules

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -108,4 +108,6 @@ rec {
 
   deploymentModules = self.deploymentModules;
 
+  vls = pkgs.callPackage ./vls {};
+
 } // modules

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -74,6 +74,7 @@ let
     (import ./rust)
     (import ./swift)
     (import ./svelte-kit)
+    (import ./vue)
     (import ./web)
   ];
 

--- a/pkgs/modules/vue/default.nix
+++ b/pkgs/modules/vue/default.nix
@@ -1,0 +1,42 @@
+{ pkgs, ... }:
+
+let
+  inherit (pkgs) nodejs;
+  nodepkgs = nodejs.pkgs;
+
+  vue-language-server = pkgs.callPackage ../../vue-language-server { };
+
+  language = "vue";
+  extensions = [ ".vue" ".js" ".mjs" ".cjs" ".jsx" ".ts" ".tsx" ".json" ".html" ".css" ];
+in
+
+{
+  id = "vue-node-20";
+  name = "Vue with Node.js 20 Tools";
+
+  replit = {
+    packages = [
+      pkgs.bun
+      nodejs
+      nodepkgs.pnpm
+      nodepkgs.yarn
+    ];
+
+    dev.runners.dev-runner = {
+      name = "package.json dev script";
+      inherit language extensions;
+      start = "${pkgs.nodejs}/bin/npm run dev";
+    };
+
+    dev.languageServers.vue-language-server = {
+      name = "Vue Language Server";
+      inherit language extensions;
+      start = "${vue-language-server}/bin/vue-language-server --stdio";
+
+      initializationOptions = {
+        typescript.tsdk = "${nodepkgs.typescript}/lib/node_modules/typescript/lib";
+      };
+    };
+  };
+}
+

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -113,4 +113,5 @@ in
 // (fns.linearUpgrade "rust-stable")
 // (fns.linearUpgrade "svelte-kit-node-20")
 // (fns.linearUpgrade "swift-5.8")
+// (fns.linearUpgrade "vue-node-20")
   // (fns.linearUpgrade "web")

--- a/pkgs/vue-language-server/default.nix
+++ b/pkgs/vue-language-server/default.nix
@@ -1,0 +1,26 @@
+# TODO: upstream this file into nixpkgs
+{ buildNpmPackage,
+  fetchurl,
+}:
+
+buildNpmPackage rec {
+  name = "@vue/language-server";
+  version = "1.8.25";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@vue/language-server/-/language-server-${version}.tgz";
+    hash = "sha256-dwciS5zJ1S8q3jqoJ6gzLn5UHpQuTqVNX3BFS5L2B5g=";
+  };
+
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  npmDepsHash = "sha256-vsZqtue2FjMrcKNznD/jhoMXoP96bFzj9E+rTg2SJe8=";
+  dontNpmBuild = true;
+
+  meta = {
+    mainProgram = "vue-language-server";
+  };
+}
+

--- a/pkgs/vue-language-server/default.nix
+++ b/pkgs/vue-language-server/default.nix
@@ -1,6 +1,6 @@
 # TODO: upstream this file into nixpkgs
-{ buildNpmPackage,
-  fetchurl,
+{ buildNpmPackage
+, fetchurl
 }:
 
 buildNpmPackage rec {

--- a/pkgs/vue-language-server/package-lock.json
+++ b/pkgs/vue-language-server/package-lock.json
@@ -1,0 +1,802 @@
+{
+	"name": "@vue/language-server",
+	"version": "1.8.25",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@vue/language-server",
+			"version": "1.8.25",
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "~1.11.1",
+				"@volar/language-server": "~1.11.1",
+				"@volar/typescript": "~1.11.1",
+				"@vue/language-core": "1.8.25",
+				"@vue/language-service": "1.8.25",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vue-component-meta": "1.8.25"
+			},
+			"bin": {
+				"vue-language-server": "bin/vue-language-server.js"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@emmetio/abbreviation": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+			"integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+			"dependencies": {
+				"@emmetio/scanner": "^1.0.4"
+			}
+		},
+		"node_modules/@emmetio/css-abbreviation": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+			"integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+			"dependencies": {
+				"@emmetio/scanner": "^1.0.4"
+			}
+		},
+		"node_modules/@emmetio/scanner": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+			"integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+		},
+		"node_modules/@johnsoncodehk/pug-beautify": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@johnsoncodehk/pug-beautify/-/pug-beautify-0.2.2.tgz",
+			"integrity": "sha512-qqNS/YD0Nck5wtQLCPHAfGVgWbbGafxSPjNh0ekYPFSNNqnDH2kamnduzYly8IiADmeVx/MfAE1njMEjVeHTMA=="
+		},
+		"node_modules/@volar/language-core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+			"integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
+			"dependencies": {
+				"@volar/source-map": "1.11.1"
+			}
+		},
+		"node_modules/@volar/language-server": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-1.11.1.tgz",
+			"integrity": "sha512-XYG4HcML2qimQV9UouQ7c1GuuqQw1NXoNDxAOAcfyYlz43P+HgzGQx4QEou+QMGHJeYIN86foDvkTN3fcopw9A==",
+			"dependencies": {
+				"@volar/language-core": "1.11.1",
+				"@volar/language-service": "1.11.1",
+				"@volar/typescript": "1.11.1",
+				"@vscode/l10n": "^0.0.16",
+				"path-browserify": "^1.0.1",
+				"request-light": "^0.7.0",
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@volar/language-service": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-1.11.1.tgz",
+			"integrity": "sha512-dKo8z1UzQRPHnlXxwfONGrasS1wEWXMoLQiohZ8KgWqZALbekZCwdGImLZD4DeFGNjk3HTTdfeCzo3KjwohjEQ==",
+			"dependencies": {
+				"@volar/language-core": "1.11.1",
+				"@volar/source-map": "1.11.1",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@volar/source-map": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+			"integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
+			"dependencies": {
+				"muggle-string": "^0.3.1"
+			}
+		},
+		"node_modules/@volar/typescript": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+			"integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
+			"dependencies": {
+				"@volar/language-core": "1.11.1",
+				"path-browserify": "^1.0.1"
+			}
+		},
+		"node_modules/@vscode/emmet-helper": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.2.tgz",
+			"integrity": "sha512-MaGuyW+fa13q3aYsluKqclmh62Hgp0BpKIqS66fCxfOaBcVQ1OnMQxRRgQUYnCkxFISAQlkJ0qWWPyXjro1Qrg==",
+			"dependencies": {
+				"emmet": "^2.4.3",
+				"jsonc-parser": "^2.3.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.15.1",
+				"vscode-uri": "^2.1.2"
+			}
+		},
+		"node_modules/@vscode/emmet-helper/node_modules/vscode-uri": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
+		},
+		"node_modules/@vscode/l10n": {
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
+			"integrity": "sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg=="
+		},
+		"node_modules/@vue/compiler-core": {
+			"version": "3.3.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.13.tgz",
+			"integrity": "sha512-bwi9HShGu7uaZLOErZgsH2+ojsEdsjerbf2cMXPwmvcgZfVPZ2BVZzCVnwZBxTAYd6Mzbmf6izcUNDkWnBBQ6A==",
+			"dependencies": {
+				"@babel/parser": "^7.23.5",
+				"@vue/shared": "3.3.13",
+				"estree-walker": "^2.0.2",
+				"source-map-js": "^1.0.2"
+			}
+		},
+		"node_modules/@vue/compiler-dom": {
+			"version": "3.3.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.13.tgz",
+			"integrity": "sha512-EYRDpbLadGtNL0Gph+HoKiYqXLqZ0xSSpR5Dvnu/Ep7ggaCbjRDIus1MMxTS2Qm0koXED4xSlvTZaTnI8cYAsw==",
+			"dependencies": {
+				"@vue/compiler-core": "3.3.13",
+				"@vue/shared": "3.3.13"
+			}
+		},
+		"node_modules/@vue/language-core": {
+			"version": "1.8.25",
+			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.25.tgz",
+			"integrity": "sha512-NJk/5DnAZlpvXX8BdWmHI45bWGLViUaS3R/RMrmFSvFMSbJKuEODpM4kR0F0Ofv5SFzCWuNiMhxameWpVdQsnA==",
+			"dependencies": {
+				"@volar/language-core": "~1.11.1",
+				"@volar/source-map": "~1.11.1",
+				"@vue/compiler-dom": "^3.3.0",
+				"@vue/shared": "^3.3.0",
+				"computeds": "^0.0.1",
+				"minimatch": "^9.0.3",
+				"muggle-string": "^0.3.1",
+				"path-browserify": "^1.0.1",
+				"vue-template-compiler": "^2.7.14"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vue/language-service": {
+			"version": "1.8.25",
+			"resolved": "https://registry.npmjs.org/@vue/language-service/-/language-service-1.8.25.tgz",
+			"integrity": "sha512-voKpGcsCrSdgstVMXmGVVQh/yaybzP/MKGMlIeTUtl2EdQwPtAbh7fCcv2y9yFlVAkifxC4q4BjC2Mzoanmfbw==",
+			"dependencies": {
+				"@volar/language-core": "~1.11.1",
+				"@volar/language-service": "~1.11.1",
+				"@volar/typescript": "~1.11.1",
+				"@vue/compiler-dom": "^3.3.0",
+				"@vue/language-core": "1.8.25",
+				"@vue/shared": "^3.3.0",
+				"computeds": "^0.0.1",
+				"path-browserify": "^1.0.1",
+				"volar-service-css": "0.0.17",
+				"volar-service-emmet": "0.0.17",
+				"volar-service-html": "0.0.17",
+				"volar-service-json": "0.0.17",
+				"volar-service-pug": "0.0.17",
+				"volar-service-pug-beautify": "0.0.17",
+				"volar-service-typescript": "0.0.17",
+				"volar-service-typescript-twoslash-queries": "0.0.17",
+				"vscode-html-languageservice": "^5.1.0",
+				"vscode-languageserver-textdocument": "^1.0.11"
+			}
+		},
+		"node_modules/@vue/shared": {
+			"version": "3.3.13",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.13.tgz",
+			"integrity": "sha512-/zYUwiHD8j7gKx2argXEMCUXVST6q/21DFU0sTfNX0URJroCe3b1UF6vLJ3lQDfLNIiiRl2ONp7Nh5UVWS6QnA=="
+		},
+		"node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"dependencies": {
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/character-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+			"integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+			"dependencies": {
+				"is-regex": "^1.0.3"
+			}
+		},
+		"node_modules/computeds": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+			"integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q=="
+		},
+		"node_modules/de-indent": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+			"integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/emmet": {
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.6.tgz",
+			"integrity": "sha512-dJfbdY/hfeTyf/Ef7Y7ubLYzkBvPQ912wPaeVYpAxvFxkEBf/+hJu4H6vhAvFN6HlxqedlfVn2x1S44FfQ97pg==",
+			"dependencies": {
+				"@emmetio/abbreviation": "^2.3.3",
+				"@emmetio/css-abbreviation": "^2.1.8"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"dependencies": {
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/is-expression": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+			"integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+			"dependencies": {
+				"acorn": "^7.1.1",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/jsonc-parser": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+			"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/muggle-string": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+			"integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg=="
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+		},
+		"node_modules/pug-error": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+			"integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
+		},
+		"node_modules/pug-lexer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+			"integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+			"dependencies": {
+				"character-parser": "^2.2.0",
+				"is-expression": "^4.0.0",
+				"pug-error": "^2.0.0"
+			}
+		},
+		"node_modules/pug-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+			"integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
+			"dependencies": {
+				"pug-error": "^2.0.0",
+				"token-stream": "1.0.0"
+			}
+		},
+		"node_modules/request-light": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+			"integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="
+		},
+		"node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/token-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+			"integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="
+		},
+		"node_modules/typescript-auto-import-cache": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.0.tgz",
+			"integrity": "sha512-Rq6/q4O9iyqUdjvOoyas7x/Qf9nWUMeqpP3YeTaLA+uECgfy5wOhfOS+SW/+fZ/uI/ZcKaf+2/ZhFzXh8xfofQ==",
+			"dependencies": {
+				"semver": "^7.3.8"
+			}
+		},
+		"node_modules/volar-service-css": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.17.tgz",
+			"integrity": "sha512-bEDJykygMzn2+a9ud6KwZZLli9eqarxApAXZuf2CqJJh6Trw1elmbBCo9SlPfqMrIhpFnwV0Sa+Xoc9x5WPeGw==",
+			"dependencies": {
+				"vscode-css-languageservice": "^6.2.10",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-emmet": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.17.tgz",
+			"integrity": "sha512-C6hVnuQL52MqaydkrblYUbzIo5ZmIGo1hR8wmpcCjs5uNcjqn8aPqZRfznhLiUSaPHpFC+zQxJwFcZI9/u2iKQ==",
+			"dependencies": {
+				"@vscode/emmet-helper": "^2.9.2",
+				"volar-service-html": "0.0.17"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-html": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.17.tgz",
+			"integrity": "sha512-OGkP+ZTo13j/+enafGe+esXvda/W4eU78YNLbbHxtV3rnX4odVrewenLJmXiECg6wdQz/PG8rLijZqQnDUYkfw==",
+			"dependencies": {
+				"vscode-html-languageservice": "^5.1.0",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-json": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-json/-/volar-service-json-0.0.17.tgz",
+			"integrity": "sha512-28pXc5l5xSDtTDZ73zg0Jklr1KOsqL60wa8SXTJptK7e+PX8PF/cxQ/2FBHQOybdJsk+fn8jx8wF/ky8cuVHag==",
+			"dependencies": {
+				"vscode-json-languageservice": "^5.3.7",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-pug": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-pug/-/volar-service-pug-0.0.17.tgz",
+			"integrity": "sha512-p6oDgH+ufWyS6r6Jv5h76cWGtjLOG/vhd5NH4Sk0pMCdh8zANHJsKsxsrIOiYsK6J9uNU1H6qRRHGg95xj34eQ==",
+			"dependencies": {
+				"@volar/language-service": "~1.11.0",
+				"@volar/source-map": "~1.11.0",
+				"muggle-string": "^0.3.1",
+				"pug-lexer": "^5.0.1",
+				"pug-parser": "^6.0.0",
+				"volar-service-html": "0.0.17",
+				"vscode-html-languageservice": "^5.1.0",
+				"vscode-languageserver-textdocument": "^1.0.11"
+			}
+		},
+		"node_modules/volar-service-pug-beautify": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-pug-beautify/-/volar-service-pug-beautify-0.0.17.tgz",
+			"integrity": "sha512-r+18HvciIOFbwi9dNTok1r1oboFyPaRPW1F5K7Yw1Ypynt2PI6ocGjBJ0V+Z5oONTXq1wHA4vzlmmvz5vzVh9g==",
+			"dependencies": {
+				"@johnsoncodehk/pug-beautify": "^0.2.2"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-typescript": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.17.tgz",
+			"integrity": "sha512-Krs8pOIo2yoBVoJ91hKT1czhWt9ek7EbuK3MxxgvDYdd4HYHOtHi1eOlb7bFnZMNgFcwsL48yQI9vbPm160s9A==",
+			"dependencies": {
+				"path-browserify": "^1.0.1",
+				"semver": "^7.5.4",
+				"typescript-auto-import-cache": "^0.3.0",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-nls": "^5.2.0",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0",
+				"@volar/typescript": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-typescript-twoslash-queries": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.17.tgz",
+			"integrity": "sha512-6FHXK5AWeFzCL6uGmEcbkZmQsaQ0m9IjbeLdgOIQ4KGvauqT2aA1BhdfDJu6vRAFIfXe7xjEJ85keIlHl72tSA==",
+			"peerDependencies": {
+				"@volar/language-service": "~1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vscode-css-languageservice": {
+			"version": "6.2.11",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.11.tgz",
+			"integrity": "sha512-qn49Wa6K94LnizpVxmlYrcPf1Cb36gq1nNueW0COhi4shylXBzET5wuDbH8ZWQlJD0HM5Mmnn7WE9vQVVs+ULA==",
+			"dependencies": {
+				"@vscode/l10n": "^0.0.16",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "3.17.5",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/vscode-html-languageservice": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.1.tgz",
+			"integrity": "sha512-JenrspIIG/Q+93R6G3L6HdK96itSisMynE0glURqHpQbL3dKAKzdm8L40lAHNkwJeBg+BBPpAshZKv/38onrTQ==",
+			"dependencies": {
+				"@vscode/l10n": "^0.0.16",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "^3.17.5",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/vscode-json-languageservice": {
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.3.7.tgz",
+			"integrity": "sha512-jdDggN2SLMQw4C/tLr11v6/OK4cMVGy7tbyZRHQvukQ6lcflY3UV+ZMkmwHKCqXz2TmxkjQb536eJW6JMEVeew==",
+			"dependencies": {
+				"@vscode/l10n": "^0.0.16",
+				"jsonc-parser": "^3.2.0",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "^3.17.5",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+		},
+		"node_modules/vscode-nls": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+			"integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
+		},
+		"node_modules/vue-component-meta": {
+			"version": "1.8.25",
+			"resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-1.8.25.tgz",
+			"integrity": "sha512-CLsDWVJGBpUmdWiNuKaQ74yvCa3kYi17tT0nO7Fdmcd3GpzChpqYl/0M+WmZjwRDJha91ojWHtrBLWBv/XQiIQ==",
+			"dependencies": {
+				"@volar/typescript": "~1.11.1",
+				"@vue/language-core": "1.8.25",
+				"path-browserify": "^1.0.1",
+				"vue-component-type-helpers": "1.8.25"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vue-component-type-helpers": {
+			"version": "1.8.25",
+			"resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.25.tgz",
+			"integrity": "sha512-NCA6sekiJIMnMs4DdORxATXD+/NRkQpS32UC+I1KQJUasx+Z7MZUb3Y+MsKsFmX+PgyTYSteb73JW77AibaCCw=="
+		},
+		"node_modules/vue-template-compiler": {
+			"version": "2.7.15",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+			"integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
+			"dependencies": {
+				"de-indent": "^1.0.2",
+				"he": "^1.2.0"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	}
+}


### PR DESCRIPTION
Why
===

we don't have vue lsp working at all right now, might as well start with nixmodules

What changed
============

- build `vue-language-server` via nix
- lsp using `vue-language-server`

Test plan
=========

- create a vue project
- lsp works in .vue files
- lsp works in .html files
- lsp works in .ts files

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
