### PR TITLE
bug/Poetry env isolation

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -547,6 +547,10 @@
     "commit": "2da491110c9866a9afb0bb9f668a6d35a8b98b43",
     "path": "/nix/store/lpn8jr69z6rbmhwmnf36y89lkbin3hrz-replit-module-python-3.10"
   },
+  "python-3.10:v39-20240105-957ab14": {
+    "commit": "957ab1412516ab163e95077dfabdcfb43a6a66c6",
+    "path": "/nix/store/y6206x96yyjalx0sqc6a962bpq67wrvz-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -779,6 +783,10 @@
     "commit": "2da491110c9866a9afb0bb9f668a6d35a8b98b43",
     "path": "/nix/store/xjgzym18rj4v13lsfdhm36kg3r4svbav-replit-module-python-3.11"
   },
+  "python-3.11:v20-20240105-957ab14": {
+    "commit": "957ab1412516ab163e95077dfabdcfb43a6a66c6",
+    "path": "/nix/store/95hb5q3p3hhk5s5ds0vz3y6d0nrk3873-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -854,6 +862,10 @@
   "python-3.8:v19-20240103-2da4911": {
     "commit": "2da491110c9866a9afb0bb9f668a6d35a8b98b43",
     "path": "/nix/store/z4755r8kl09v6hx5ba8ajihch0kv6wzr-replit-module-python-3.8"
+  },
+  "python-3.8:v20-20240105-957ab14": {
+    "commit": "957ab1412516ab163e95077dfabdcfb43a6a66c6",
+    "path": "/nix/store/7ny9bzwprwb32m967y7zln14n7g7bqlm-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -986,6 +998,10 @@
   "python-with-prybar-3.10:v17-20240103-2da4911": {
     "commit": "2da491110c9866a9afb0bb9f668a6d35a8b98b43",
     "path": "/nix/store/4kx20aaasddm86g46liqqmwkspc7k8j4-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v18-20240105-957ab14": {
+    "commit": "957ab1412516ab163e95077dfabdcfb43a6a66c6",
+    "path": "/nix/store/04q43wibzcznav31lpgvp4dd9gwqlqnj-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/poetry/poetry-in-venv.nix
+++ b/pkgs/poetry/poetry-in-venv.nix
@@ -12,7 +12,7 @@ let
       mkdir -p $out/bin
       ${python}/bin/python3 -m venv $out/env
       touch $out/env/poetry_env # This allows poetry to recognize it
-                                # https://github.com/replit/poetry/blob/replit-1.1/poetry/utils/env.py#L885
+                                # https://github.com/replit/poetry/blob/replit-1.5/src/poetry/utils/env.py#L1154
                                 # invoking the workaround so that poetry
                                 # does not use its own venv for the project
                                 # env

--- a/pkgs/poetry/poetry-py3.10.nix
+++ b/pkgs/poetry/poetry-py3.10.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.3";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.3-python-3.10.11-bundle.tgz;
-  sha256 = "sha256:10jh59xcj0yx9hh97w47ixr1np7szw9y62zxqy9phzpk6yc2qm68";
+  version = "1.5.4";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.4-python-3.10.11-bundle.tgz;
+  sha256 = "sha256:0n25d8isdyjpafwrlszpsw3xi9kik24gz9b8qd9q84g9iqwxg0zp";
   inherit python pypkgs;
 }

--- a/pkgs/poetry/poetry-py3.11.nix
+++ b/pkgs/poetry/poetry-py3.11.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.3";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.3-python-3.11.3-bundle.tgz;
-  sha256 = "sha256:0vrpl5izgmz3g5ihk5wkm2lswaxsffp3w153xg3ssfnq47xzc0p4";
+  version = "1.5.4";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.4-python-3.11.3-bundle.tgz;
+  sha256 = "sha256:153i36hhpnyr5wj4x0klfmzsxakmi1hmsahppd7q0mf0fchdlgwx";
   inherit python pypkgs;
 }

--- a/pkgs/poetry/poetry-py3.8.nix
+++ b/pkgs/poetry/poetry-py3.8.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.3";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.3-python-3.8.17-bundle.tgz;
-  sha256 = "sha256:0vazh05z7zfwbgbykq6xaba6dkfhvspf9rikpvqnnic5v7izm502";
+  version = "1.5.4";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.4-python-3.8.17-bundle.tgz;
+  sha256 = "sha256:061zcr31caf5p5qi7jxqz7hnw5ic26737lykd8vjs4yl4w9qsrwd";
   inherit python pypkgs;
 }

--- a/pkgs/poetry/poetry-py3.8.nix
+++ b/pkgs/poetry/poetry-py3.8.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
   version = "1.5.3";
-  url = "https://storage.googleapis.com/poetry-bundles/poetry-1.5.3-python-3.8.17-bundle.tgz";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.3-python-3.8.17-bundle.tgz;
   sha256 = "sha256:0vazh05z7zfwbgbykq6xaba6dkfhvspf9rikpvqnnic5v7izm502";
   inherit python pypkgs;
 }


### PR DESCRIPTION
Why
===

Resolves [installing redberry breaks poetry](https://linear.app/replit/issue/DX-380/installing-redberry-breaks-poetry), as well as https://ask.replit.com/t/nix-error-when-installing-or-uninstalling-packages/94756

What changed
============

poetry wrapper removes `PYTHONUSERPATH` from `sys.path` before invoking `main()` to ensure that no user packages conflict with Poetry deps.

Test plan
=========

- [x] Already tested on devvm, verified bug, verified fix.
- [ ] Test in canary, install `redberry` (depends on `html5lib===1.0b8`, which causes the problem). Attempt to uninstall `redberry`, verify poetry does not crash.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
