### PR TITLE
Add hermit Nix module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1550,5 +1550,9 @@
   "rust-nightly:v2-20240206-fdbd396": {
     "commit": "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f",
     "path": "/nix/store/9cz5z738s9vc45dvfkmgm2cp5inmhj3h-replit-module-rust-nightly"
+  },
+  "hermit-0.38.2:v1-20240208-9bf7683": {
+    "commit": "9bf76831508415761756fbb980dabe6d21b6394f",
+    "path": "/nix/store/iy17j7mn74d26bdd19k5v0cciipdf6hp-replit-module-hermit-0.38.2"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -79,6 +79,7 @@ let
     (import ./svelte-kit)
     (import ./vue)
     (import ./web)
+    (import ./hermit)
   ];
 
   modules = builtins.listToAttrs (

--- a/pkgs/modules/hermit/default.nix
+++ b/pkgs/modules/hermit/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, lib, ... }:
+let
+  version = "0.38.2";
+
+  hermit = pkgs.buildGoModule rec {
+    pname = "hermit";
+    version = "0.38.2";
+
+    src = pkgs.fetchFromGitHub {
+      rev = "v${version}";
+      owner = "cashapp";
+      repo = "hermit";
+      hash = "sha256-cBVTIpY85lrKJ1bX1mIlUW1oWEHgg8wjdUh+0FHUp80=";
+    };
+
+    vendorHash = "sha256-W8n7WA1gHx73jHF69apoKnDCIKlbWkj5f1wVITt7F+M=";
+
+    subPackages = [ "cmd/hermit" ];
+
+    ldflags = [
+      "-X main.version=${version}"
+      "-X main.channel=stable"
+    ];
+
+    meta = with lib; {
+      homepage = "https://cashapp.github.io/hermit";
+      description = "Hermit manages isolated, self-bootstrapping sets of tools in software projects.";
+      license = licenses.asl20;
+      mainProgram = "hermit";
+    };
+  };
+in
+{
+  id = "hermit-${version}";
+  name = "Hermit Environment Manager";
+
+  replit.dev.packages = [
+    hermit
+  ];
+}


### PR DESCRIPTION
Why
===

Adds support for the Hermit environment manager: https://cashapp.github.io/hermit/

This is being added to upstream nixpkgs, but we can inline it here until that lands upstream: https://github.com/NixOS/nixpkgs/pull/287322#pullrequestreview-1871399467

What changed
============

- Add a new hermit module with the hermit CLI

Test plan
=========

- I'm new here

Rollout
=======

- [x] This is fully backward and forward compatible
