### PR TITLE
upgrade vue module to node 20

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1171,6 +1171,10 @@
     "commit": "a18bbd4b3508bf0c247a67f407cbd9023b8d2ebb",
     "path": "/nix/store/lmk3sapswzjx1clighaxdaw7c0hp411x-replit-module-vue-node-20"
   },
+  "vue-node-20:v2-20240116-2181bf7": {
+    "commit": "2181bf7e0edc9eb2adced53ffd034a975582a7e3",
+    "path": "/nix/store/iyhmq1qij7mvwxns9ll8icmpgg7716lj-replit-module-vue-node-20"
+  },
   "vue-node-18:v1-20240116-3ea4bcd": {
     "commit": "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7",
     "path": "/nix/store/87p91q8irymjmykl8bc3ccq62i00qv78-replit-module-vue-node-18"

--- a/pkgs/modules/vue/default.nix
+++ b/pkgs/modules/vue/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 
 let
-  inherit (pkgs) nodejs;
+  nodejs = pkgs.nodejs_20;
   nodepkgs = nodejs.pkgs;
 
   vue-language-server = pkgs.callPackage ../../vue-language-server { };
@@ -11,8 +11,8 @@ let
 in
 
 {
-  id = "vue-node-18";
-  name = "Vue with Node.js 18 Tools";
+  id = "vue-node-20";
+  name = "Vue with Node.js 20 Tools";
 
   replit = {
     packages = [
@@ -25,7 +25,7 @@ in
     dev.runners.dev-runner = {
       name = "package.json dev script";
       inherit language extensions;
-      start = "${pkgs.nodejs}/bin/npm run dev";
+      start = "${nodejs}/bin/npm run dev";
     };
 
     dev.languageServers.vue-language-server = {


### PR DESCRIPTION
Why
===

follow up from #230. this upgrades the vue module to node 20. note that #230 corrects an issue where the v1 of `vue-node-20` is actually using node 18. as such, node 20 for vue starts with `vue-node-20:v2`

What changed
============

upgraded the vue nixmodule to node 20

Test plan
=========

- load the module in a repl
- `node --version` prints 20.x
- in a fork of the [Vue template](https://replit.com/@replit/VueJS-beta?v=1) upgrade the version to v2
- `kill 1` and reload the workspace
- run button and lsp still work

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
