### PR TITLE
Tool registry

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -51,6 +51,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/aijq229zv4bfnhqb4qjmqi4qyib065v2-replit-module-c-clang14"
   },
+  "c-clang14:v8-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/8737vy3r6zsjdyw480grjpyvzbv39gw7-replit-module-c-clang14"
+  },
   "clojure-1.11:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/giqq76fl3yphzsm6rkl1qxqh4mszknpl-replit-module-clojure-1.11"
@@ -70,6 +74,10 @@
   "clojure-1.11:v5-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/qqmsyb469gqhycr7agarj60fxp97y3b1-replit-module-clojure-1.11"
+  },
+  "clojure-1.11:v6-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/a0rn6xkzh736i9wfaljpm2arz9xkyyj0-replit-module-clojure-1.11"
   },
   "cpp-clang14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -99,6 +107,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/37b2nsikhh5v85ch387nrprgnd607j59-replit-module-cpp-clang14"
   },
+  "cpp-clang14:v8-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/wgnb6pyh3imjq5bxnlgzq1xdkj5b14pf-replit-module-cpp-clang14"
+  },
   "dart-2.18:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/mhl58f8y3z6jv0javkmx28y5h9aacw39-replit-module-dart-2.18"
@@ -126,6 +138,10 @@
   "dotnet-7.0:v5-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/qrapphhis2x9mhwhgnzqcvsl88rmqry6-replit-module-dotnet-7.0"
+  },
+  "dotnet-7.0:v6-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/vkw95ydpdsaixvjrpr9kc55hqashx0zb-replit-module-dotnet-7.0"
   },
   "go-1.19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -195,6 +211,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/66whlrli693bb1gab4kisnsl5whgi43g-replit-module-java-graalvm22.3"
   },
+  "java-graalvm22.3:v11-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/m1ss7zjq696hn0vwlzvxjyhzvlbq2x5l-replit-module-java-graalvm22.3"
+  },
   "lua-5.2:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/d6a5wl9pyla9si60plaxzmhqggywkcxy-replit-module-lua-5.2"
@@ -214,6 +234,10 @@
   "lua-5.2:v5-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/v1bf194ljb87prypxrb8dl97c0x7inzg-replit-module-lua-5.2"
+  },
+  "lua-5.2:v6-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/3l56r4d9bv413k5ywcgv8mm4yf3m7csy-replit-module-lua-5.2"
   },
   "nodejs-14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -351,6 +375,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/n9d44xcik6y90f2lp3rkr8w99p7hy45m-replit-module-nodejs-18"
   },
+  "nodejs-18:v29-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/k1i0ps5yrdcgb6wgxs75b643a043j9lf-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -462,6 +490,10 @@
   "nodejs-20:v25-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/9xzccj5h8xmz1mz454cw9lyr4m1mc2gl-replit-module-nodejs-20"
+  },
+  "nodejs-20:v26-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/qyd44aaz6rhrnf71izix3sb888ii9xg7-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -643,6 +675,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/m05gv500jwmpsqzh8qa3clm449flgkrw-replit-module-python-3.10"
   },
+  "python-3.10:v45-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/hb9chj2ccfxnyv8m0hch8cwcbj9575dx-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -666,6 +702,10 @@
   "qbasic:v6-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/yl8a0y0i4dcccb7hm30ylxrp0aysggqf-replit-module-qbasic"
+  },
+  "qbasic:v7-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/39jrxa0qd24cxi7iy5prh7pmphisv58f-replit-module-qbasic"
   },
   "r-4.2:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -707,6 +747,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/98p3qlwqf3y74p3hfs83gmg5fxrlxch5-replit-module-ruby-3.1"
   },
+  "ruby-3.1:v8-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/kfax6rn26vlkgdzznxvw02qg7gcpbsw3-replit-module-ruby-3.1"
+  },
   "rust-1.69:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/xkp307fdmgwn8dnbqadzlrb8fr0bvkx4-replit-module-rust-1.69"
@@ -743,6 +787,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/iqy45ig68sg7na3jbpirk7k5ziiv1jz9-replit-module-swift-5.8"
   },
+  "swift-5.8:v6-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/5lgc7fprybd0dynsadx2fvq7m480fsaq-replit-module-swift-5.8"
+  },
   "web:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7lhwlqy8nmrmc27n68ia16q6bn27cwk5-replit-module-web"
@@ -766,6 +814,10 @@
   "web:v6-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/jyzy4yr75y1am0dip2l0dfpwsbwdrgfn-replit-module-web"
+  },
+  "web:v7-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/7xfkqia0q89pcxbnnwb5lbxxas991hrj-replit-module-web"
   },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
@@ -811,6 +863,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/zz6f6mk0zjyjyiqmkhxlb3n4aa39lx8b-replit-module-pyright-extended"
   },
+  "pyright-extended:v12-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/r1q474ry0wlmz67wa3p1bwpjbiqrjkgc-replit-module-pyright-extended"
+  },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
@@ -839,6 +895,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/slgy4rgn4mbks3vk4jdnxb1ia7yz2k5j-replit-module-svelte-kit-node-20"
   },
+  "svelte-kit-node-20:v8-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/5ly9kwdviay14gg2glv1xkl80y0r0v4w-replit-module-svelte-kit-node-20"
+  },
   "gcloud:v1-20230815-e6e4431": {
     "commit": "e6e4431a8f1d71ec0664ce97828bede1608dcfd1",
     "path": "/nix/store/q67zzk6y4zzw7k6nc2plql97z1yv7xwx-replit-module-gcloud"
@@ -854,6 +914,10 @@
   "gcloud:v4-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/wi43yajcc2cfaynf3pi9x0raa275qpa1-replit-module-gcloud"
+  },
+  "gcloud:v5-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/6lh7wcp3azfvl769l9n4dxgkjvlj1k2j-replit-module-gcloud"
   },
   "python-3.11:v1-20230828-e4baa21": {
     "commit": "e4baa21ed52b51e2a4963fc8136f211a2b277455",
@@ -955,6 +1019,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/n5cn7qjfvw1w7a8sz3nnknbrq280byi4-replit-module-python-3.11"
   },
+  "python-3.11:v26-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/11ihbg6c0y98bnlp4i76l99ffr1qx6lr-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1055,6 +1123,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/9cgf0vrhfn9gac0cpzb8r1f3cr02fkhj-replit-module-python-3.8"
   },
+  "python-3.8:v26-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/qb49aj99v1y8zy9pdg77z9ldqhvrl976-replit-module-python-3.8"
+  },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/qf9aiylryg8lq5q4z7fcj11824k9rf17-replit-module-bun-1.0"
@@ -1127,6 +1199,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/h7msisixdpn89azgygliybv738bjgas5-replit-module-bun-1.0"
   },
+  "bun-1.0:v19-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/0li2nfmw63n16brwn5w4my0q441v0503-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -1146,6 +1222,10 @@
   "nix:v4-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/qh2fjmnln933si13qn3c130bxc8h225g-replit-module-nix"
+  },
+  "nix:v5-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/i90lbgfqvryw83shy1vcsxqi3mkgqwvg-replit-module-nix"
   },
   "python-with-prybar-3.10:v2-20230925-77b13e4": {
     "commit": "77b13e434deb254c3792ddd97191586c193a83a6",
@@ -1239,6 +1319,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/yxc1wvzrzvkkzg0js3q038zfxnsbrf25-replit-module-python-with-prybar-3.10"
   },
+  "python-with-prybar-3.10:v25-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/h114hwqcfpnh1b4i5lihddw149n8pm8r-replit-module-python-with-prybar-3.10"
+  },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",
     "path": "/nix/store/8v3laig35f30bvgw8mwjcsznk06l7vf3-replit-module-nodejs-with-prybar-18"
@@ -1315,6 +1399,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/kqn9j58plq10i4g4xs2qc1bhf6v1h7r3-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v20-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/b835avnb4dnmlx2p75pj1hcwlsh3w76l-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -1343,6 +1431,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/hiy1hswyv4fbddfc1y4z2hkm2sygjvjy-replit-module-rust-stable"
   },
+  "rust-stable:v7-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/9sl10as4lqa0f8qmzf2i05i2718amwr9-replit-module-rust-stable"
+  },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
@@ -1358,6 +1450,10 @@
   "go-1.21:v4-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/8xb80ahapnmbbi8vvikkl434bap1bj57-replit-module-go-1.21"
+  },
+  "go-1.21:v5-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/qhp8azymk20wjz1w5awpr82h9d9m9p73-replit-module-go-1.21"
   },
   "docker:v1-20231026-3990bf0": {
     "commit": "3990bf05353ec3cffd54b8376616fdf6165d4580",
@@ -1399,6 +1495,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/aiykv2agr4y7jpzl5n400hq4wq1pdng3-replit-module-docker"
   },
+  "docker:v11-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/dfy3dsys7g5a1ykrqcrbdbp55x5wjrm7-replit-module-docker"
+  },
   "ruby-3.2:v1-20231130-c16dd76": {
     "commit": "c16dd76d69047cb0cccdd37b39c6163b130368a6",
     "path": "/nix/store/2n9kykvlhk9h1xp6d99839wqf6bd7hl6-replit-module-ruby-3.2"
@@ -1419,6 +1519,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/6vmcdng47v69xc2xjbbk43391mx1939a-replit-module-ruby-3.2"
   },
+  "ruby-3.2:v6-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/whpmpscmx65p7bkx1pwbaai3lmjbpww3-replit-module-ruby-3.2"
+  },
   "dart-3.1:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/ra46cfdhzrp1gn6rh4l5nnycn3vjv18l-replit-module-dart-3.1"
@@ -1435,6 +1539,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/3vm615s8hjb6a1c2nskw5yb7kaah6jjz-replit-module-haskell-ghc9.4"
   },
+  "haskell-ghc9.4:v4-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/i4708nb102dc1zriq51izrz7mk1xznwv-replit-module-haskell-ghc9.4"
+  },
   "php-8.2:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/8whfz8mxysaz299a54kvpm0a96gc89v3-replit-module-php-8.2"
@@ -1447,6 +1555,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/rxbbq3adb719klz06apdg55xn8kfkn8z-replit-module-php-8.2"
   },
+  "php-8.2:v4-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/z03aivbdsfzj18gxq7jzk5zpmqhs9p73-replit-module-php-8.2"
+  },
   "r-4.3:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/naz6n9b9fd8swy5yb2i9sn4haw4h3c48-replit-module-r-4.3"
@@ -1458,6 +1570,10 @@
   "r-4.3:v3-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/kgdl7dyn8zcrgwz25v576qi9bkaxlnws-replit-module-r-4.3"
+  },
+  "r-4.3:v4-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/ywqj5dsha9ar22mj24miyc8b8pvpd81z-replit-module-r-4.3"
   },
   "replit:v1-20231211-d5ddcff": {
     "commit": "d5ddcff9419456ecf54d2582c4b1cc4242198ac0",
@@ -1475,6 +1591,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/fjjg8nyqxsjpbjxa5gfzrapm01irwva7-replit-module-replit"
   },
+  "replit:v5-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/2awisfflrn4n3v7083w5qr8chgxqxz1x-replit-module-replit"
+  },
   "bash:v1-20231215-e6d471c": {
     "commit": "e6d471c9fd81b6ca469e1c42692953146c7cfb20",
     "path": "/nix/store/0j5kz53myr8kycfc4w1vkfccz4m5rsyv-replit-module-bash"
@@ -1487,6 +1607,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/27lisnmyfh60813gk80gp7awiaksisxv-replit-module-bash"
   },
+  "bash:v4-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/mn21mqnii6m2vn4d5zhs6yfssmi6kkgz-replit-module-bash"
+  },
   "deno-1:v1-20231215-5d427a8": {
     "commit": "5d427a83eae4fc1be41c3842b294c98f41271462",
     "path": "/nix/store/z02na0yx2xlnrkaaf1k515ddnib8hd2h-replit-module-deno-1"
@@ -1498,6 +1622,10 @@
   "deno-1:v3-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/nrhfc5h5r5167swsbpb0hmkpgx86y7lx-replit-module-deno-1"
+  },
+  "deno-1:v4-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/rmv0hwj7iaicabq1i7wc06val212wa0h-replit-module-deno-1"
   },
   "vue-node-20:v1-20231220-a18bbd4": {
     "commit": "a18bbd4b3508bf0c247a67f407cbd9023b8d2ebb",
@@ -1515,6 +1643,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/askp3p6sggbmll6lc11rd5c4fm67xyah-replit-module-vue-node-20"
   },
+  "vue-node-20:v5-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/gmq3avvi8gflwva26h3ghpmf1yz84rms-replit-module-vue-node-20"
+  },
   "vue-node-18:v1-20240116-3ea4bcd": {
     "commit": "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7",
     "path": "/nix/store/87p91q8irymjmykl8bc3ccq62i00qv78-replit-module-vue-node-18"
@@ -1526,6 +1658,10 @@
   "dart-3.2:v2-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/chli288r2pfhcs42md4b7a895kzirwxc-replit-module-dart-3.2"
+  },
+  "dart-3.2:v3-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/431b32bhh50k25cxvppspy6smschm7rz-replit-module-dart-3.2"
   },
   "angular-node-20:v1-20231220-48a5a72": {
     "commit": "48a5a72ac95590da6719cf0c7f2dc728b1087903",
@@ -1543,6 +1679,10 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/5bddd28fb8ywhg8zfbfdacfkr8lc5av4-replit-module-angular-node-20"
   },
+  "angular-node-20:v5-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/n6rshi31l1bhdcdyhz072bri6zrp0v81-replit-module-angular-node-20"
+  },
   "rust-nightly:v1-20240126-d98d19e": {
     "commit": "d98d19ee06a8b30ecabf9cf154fd403103c7fee6",
     "path": "/nix/store/f71v169hdnv8g9w5kjpmv9z4dhzpfzjp-replit-module-rust-nightly"
@@ -1551,8 +1691,16 @@
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/9cz5z738s9vc45dvfkmgm2cp5inmhj3h-replit-module-rust-nightly"
   },
+  "rust-nightly:v3-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/ib074ai3cmi4rszc8i9b38yjnxhamlc6-replit-module-rust-nightly"
+  },
   "hermit-0.38.2:v1-20240208-9bf7683": {
     "commit": "9bf76831508415761756fbb980dabe6d21b6394f",
     "path": "/nix/store/iy17j7mn74d26bdd19k5v0cciipdf6hp-replit-module-hermit-0.38.2"
+  },
+  "hermit-0.38.2:v2-20240209-9e3a339": {
+    "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
+    "path": "/nix/store/b5hnppfyidr85xbcka15nr9ii5icnanm-replit-module-hermit-0.38.2"
   }
 }

--- a/pkgs/bundle-locked/default.nix
+++ b/pkgs/bundle-locked/default.nix
@@ -32,6 +32,10 @@ let
     inherit pkgs self modulesLocks;
   };
 
+  registry = import ../registry {
+    inherit pkgs self modulesLocks;
+  };
+
 in
 
 (pkgs.linkFarm "nixmodules-bundle" ([
@@ -51,10 +55,15 @@ in
     name = "etc/nixmodules/recommend-upgrade.json";
     path = "${upgrade-maps}/recommend-upgrade.json";
   }
+  {
+    name = "etc/nixmodules/registry.json";
+    path = registry;
+  }
 ] ++ (
   mapAttrsToList (name: value: { inherit name; path = value; }) modules
 ))).overrideAttrs (finalAttrs: previousAttrs: {
   passthru = {
     inherit active-modules;
+    inherit registry;
   };
 })

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -59,7 +59,15 @@ rec {
       inherit pkgs upgrade-maps;
     };
   };
-  inherit (bundle-locked) active-modules;
+
+  custom-bundle-locked = bundle-locked-fn {
+    modulesLocks = import ./filter-modules-locks {
+      inherit pkgs upgrade-maps;
+      moduleIds = [ "python-3.10" "nodejs-20" ];
+    };
+  };
+
+  inherit (bundle-locked) active-modules registry;
 
   bundle-image = bundle-squashfs-fn { };
 

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -117,7 +117,7 @@ let
         '';
       };
 
-      display-version = mkOption {
+      displayVersion = mkOption {
         type = types.str;
         description = lib.mdDoc ''
           The display version of the runner.
@@ -201,7 +201,7 @@ let
         '';
       };
 
-      display-version = mkOption {
+      displayVersion = mkOption {
         type = types.str;
         description = lib.mdDoc ''
           The display version of the language server.
@@ -261,7 +261,7 @@ let
         '';
       };
 
-      display-version = mkOption {
+      displayVersion = mkOption {
         type = types.str;
         description = lib.mdDoc ''
           The display version of the formatter.
@@ -309,7 +309,7 @@ let
         '';
       };
 
-      display-version = mkOption {
+      displayVersion = mkOption {
         type = types.str;
         description = lib.mdDoc ''
           The display version of the debugger.
@@ -436,7 +436,7 @@ let
         '';
       };
 
-      display-version = mkOption {
+      displayVersion = mkOption {
         type = types.str;
         description = lib.mdDoc ''
           The display version of the language server.
@@ -610,7 +610,7 @@ in
       description = "Name of the module";
     };
 
-    display-version = mkOption {
+    displayVersion = mkOption {
       type = types.str;
       description = "Display version - version of the main product (language or framework) provided by this module";
       default = "";
@@ -671,7 +671,7 @@ in
         moduleJSON = {
           id = config.id;
           name = config.name;
-          display-version = config.display-version;
+          displayVersion = config.displayVersion;
           description = config.description;
           env = envWithMergedPath allEnv (lib.makeBinPath allPackages);
           initializers = allInitializers;
@@ -697,7 +697,7 @@ in
         moduleJSON = {
           id = config.id;
           name = config.name;
-          display-version = config.display-version;
+          displayVersion = config.displayVersion;
           description = config.description;
           env = envWithMergedPath config.replit.env (lib.makeBinPath config.replit.packages);
           initializers = config.replit.initializers;

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -11,7 +11,7 @@ in
 {
   id = "bun-${community-version}";
   name = "Bun Tools";
-  display-version = bun.version;
+  displayVersion = bun.version;
 
   imports = [
     (import ../run-package-json {

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -34,7 +34,7 @@ in
 {
   id = "java-graalvm${short-graalvm-version}";
   name = "Java Tools (with Graal VM)";
-  display-version = graalvm.version;
+  displayVersion = graalvm.version;
 
   replit.packages = [
     graalvm
@@ -43,7 +43,7 @@ in
 
   replit.runners.graal = {
     name = "GraalVM ${short-graalvm-version}";
-    display-version = graalvm.version;
+    displayVersion = graalvm.version;
     language = "java";
 
     compile = graal-compile-command;
@@ -62,7 +62,7 @@ in
 
   replit.dev.debuggers.java-debug = {
     name = "Jave Debug";
-    display-version = java-debug.version;
+    displayVersion = java-debug.version;
     language = "java";
     extensions = [ ".java" ];
 
@@ -99,7 +99,7 @@ in
 
   replit.dev.languageServers.java-language-server = {
     name = "Java Language Server";
-    display-version = java-language-server.version;
+    displayVersion = java-language-server.version;
     language = "java";
 
     start = "${run-lsp}/bin/run-lsp";

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -43,7 +43,7 @@ in
 {
   id = "nodejs-${short-version}";
   name = "Node.js Tools";
-  display-version = nodejs.version;
+  displayVersion = nodejs.version;
   imports = [
     (import ../typescript-language-server {
       inherit nodepkgs;
@@ -66,7 +66,7 @@ in
 
     runners.nodeJS = {
       name = "Node.js";
-      display-version = nodejs.version;
+      displayVersion = nodejs.version;
       language = "javascript";
       start = "${nodejs-wrapped}/bin/node $file";
       fileParam = true;
@@ -118,7 +118,7 @@ in
 
     dev.formatters.prettier = {
       name = "Prettier";
-      display-version = nodepkgs.prettier.version;
+      displayVersion = nodepkgs.prettier.version;
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".html" ];
       start = {

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -52,7 +52,7 @@ let
   debuggerConfig = {
     dapPython = {
       name = "debugpy";
-      display-version = dapPython.version;
+      displayVersion = dapPython.version;
       language = "python3";
       start = {
         args = [ "${dapPython}/bin/dap-python" "$file" ];
@@ -102,7 +102,7 @@ in
 {
   id = "python-${pythonVersion}";
   name = "Python Tools";
-  display-version = python.version;
+  displayVersion = python.version;
 
   replit.packages = [
     python3-wrapper
@@ -112,7 +112,7 @@ in
 
   replit.runners.python = {
     name = "Python ${pythonVersion}";
-    display-version = python.version;
+    displayVersion = python.version;
     fileParam = true;
     language = "python3";
     start = "${python3-wrapper}/bin/python3 $file";
@@ -122,7 +122,7 @@ in
 
   replit.dev.languageServers.pyright-extended = {
     name = "pyright-extended";
-    display-version = pyright-extended.version;
+    displayVersion = pyright-extended.version;
     language = "python3";
     start = "${pyright-extended}/bin/langserver.index.js --stdio";
   };

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -20,7 +20,7 @@ in
 {
   replit.dev.languageServers.typescript-language-server = {
     name = "TypeScript Language Server";
-    display-version = typescript-language-server.version;
+    displayVersion = typescript-language-server.version;
     language = "javascript";
     start = "${typescript-language-server}/bin/typescript-language-server --stdio";
 

--- a/pkgs/registry/default.nix
+++ b/pkgs/registry/default.nix
@@ -1,0 +1,99 @@
+{ self, pkgs, modulesLocks }:
+with pkgs.lib;
+let
+  mapping = import ../upgrade-maps/mapping.nix pkgs;
+  isTerminal = mod: !((mapping.${mod} or false).auto or false);
+  shortModuleId = (module-id:
+    let
+      parts = strings.splitString ":" module-id;
+    in
+    elemAt parts 0
+  );
+  versionTag = (module-id:
+    let
+      parts = strings.splitString ":" module-id;
+    in
+    elemAt parts 1
+  );
+  get-version-num = (tag:
+    let
+      tag-parts = strings.splitString "-" tag;
+      version-str = elemAt tag-parts 0;
+      version = toInt (substring 1 (stringLength version-str) version-str);
+    in
+    version
+  );
+  latestModulesLocks = filterAttrs (module-id: _: isTerminal module-id) modulesLocks;
+  latestModules = mapAttrs
+    (
+      module-id: moduleLockInfo:
+        let
+          module = self.modules.${shortModuleId module-id};
+          module-info = (builtins.fromJSON (builtins.unsafeDiscardStringContext module.text));
+          parts = strings.splitString ":" module-id;
+          short-id = elemAt parts 0;
+          tag = elemAt parts 1;
+          version = get-version-num tag;
+        in
+        {
+          id = short-id;
+          inherit version;
+          inherit tag;
+          inherit (moduleLockInfo) commit path;
+        } // module-info
+    )
+    (filterAttrs (module-id: _: builtins.hasAttr (shortModuleId module-id) self.modules) latestModulesLocks);
+  registry = foldlAttrs
+    (acc: moduleId: module:
+      {
+        languageServers = acc.languageServers ++
+          mapAttrsToList
+            (lsp-id: lsp: {
+              id = lsp-id;
+              inherit moduleId;
+            } // lsp)
+            module.languageServers;
+        formatters = acc.formatters ++
+          mapAttrsToList
+            (formatter-id: formatter: {
+              id = formatter-id;
+              inherit moduleId;
+            } // formatter)
+            module.formatters;
+        packagers = acc.packagers ++
+          mapAttrsToList
+            (packager-id: packager: {
+              id = packager-id;
+              inherit moduleId;
+            } // packager)
+            module.packagers;
+        modules = acc.modules ++ [
+          {
+            inherit (module) id name description displayVersion version tag commit path;
+          }
+        ];
+      }
+    )
+    {
+      languageServers = [ ];
+      formatters = [ ];
+      packagers = [ ];
+      modules = [ ];
+    }
+    latestModules;
+in
+pkgs.stdenv.mkDerivation {
+  pname = "registry";
+  version = "1";
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = ''
+    echo '${builtins.toJSON registry}' > $out
+  '';
+  passthru = {
+    # this allows you to query for this info without building it:
+    # nix eval .#registry.info --json
+    info = registry;
+  };
+}


### PR DESCRIPTION
Why
===

Added toolchain registry to support #p_repl_configuration. Based on [this PoC](https://replit.slack.com/archives/C03KS2B221W/p1707152290346819?thread_ts=1707135666.740919&cid=C03KS2B221W). Will need pid1 update to take advantage.

What changed
============

1. Added `.#registry`
2. this will put `/etc/nixmodules/registry.json` containing:
  * available language serverss
  * available formatters
  * available packagers
  * available modules
  * but not runners or debuggers
3. registry.json will supercede `/etc/nixmodules/active-modules.json`
4. Renamed `display-version` to `displayVersion` to match naming convention in JSON space

Test plan
=========

1. `nix build .#registry`
2. `cat result |jq`

or

1. `nix build .#custom-bundle-locks`
2. `cat result/etc/nixmodules/registry.json`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
