### PR TITLE
DX-415: Temporarily work around upm lock slowdown

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -599,6 +599,10 @@
     "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
     "path": "/nix/store/yl6qynci35jjjw50h7ig1sq8c78a8qay-replit-module-python-3.10"
   },
+  "python-3.10:v42-20240125-d91747b": {
+    "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
+    "path": "/nix/store/8aac58hws572pzqmdy0ivqyilfivppk4-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -871,6 +875,10 @@
     "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
     "path": "/nix/store/iq8wc3hrb02mmhsa6rdnpf6wj68hwfij-replit-module-python-3.11"
   },
+  "python-3.11:v23-20240125-d91747b": {
+    "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
+    "path": "/nix/store/mw6msfs65l4wd03jdrfa5dyp1y3814w4-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -958,6 +966,10 @@
   "python-3.8:v22-20240117-c740790": {
     "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
     "path": "/nix/store/wpk69pvy0y8barc149f934w1x79pbnvx-replit-module-python-3.8"
+  },
+  "python-3.8:v23-20240125-d91747b": {
+    "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
+    "path": "/nix/store/g8vi5y4h9anfk4p4ikywsj6yhzdr6m6n-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1118,6 +1130,10 @@
   "python-with-prybar-3.10:v20-20240117-c740790": {
     "commit": "c740790111c4166c1764ba7073662129eef6b9d6",
     "path": "/nix/store/pcj5rzyay0nypwhifksm1k2fk0whsv85-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v21-20240125-d91747b": {
+    "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
+    "path": "/nix/store/58p275vnh2ajp0bi3w43pbj0150w39jk-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/poetry/poetry-in-venv.nix
+++ b/pkgs/poetry/poetry-in-venv.nix
@@ -30,6 +30,12 @@ pkgs.writeShellApplication {
     if [ "''${numVCpu}" = "0.5" ]; then
     export POETRY_INSTALLER_PARALLEL="0"
     fi
+    # Temporarily work around upm locking infrastructute being very slow
+    # In replit, poetry is not currently configured in such a way that this
+    # would ever print any virtualenv paths.
+    if [ "$1" = env ] && [ "$2" = list ]; then
+      exit 0
+    fi
     ${poetry}/bin/poetry "$@"
   '';
 }


### PR DESCRIPTION
Why
===

upm calls out to `poetry env list` during guess, add, lock, and remove. Inside a repl, poetry isn't (typically?) configured in such a way for this to return any entries, so just suppress that subcommand until `.pythonlibs` gets promoted to a virtualenv.

The only caveat here is if users have explicitly altered their envvars such that poetry is installing to a venv somewhere inside the repl directory, this would disable one of the conditionals in upm that would trigger a call to `Lock`.

What changed
============

Alter the `poetry-in-venv` wrapper to make any arglist starting with `env list` just `exit 0`, bypassing poetry.

Test plan
=========

I copied the poetry wrapper inside a repl, added these, and modified `poetry.lock` to trigger upm's desire to recheck the lock, verifying the early termination and subsequent speedup.

Rollout
=======

I don't anticipate this workaround being needed for more than a month, but should improve UX for users during that time.

- [x] This is fully backward and forward compatible
