### PR TITLE
lock modules after pushing the flake update

### DIFF
--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -2,7 +2,7 @@ name: weekly updates
 
 on:
   schedule:
-    - cron: "0 8 * * 1"
+    - cron: "0 18 * * 1" # NOTE: Mondays at 6 pm GMT
 
 jobs:
   fenix:
@@ -16,9 +16,6 @@ jobs:
 
       - name: update Fenix
         run: nix flake lock --update-input fenix
-
-      - name: lock modules
-        run: nix develop -c python scripts/lock_modules.py
 
       - name: open PR
         uses: peter-evans/create-pull-request@v5
@@ -43,3 +40,11 @@ jobs:
             take care to ensure its contents are correct. This Workflow
             runs every week to ensure the rust-nightly module is regularly
             updated.
+
+      - name: lock modules
+        run: nix develop -c python scripts/lock_modules.py
+
+      - name: push locked modules
+        run: |
+          git commit -am 'lock modules'
+          git push actions/update-weekly


### PR DESCRIPTION
Why
===

my auto-update gha workflow failed to create the PR because the `flake.lock` wasn't committed/pushed before opening the PR

What changed
============

the pr is now created right after updating the `flake.lock` and before running `lock_modules.py`. there's some logic in the action to reset branches and such if the action is running on a branch that's already been pushed to, so this is the safest timing option, i think

Test plan
=========

find out in a little under an hour :)

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
