### PR TITLE
Log netrc path and hash contents

### DIFF
--- a/scripts/build_disk_image.sh
+++ b/scripts/build_disk_image.sh
@@ -10,6 +10,13 @@ set -eo pipefail
 # To run, make sure you are logged in via:
 # gcloud auth login
 
+# We've been having some authentication-related issues. Sledgehammer to figure out what's wrong.
+if hash md5sum; then
+  md5sum $(nix --extra-experimental-features nix-command show-config netrc-file) || true
+elif hash md5; then
+  md5 $(nix --extra-experimental-features nix-command show-config netrc-file) || true
+fi
+
 rev=$(nix build --refresh --quiet .#rev --print-out-paths $NIX_FLAGS| xargs cat)
 
 img_name="nixmodules-${rev}"


### PR DESCRIPTION
Why
===

Despite #236, we're still getting the same error. Instead of guessing, let's see what the state of the world looks like.

What changed
============

Informational logging around the existence and path of what nix thinks the netrc file looks like. This should be safe to stay to help debug future config drift as well.

Test plan
=========

Tested `nix --extra-experimental-features nix-command show-config netrc-file` on a devbox

Rollout
=======

N/a

- [x] This is fully backward and forward compatible
