### PR TITLE
[angular] actually run "npm run watch"

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1374,5 +1374,9 @@
   "angular-node-20:v2-20240124-02d14a4": {
     "commit": "02d14a4b0fd84ad1e451a613838931144a8788e9",
     "path": "/nix/store/3ai9vin6330qicbyyfqs6n0n70zzy286-replit-module-angular-node-20"
+  },
+  "angular-node-20:v3-20240126-939674c": {
+    "commit": "939674c9587905d8fb333e54e554288be95bda1b",
+    "path": "/nix/store/m9j5l1knjhrb5p5m57bcznaqncpd508d-replit-module-angular-node-20"
   }
 }

--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -39,7 +39,7 @@ in
     dev.runners.dev-runner = {
       name = "package.json watch script";
       inherit language;
-      start = "${nodejs}/bin/npm run start";
+      start = "${nodejs}/bin/npm run watch";
     };
 
     dev.languageServers.angular-language-server = {


### PR DESCRIPTION
Why
===

i'm silly and set the module to run `npm run start` instead of `npm run watch` in #244 

What changed
============

the "package.json watch script" runner now actually runs the `watch` script from `package.json`

Test plan
=========

same as #244 

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
