### PR TITLE
[python] unset PYTHONNOUSERSITE 

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -527,6 +527,10 @@
     "commit": "fd07a42a68c761fd2f832ad0c52e6942d8579c66",
     "path": "/nix/store/2baqw5sn1fh5mizphsfslz1ayxb8kv36-replit-module-python-3.10"
   },
+  "python-3.10:v37-20240103-6eb2819": {
+    "commit": "6eb2819a91e75cb52fbb17a2371422d82e1c064f",
+    "path": "/nix/store/2rdlkmn4w6g8rjwl7alywz2g62jrbs7b-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -751,6 +755,10 @@
     "commit": "fd07a42a68c761fd2f832ad0c52e6942d8579c66",
     "path": "/nix/store/6v3qfmfmmfadi9j3mpagdns2mgh97xia-replit-module-python-3.11"
   },
+  "python-3.11:v18-20240103-6eb2819": {
+    "commit": "6eb2819a91e75cb52fbb17a2371422d82e1c064f",
+    "path": "/nix/store/8zcxw6s7hgmwq1z9aasls3zrd7x8nc3v-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -818,6 +826,10 @@
   "python-3.8:v17-20240102-fd07a42": {
     "commit": "fd07a42a68c761fd2f832ad0c52e6942d8579c66",
     "path": "/nix/store/y0xxx5fv7zrbbpck64z14ypfvmrkd2nn-replit-module-python-3.8"
+  },
+  "python-3.8:v18-20240103-6eb2819": {
+    "commit": "6eb2819a91e75cb52fbb17a2371422d82e1c064f",
+    "path": "/nix/store/dygcc0dmh3y33hdhyyr2vvmc4iz7llkh-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -942,6 +954,10 @@
   "python-with-prybar-3.10:v15-20240102-fd07a42": {
     "commit": "fd07a42a68c761fd2f832ad0c52e6942d8579c66",
     "path": "/nix/store/fp0fk3aci1psljzilasmkvqyiwck8yic-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v16-20240103-6eb2819": {
+    "commit": "6eb2819a91e75cb52fbb17a2371422d82e1c064f",
+    "path": "/nix/store/c8340g1hk1nysk4f8mr8p42agryzb05j-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -50,7 +50,9 @@ let
       buildCommand = ''
         mkdir -p $out/bin
         makeWrapper ${ldLibraryPathConvertWrapper}/bin/${name} $out/bin/${name} \
-          --prefix PYTHONPATH : "${pypkgs.setuptools}/${python.sitePackages}"
+          --prefix PYTHONPATH : "${pypkgs.setuptools}/${python.sitePackages}" \
+          --unset PYTHONNOUSERSITE
+
       '' + pkgs.lib.concatMapStringsSep "\n" (s: "ln -s $out/bin/${name} $out/bin/${s}") aliases;
 
     };


### PR DESCRIPTION
Why
===
* We set POETRY_USE_USER_SITE = 1 but some nixpkgs pkgs use a python
setup hook that sets PYTHONNOUSERSITE=1, which breaks poetry
installs. Reproduce breakage with:

```
nix-editor --add pkgs.magic-wormhole
poetry add pycparser
```

What changed
===
* In the python wrapper, unset PYTHONNOUSERSITE.

Test plan
===
```
nix-editor --add pkgs.magic-wormhole
poetry add pycparser
```
observe the poetry package installs fine

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
