### PR TITLE
add rust-nightly nixmodule

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1227,6 +1227,10 @@
     "commit": "0bd73cd137ee828d927e95d97e8199e7b66b6c29",
     "path": "/nix/store/n5wn8jgxia9jisw615i1hk6alklpwckw-replit-module-rust-stable"
   },
+  "rust-stable:v5-20240126-d98d19e": {
+    "commit": "d98d19ee06a8b30ecabf9cf154fd403103c7fee6",
+    "path": "/nix/store/9s6kxk29chccbnwv4f0qgndmv2lrxj9i-replit-module-rust-stable"
+  },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
@@ -1378,5 +1382,9 @@
   "angular-node-20:v3-20240126-939674c": {
     "commit": "939674c9587905d8fb333e54e554288be95bda1b",
     "path": "/nix/store/m9j5l1knjhrb5p5m57bcznaqncpd508d-replit-module-angular-node-20"
+  },
+  "rust-nightly:v1-20240126-d98d19e": {
+    "commit": "d98d19ee06a8b30ecabf9cf154fd403103c7fee6",
+    "path": "/nix/store/f71v169hdnv8g9w5kjpmv9z4dhzpfzjp-replit-module-rust-nightly"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -45,6 +45,9 @@ let
       };
     })
 
+    (import ./rust "stable")
+    (import ./rust "latest")
+
     (import ./angular)
     (import ./bash)
     (import ./bun)
@@ -72,7 +75,6 @@ let
       ruby = pkgs.ruby_3_2;
       rubyPackages = pkgs.rubyPackages_3_2;
     })
-    (import ./rust)
     (import ./swift)
     (import ./svelte-kit)
     (import ./vue)

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -1,13 +1,15 @@
+fenix-channel-name:
 { pkgs, ... }:
 let
-  inherit (pkgs.fenix) stable;
+  rust-channel-name = if fenix-channel-name == "latest" then "nightly" else fenix-channel-name;
+  channel = pkgs.fenix."${fenix-channel-name}";
 in
 {
-  id = "rust-stable";
-  name = "Rust Tools";
+  id = "rust-${rust-channel-name}";
+  name = "Rust Tools (${rust-channel-name})";
 
   replit.packages = [
-    (stable.withComponents [
+    (channel.withComponents [
       "cargo"
       "llvm-tools"
       "rust-src"
@@ -20,7 +22,7 @@ in
   ];
 
   replit.dev.packages = [
-    stable.toolchain
+    channel.toolchain
   ];
 
   # TODO: should compile a binary to use in deployment and not include the runtime
@@ -28,7 +30,7 @@ in
     name = "cargo run";
     language = "rust";
 
-    start = "${stable.toolchain}/bin/cargo run";
+    start = "${channel.toolchain}/bin/cargo run";
     fileParam = false;
   };
 
@@ -36,10 +38,10 @@ in
     name = "rust-analyzer";
     language = "rust";
 
-    start = "${stable.toolchain}/bin/rust-analyzer";
+    start = "${channel.toolchain}/bin/rust-analyzer";
 
     initializationOptions = {
-      cargo.sysroot = "${stable.toolchain}";
+      cargo.sysroot = "${channel.toolchain}";
     };
   };
 

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -127,6 +127,7 @@ in
 // (fns.linearUpgrade "replit")
 // (fns.linearUpgrade "ruby-3.1")
 // (fns.linearUpgrade "ruby-3.2")
+// (fns.linearUpgrade "rust-nightly")
 // (fns.linearUpgrade "rust-stable")
 // (fns.linearUpgrade "svelte-kit-node-20")
 // (fns.linearUpgrade "swift-5.8")


### PR DESCRIPTION
Why
===

nightly isn't uncommon to use amongst rustaceans

What changed
============

added nightly nixmodule

Test plan
=========

- add nightly module
- `rustc --version` prints a nightly version
- template-tester with identical tests to \@replit/Rust work for nightly

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
