### PR TITLE
[chore] Also upgrade python 3.8

### DIFF
--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -11,7 +11,6 @@ let
     ];
     specialArgs = {
       inherit pkgs pkgs-23_05;
-      pkgs-unstable = pkgs;
       modulesPath = builtins.toString ./.;
     };
   });

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -12,8 +12,8 @@ let
 
   modulesList = [
     (import ./python {
-      python = pkgs-23_05.python38Full;
-      pypkgs = pkgs-23_05.python38Packages;
+      python = pkgs.python38Full;
+      pypkgs = pkgs.python38Packages;
     })
     (import ./python {
       python = pkgs.python310Full;

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -3,7 +3,7 @@
 let
   pythonVersion = lib.versions.majorMinor python.version;
 
-  pkgs = if pythonVersion == "3.8" then pkgs-23_05 else pkgs-unstable;
+  pkgs = pkgs-unstable;
 
   pylibs-dir = ".pythonlibs";
 

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -1,9 +1,7 @@
 { python, pypkgs }:
-{ pkgs-unstable, pkgs-23_05, lib, ... }:
+{ pkgs, lib, ... }:
 let
   pythonVersion = lib.versions.majorMinor python.version;
-
-  pkgs = pkgs-unstable;
 
   pylibs-dir = ".pythonlibs";
 


### PR DESCRIPTION
Why
===

#256 had 3.8, but #257 skipped it. Tested locally, it seems to work, so upgrading that as well.

What changed
============

python 3.8 is no longer special-cased to 23_05.

Test plan
=========

Install python 3.8 module, try to import libraries that use native `.so` files

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
