### PR TITLE
[angular] run "npm run start" instead of "npm run dev"

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1354,5 +1354,9 @@
   "angular-node-20:v1-20231220-48a5a72": {
     "commit": "48a5a72ac95590da6719cf0c7f2dc728b1087903",
     "path": "/nix/store/8b167sws0ngpb3f9pvlmncx23j590min-replit-module-angular-node-20"
+  },
+  "angular-node-20:v2-20240124-02d14a4": {
+    "commit": "02d14a4b0fd84ad1e451a613838931144a8788e9",
+    "path": "/nix/store/3ai9vin6330qicbyyfqs6n0n70zzy286-replit-module-angular-node-20"
   }
 }

--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -37,9 +37,9 @@ in
     dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".mjs" ".mts" ".cjs" ".cts" ".es6" ];
 
     dev.runners.dev-runner = {
-      name = "package.json dev script";
+      name = "package.json watch script";
       inherit language;
-      start = "${nodejs}/bin/npm run dev";
+      start = "${nodejs}/bin/npm run start";
     };
 
     dev.languageServers.angular-language-server = {


### PR DESCRIPTION
Why
===

when i created the repl for the angular template, the run button didn't work because it ran `npm run dev` instead of `npm run start` which is what angular creates in its project creation instead.

What changed
============

- changed the angular runner to run `npm run start` instead of `npm run dev`

Test plan
=========

- create new repl
- `npm i -g @angular/cli`
- `ng new my-angular-project`
- `mv my-angular-project/* my-angular-project/.* .`
- click run button
- it works

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
