### PR TITLE
Update python to unstable channel

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -643,6 +643,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/m05gv500jwmpsqzh8qa3clm449flgkrw-replit-module-python-3.10"
   },
+  "python-3.10:v45-20240206-43a6215": {
+    "commit": "43a6215b988e19ca3c4d03d34ed7cdc259e8278f",
+    "path": "/nix/store/zn59f2pamjabls5z8yxb99c7fcm9l2lx-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -955,6 +959,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/n5cn7qjfvw1w7a8sz3nnknbrq280byi4-replit-module-python-3.11"
   },
+  "python-3.11:v26-20240206-43a6215": {
+    "commit": "43a6215b988e19ca3c4d03d34ed7cdc259e8278f",
+    "path": "/nix/store/jlyglxz4svns7bzhak3cqz366h0h4v1p-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1054,6 +1062,10 @@
   "python-3.8:v25-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/9cgf0vrhfn9gac0cpzb8r1f3cr02fkhj-replit-module-python-3.8"
+  },
+  "python-3.8:v26-20240206-43a6215": {
+    "commit": "43a6215b988e19ca3c4d03d34ed7cdc259e8278f",
+    "path": "/nix/store/v1s06b3zv6znlazrsy7phqq6qf87hmhv-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1238,6 +1250,10 @@
   "python-with-prybar-3.10:v24-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/yxc1wvzrzvkkzg0js3q038zfxnsbrf25-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v25-20240206-43a6215": {
+    "commit": "43a6215b988e19ca3c4d03d34ed7cdc259e8278f",
+    "path": "/nix/store/vyh5v7r0m0jp8w6kiflaslq7s0yjgmxw-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -11,6 +11,7 @@ let
     ];
     specialArgs = {
       inherit pkgs pkgs-23_05;
+      pkgs-unstable = pkgs;
       modulesPath = builtins.toString ./.;
     };
   });

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -16,12 +16,12 @@ let
       pypkgs = pkgs-23_05.python38Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python310Full;
-      pypkgs = pkgs-23_05.python310Packages;
+      python = pkgs.python310Full;
+      pypkgs = pkgs.python310Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python311Full;
-      pypkgs = pkgs-23_05.python311Packages;
+      python = pkgs.python311Full;
+      pypkgs = pkgs.python311Packages;
     })
     (import ./python-with-prybar)
 

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -1,9 +1,9 @@
 { python, pypkgs }:
-{ pkgs-23_05, lib, ... }:
+{ pkgs-unstable, pkgs-23_05, lib, ... }:
 let
-  pkgs = pkgs-23_05;
-
   pythonVersion = lib.versions.majorMinor python.version;
+
+  pkgs = if pythonVersion == "3.8" then pkgs-23_05 else pkgs-unstable;
 
   pylibs-dir = ".pythonlibs";
 
@@ -15,10 +15,8 @@ let
   pythonWrapper = pythonUtils.pythonWrapper;
   python-ld-library-path = pythonUtils.python-ld-library-path;
 
-  pip = import ./pip.nix (pkgs // {
-    inherit python pypkgs;
-  });
-  pip-wrapper = pythonWrapper { bin = "${pip.bin}/bin/pip"; name = "pip"; };
+  pip = pypkgs.pip;
+  pip-wrapper = pythonWrapper { bin = "${pip}/bin/pip"; name = "pip"; };
 
   poetry = pkgs.callPackage (../../poetry/poetry-py + "${pythonVersion}.nix") {
     inherit python;
@@ -147,7 +145,7 @@ in
     POETRY_PIP_FROM_PATH = "1";
     POETRY_USE_USER_SITE = "1";
     PYTHONUSERBASE = userbase;
-    PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}:${pip.pip}/${python.sitePackages}";
+    PYTHONPATH = "${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}:${pip}/${python.sitePackages}";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.


### PR DESCRIPTION
Why
===

We have a lot of instance of people updating their nix channel in .replit to stable-23_11 and then sys deps causing this to break. If python's nix channel is at or ahead of stable-23_11, which breakage will be far less common. This is a short-term fix before we have a good rtld-loader-based solution.

What changed
============

1. Updated python-3.10 and 3.11's nix channel to unstable (which is ahead of 23_11)
2. Revert pip to pypkgs.pip
3. added pkgs-unstable argument for convenience when you need to pick between the 2 channels

Test plan
=========

1. template tests and sanity checks