### PR TITLE
rename vue module to indicate node 18 (not 20)

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1170,5 +1170,9 @@
   "vue-node-20:v1-20231220-a18bbd4": {
     "commit": "a18bbd4b3508bf0c247a67f407cbd9023b8d2ebb",
     "path": "/nix/store/lmk3sapswzjx1clighaxdaw7c0hp411x-replit-module-vue-node-20"
+  },
+  "vue-node-18:v1-20240116-3ea4bcd": {
+    "commit": "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7",
+    "path": "/nix/store/87p91q8irymjmykl8bc3ccq62i00qv78-replit-module-vue-node-18"
   }
 }

--- a/pkgs/modules/vue/default.nix
+++ b/pkgs/modules/vue/default.nix
@@ -11,8 +11,8 @@ let
 in
 
 {
-  id = "vue-node-20";
-  name = "Vue with Node.js 20 Tools";
+  id = "vue-node-18";
+  name = "Vue with Node.js 18 Tools";
 
   replit = {
     packages = [

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -80,6 +80,8 @@ in
   "rust-1.72:v1-20230911-f253fb1" = { to = "rust-stable:v1-20231012-19c270f"; auto = true; };
 
   "swift" = { to = "swift-5.6:v1-20230525-c48c43c"; auto = true; };
+
+  "vue-node-20:v1-20231220-a18bbd4" = { to = "vue-node-18:v1-20240116-3ea4bcd"; auto = true; };
 }
 // (fns.linearUpgrade "bash")
 // (fns.linearUpgrade "c-clang14")
@@ -115,5 +117,4 @@ in
 // (fns.linearUpgrade "rust-stable")
 // (fns.linearUpgrade "svelte-kit-node-20")
 // (fns.linearUpgrade "swift-5.8")
-// (fns.linearUpgrade "vue-node-20")
   // (fns.linearUpgrade "web")


### PR DESCRIPTION
Why
===

oof, i didn't check the `node --version` output before i released the template and noticed that the module is actually shipping node 18, not 20

i'll follow up in another pr to use nodejs_20, but this PR is to address the naming issue, which will be guaranteed to not break user envs by not silently upgrading users to node 20.

What changed
============

- renamed the `vue-node-20` module to `vue-node-18` and update the title of the module appropriately
- upgrade `vue-node-20:v1` to `vue-node-18:v1` automatically

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
