### PR TITLE
Supplying poetry config.toml with empty contents to suppress poetry error

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -595,6 +595,10 @@
     "commit": "0bd73cd137ee828d927e95d97e8199e7b66b6c29",
     "path": "/nix/store/ii8s3313impgc8v74l9v9nvr85lvmzng-replit-module-python-3.10"
   },
+  "python-3.10:v41-20240117-c740790": {
+    "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
+    "path": "/nix/store/yl6qynci35jjjw50h7ig1sq8c78a8qay-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -863,6 +867,10 @@
     "commit": "0bd73cd137ee828d927e95d97e8199e7b66b6c29",
     "path": "/nix/store/vy92v8wxjqljkl7qn0ndnqfi4i2l31sp-replit-module-python-3.11"
   },
+  "python-3.11:v22-20240117-c740790": {
+    "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
+    "path": "/nix/store/iq8wc3hrb02mmhsa6rdnpf6wj68hwfij-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -946,6 +954,10 @@
   "python-3.8:v21-20240117-0bd73cd": {
     "commit": "0bd73cd137ee828d927e95d97e8199e7b66b6c29",
     "path": "/nix/store/rfk3j8q7jzj8l0zbc5ajf2i72x4zj1p9-replit-module-python-3.8"
+  },
+  "python-3.8:v22-20240117-c740790": {
+    "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
+    "path": "/nix/store/wpk69pvy0y8barc149f934w1x79pbnvx-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1102,6 +1114,10 @@
   "python-with-prybar-3.10:v19-20240117-0bd73cd": {
     "commit": "0bd73cd137ee828d927e95d97e8199e7b66b6c29",
     "path": "/nix/store/l0ywpr6hiqrqjgbdx5yy5npflfajyh6j-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v20-20240117-c740790": {
+    "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
+    "path": "/nix/store/pcj5rzyay0nypwhifksm1k2fk0whsv85-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -28,13 +28,8 @@ let
   poetry-config = pkgs.writeTextFile {
     name = "poetry-config";
     text = ''
-      [[tool.poetry.source]]
-      name = "replit"
-      url = "https://package-proxy.replit.com/pypi/simple/"
-      default = true
-
     '';
-    destination = "/conf.toml";
+    destination = "/config.toml";
   };
 
   debugpy = pypkgs.debugpy.overridePythonAttrs


### PR DESCRIPTION
Why
===

Resolves https://linear.app/replit/issue/DX-367/poetry-config-errors .

`poetry config` attempts to create the config file at `$POETRY_CONFIG_DIR/config.toml` if it doesn't exist. An empty file is fine.

The previous `conf.toml` does not appear to be used by anything.

What changed
============

Removed `conf.toml`, created an empty `config.toml`

Test plan
=========

Tested `poetry conf` locally with an empty `config.toml`

Rollout
=======

- [x] This is fully backward and forward compatible
