### PR TITLE
Supply nix cache secrets to builder

### DIFF
--- a/.semaphore/build-nixmodules.yml
+++ b/.semaphore/build-nixmodules.yml
@@ -40,6 +40,8 @@ blocks:
             - set -o pipefail
             - scripts/setup_nix_binary_cache.py
             - scripts/build_disk_image.sh 2>&1 | tee nixmodules_build.log
+      secrets:
+        - name: nix-build-cache-auth
       epilogue:
         always:
           commands:


### PR DESCRIPTION
Why
===

So, this error:
<img width="826" alt="image" src="https://github.com/replit/nixmodules/assets/278900/a55c8109-087d-4c99-a845-6a6a4e44fb3c">

seems to be due to `scripts/setup_nix_binary_cache.py`'s `create_netrc()` needing [these envvars](https://github.com/replit/nixmodules/blob/bb8c970212b268195022dc4b050bfc25d580f648/scripts/setup_nix_binary_cache.py#L49-L53)
<img width="443" alt="image" src="https://github.com/replit/nixmodules/assets/278900/74d4b555-dd6e-4aaf-a88d-7bfb339a409d">

which would be provided by

<img width="1047" alt="image" src="https://github.com/replit/nixmodules/assets/278900/a944946a-5ee4-4d2b-b2f7-f1ff2230105e">

if this secret were available

<img width="737" alt="image" src="https://github.com/replit/nixmodules/assets/278900/715460ab-bb92-4c24-ad24-2d1f34efa527">


What changed
============

Expose that secret to the build phase

Test plan
=========

Verify that warning disappears. Presumably the build cache being present will only make the build faster, and we can rely on nix to not ship something broken beyond that.

Rollout
=======

N/A

- [x] This is fully backward and forward compatible
