### PR TITLE
adds the prerelease RG cluster to prodvana

### DIFF
--- a/manifests/application.pvn.yaml
+++ b/manifests/application.pvn.yaml
@@ -107,7 +107,6 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
-# regional goval
     - name: staging
       constants:
         - name: name
@@ -120,6 +119,19 @@ application:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
           type: EXTENSION
+    # regional goval
+    - name: prerelease
+      constants:
+        - name: name
+          string:
+            value: prerelease
+      preconditions:
+        - releaseChannelStable:
+            releaseChannel: staging
+      runtimes:
+        - name: config-raw
+          runtime: marine-cycle-160323--govalctl-config-raw
+          type: EXTENSION
     - name: picard
       constants:
         - name: name
@@ -127,7 +139,7 @@ application:
             value: picard
       preconditions:
         - releaseChannelStable:
-            releaseChannel: staging
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -139,7 +151,7 @@ application:
             value: riker
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -151,7 +163,7 @@ application:
             value: kirk
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -163,7 +175,7 @@ application:
             value: spock
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -175,7 +187,7 @@ application:
             value: worf
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -187,7 +199,7 @@ application:
             value: janeway
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -199,7 +211,7 @@ application:
             value: sisko
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -211,7 +223,7 @@ application:
             value: pike
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw
@@ -223,7 +235,7 @@ application:
             value: wesley
       preconditions:
         - releaseChannelStable:
-            releaseChannel: picard
+            releaseChannel: prerelease
       runtimes:
         - name: config-raw
           runtime: marine-cycle-160323--govalctl-config-raw

--- a/manifests/service.pvn.yaml
+++ b/manifests/service.pvn.yaml
@@ -157,6 +157,22 @@ service:
                 "version":"{{.Params.nixmodules_version}}",
                 "configPullJitter":"{{.Params.jitter}}"
               }
+    - releaseChannel: prerelease
+      runtimeConnection: config-raw
+      runtimeExtension:
+        parameterValues:
+          - name: image
+            string: "{{.Params.image_govalctl}}"
+          - name: service
+            string: "nixmodules"
+          - name: name
+            string: "{{.Constants.name}}"
+          - name: json
+            string: >-
+              {
+                "version":"{{.Params.nixmodules_version}}",
+                "configPullJitter":"{{.Params.jitter}}"
+              }
     - releaseChannel: picard
       runtimeConnection: config-raw
       runtimeExtension:


### PR DESCRIPTION
Why
===

https://linear.app/replit/issue/INC-2264/inc-1238-ai-follow-up-on-why-prerelease-has-a-very-old-nixmodules-disk

What changed
============

Adds the prerelease cluster to the Prodvana manifests, updates the dependencies from `picard` ->  `prerelease` from the rollout. 

Test plan
=========

`prerelease` is in the [config bucket already](https://console.cloud.google.com/storage/browser/replit-config/nixmodules/prerelease), it just hasn't been updated since November at the latest. 

Rollout
=======

We will just need to monitor the rollout plan and ensure the config bucket + prerelease blob look good.

- [X] This is fully backward and forward compatible
