### PR TITLE
jitter to 1s in canary/prerelease

### DIFF
--- a/manifests/service.pvn.yaml
+++ b/manifests/service.pvn.yaml
@@ -24,6 +24,10 @@ service:
       description: duration to wait between pulls of new configs
       string:
         defaultValue: "3600s"
+    - name: canary_jitter
+      description: duration to wait between pulls of new configs in non prod stages
+      string:
+        defaultValue: "1s"
   perReleaseChannel:
     - releaseChannel: canary
       runtimeExtension:
@@ -36,15 +40,8 @@ service:
             string: >-
               {
                 "version":"{{.Params.nixmodules_version}}",
-                "configPullJitter":"1s"
+                "configPullJitter":"{{.Params.canary_jitter}}"
               }
-    # - releaseChannel: test-templates
-    #   externalConfig:
-    #     type: KUBERNETES
-    #     local:
-    #       path: test_templates.yaml
-
-
     - releaseChannel: tarpit
       runtimeConnection: config-raw
       runtimeExtension:
@@ -155,7 +152,7 @@ service:
             string: >-
               {
                 "version":"{{.Params.nixmodules_version}}",
-                "configPullJitter":"{{.Params.jitter}}"
+                "configPullJitter":"{{.Params.canary_jitter}}"
               }
     - releaseChannel: prerelease
       runtimeConnection: config-raw
@@ -171,7 +168,7 @@ service:
             string: >-
               {
                 "version":"{{.Params.nixmodules_version}}",
-                "configPullJitter":"{{.Params.jitter}}"
+                "configPullJitter":"{{.Params.canary_jitter}}"
               }
     - releaseChannel: picard
       runtimeConnection: config-raw

--- a/manifests/service.pvn.yaml
+++ b/manifests/service.pvn.yaml
@@ -24,7 +24,7 @@ service:
       description: duration to wait between pulls of new configs
       string:
         defaultValue: "3600s"
-    - name: canary_jitter
+    - name: nonprod_jitter
       description: duration to wait between pulls of new configs in non prod stages
       string:
         defaultValue: "1s"
@@ -40,7 +40,7 @@ service:
             string: >-
               {
                 "version":"{{.Params.nixmodules_version}}",
-                "configPullJitter":"{{.Params.canary_jitter}}"
+                "configPullJitter":"{{.Params.nonprod_jitter}}"
               }
     - releaseChannel: tarpit
       runtimeConnection: config-raw
@@ -152,7 +152,7 @@ service:
             string: >-
               {
                 "version":"{{.Params.nixmodules_version}}",
-                "configPullJitter":"{{.Params.canary_jitter}}"
+                "configPullJitter":"{{.Params.nonprod_jitter}}"
               }
     - releaseChannel: prerelease
       runtimeConnection: config-raw
@@ -168,7 +168,7 @@ service:
             string: >-
               {
                 "version":"{{.Params.nixmodules_version}}",
-                "configPullJitter":"{{.Params.canary_jitter}}"
+                "configPullJitter":"{{.Params.nonprod_jitter}}"
               }
     - releaseChannel: picard
       runtimeConnection: config-raw


### PR DESCRIPTION
Why
===

https://replit.slack.com/archives/C03DMFRB1U6/p1705523790938779

What changed
============

jitter to 1s in nonprod

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
