### PR TITLE
bun 1.0.26

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -379,6 +379,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/k1i0ps5yrdcgb6wgxs75b643a043j9lf-replit-module-nodejs-18"
   },
+  "nodejs-18:v30-20240213-5e75727": {
+    "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
+    "path": "/nix/store/bbjq3ymm9nz6s0i0vq9y0d1n2kns3zas-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -494,6 +498,10 @@
   "nodejs-20:v26-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/qyd44aaz6rhrnf71izix3sb888ii9xg7-replit-module-nodejs-20"
+  },
+  "nodejs-20:v27-20240213-5e75727": {
+    "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
+    "path": "/nix/store/j2yifwnn9mjyfs8f0hbaylpplgfrg2gl-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -1203,6 +1211,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/0li2nfmw63n16brwn5w4my0q441v0503-replit-module-bun-1.0"
   },
+  "bun-1.0:v20-20240213-5e75727": {
+    "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
+    "path": "/nix/store/c4rhx195x2z3i0my3dk8damrg086jrrr-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -1402,6 +1414,10 @@
   "nodejs-with-prybar-18:v20-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/b835avnb4dnmlx2p75pj1hcwlsh3w76l-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v21-20240213-5e75727": {
+    "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
+    "path": "/nix/store/5hs1qsw8rimv85mgnc1csw0lzv5a637r-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.0.23";
+  version = "1.0.26";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-IPQ4W8B4prlLljf7OviGpYtqNxSxMB1kHCMOrnbxldw=";
+    hash = "sha256-mWVe8BFGSXKJYnr2QXZah1XYfir5zN5+2wQ4HfgdOyE=";
   };
 }

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -67,6 +67,7 @@ in
   "bun-1.0:v14-20231219-faac932" = { to = "bun-1.0:v15-20240106-a63003a"; auto = true; };
   "bun-1.0:v15-20240106-a63003a" = { to = "bun-1.0:v16-20240116-9f73277"; auto = true; };
   "bun-1.0:v16-20240116-9f73277" = { to = "bun-1.0:v17-20240117-0bd73cd"; auto = true; };
+  "bun-1.0:v17-20240117-0bd73cd" = { to = "bun-1.0:v20-20240213-5e75727"; auto = true; };
 
   # dart minor versions aren't forwards-compatible
   "dart-3.0:v1-20230623-0b7a606".to = "dart-3.1:v1-20231201-3b22c78";


### PR DESCRIPTION
Why
===

user asked for bun update

What changed
============

upgraded bun from 1.0.23 to 1.0.26

Test plan
=========

load module in a repl, `bun --version` prints 1.0.26

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
