### PR TITLE
chore/liberate python

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -603,6 +603,10 @@
     "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
     "path": "/nix/store/8aac58hws572pzqmdy0ivqyilfivppk4-replit-module-python-3.10"
   },
+  "python-3.10:v43-20240202-3dbc1c2": {
+    "commit": "3dbc1c2c70a88b340da1dead86ddf05fbd374554",
+    "path": "/nix/store/s94vzyixcxnx68gx9ppzl6v9d1l647cs-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -879,6 +883,10 @@
     "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
     "path": "/nix/store/mw6msfs65l4wd03jdrfa5dyp1y3814w4-replit-module-python-3.11"
   },
+  "python-3.11:v24-20240202-3dbc1c2": {
+    "commit": "3dbc1c2c70a88b340da1dead86ddf05fbd374554",
+    "path": "/nix/store/rkgmx146jdcq9r7kq12bdzf1b7f6nrxq-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -970,6 +978,10 @@
   "python-3.8:v23-20240125-d91747b": {
     "commit": "d91747b1a9655b307a69613063d0599aef8b8f3e",
     "path": "/nix/store/g8vi5y4h9anfk4p4ikywsj6yhzdr6m6n-replit-module-python-3.8"
+  },
+  "python-3.8:v24-20240202-3dbc1c2": {
+    "commit": "3dbc1c2c70a88b340da1dead86ddf05fbd374554",
+    "path": "/nix/store/hskcf7ymk2iigb3qczljh5g9355lplfq-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1138,6 +1150,10 @@
   "python-with-prybar-3.10:v22-20240203-ce85ddb": {
     "commit": "ce85ddbaacf5bb78c6fec1174ad6899abe102850",
     "path": "/nix/store/brnql4lydsahvv3xhw445nn544cq80fs-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v23-20240202-3dbc1c2": {
+    "commit": "3dbc1c2c70a88b340da1dead86ddf05fbd374554",
+    "path": "/nix/store/iwmnhv9cyxhhf99hq5051rlbinb3wi1n-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -12,16 +12,16 @@ let
 
   modulesList = [
     (import ./python {
-      python = pkgs-23_05.python38Full;
-      pypkgs = pkgs-23_05.python38Packages;
+      python = pkgs.python38Full;
+      pypkgs = pkgs.python38Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python310Full;
-      pypkgs = pkgs-23_05.python310Packages;
+      python = pkgs.python310Full;
+      pypkgs = pkgs.python310Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python311Full;
-      pypkgs = pkgs-23_05.python311Packages;
+      python = pkgs.python311Full;
+      pypkgs = pkgs.python311Packages;
     })
     (import ./python-with-prybar)
 

--- a/pkgs/pip/default.nix
+++ b/pkgs/pip/default.nix
@@ -26,7 +26,7 @@ pypkgs.buildPythonPackage rec {
     name = "${pname}-${version}-source";
   };
 
-  nativeBuildInputs = [ pypkgs.bootstrapped-pip ];
+  nativeBuildInputs = [ ];
 
   # pip detects that we already have bootstrapped_pip "installed", so we need
   # to force it a little.


### PR DESCRIPTION
Why
===

Switch python back to `nixpkgs-unstable`, `bootstrapped-pip` has been a noop for a while, from what I can tell (see https://github.com/NixOS/nixpkgs/pull/251824 for a little bit of context, though the implications are still somewhat over my head.)

Presumably if the disk builds and template tests pass, we're good to go.

What changed
============

Deleted the reference to bootstrapped-pip, switched python over to `nixpkgs-unstable`

Test plan
=========

- Built the disk locally with all suppported versions of python
- Ran some tests against local conman

Rollout
=======

- [x] This is fully backward and forward compatible
