### PR TITLE
bun: support replit ld library path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,35 @@
     {
       overlays.default = final: prev: {
         moduleit = self.packages.${prev.system}.moduleit;
+
+        lib = prev.lib // {
+          mkWrapper-replit_ld_library_path = package: final.stdenvNoCC.mkDerivation {
+            name = "${package.name}-wrapped";
+            inherit (package) meta version;
+
+            buildInputs = [ pkgs.makeWrapper ];
+            buildCommand = ''
+              if [ ! -d ${package}/bin ]; then
+                echo "No bin directory found in ${package}"
+                exit 1
+              fi
+          
+              mkdir -p $out/bin
+          
+              for bin in ${package}/bin/*; do
+                local binName=$(basename $bin)
+                cat >$out/bin/$binName <<-EOF
+              #!${final.bash}/bin/bash
+              if [ -n "\''${REPLIT_LD_LIBRARY_PATH-}" ]; then
+                export LD_LIBRARY_PATH="\$REPLIT_LD_LIBRARY_PATH:\$LD_LIBRARY_PATH"
+              fi
+              exec "$bin" "\$@"
+              EOF
+                chmod +x $out/bin/$binName
+              done
+            '';
+          };
+        };
       };
       formatter.x86_64-linux = pkgs.nixpkgs-fmt;
       packages.x86_64-linux = import ./pkgs {

--- a/modules.json
+++ b/modules.json
@@ -383,6 +383,10 @@
     "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
     "path": "/nix/store/bbjq3ymm9nz6s0i0vq9y0d1n2kns3zas-replit-module-nodejs-18"
   },
+  "nodejs-18:v31-20240213-3f08513": {
+    "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
+    "path": "/nix/store/4pfjrkgk5vlpv38v86r3hr20y101c2k1-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -502,6 +506,10 @@
   "nodejs-20:v27-20240213-5e75727": {
     "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
     "path": "/nix/store/j2yifwnn9mjyfs8f0hbaylpplgfrg2gl-replit-module-nodejs-20"
+  },
+  "nodejs-20:v28-20240213-3f08513": {
+    "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
+    "path": "/nix/store/vd4fm7m4s33jgxamy58aplxpygmrrgva-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -1215,6 +1223,10 @@
     "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
     "path": "/nix/store/c4rhx195x2z3i0my3dk8damrg086jrrr-replit-module-bun-1.0"
   },
+  "bun-1.0:v21-20240213-3f08513": {
+    "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
+    "path": "/nix/store/i0kdqzjl5piv5ddi8s85dydjc6376w93-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -1418,6 +1430,10 @@
   "nodejs-with-prybar-18:v21-20240213-5e75727": {
     "commit": "5e75727b65212b4793aee2ee4d772a2fc82ce549",
     "path": "/nix/store/5hs1qsw8rimv85mgnc1csw0lzv5a637r-replit-module-nodejs-with-prybar-18"
+  },
+  "nodejs-with-prybar-18:v22-20240213-3f08513": {
+    "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
+    "path": "/nix/store/j67mvs3xg8xjng8wkarl2fphh85zk2mz-replit-module-nodejs-with-prybar-18"
   },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -2,6 +2,7 @@
 
 let
   bun = pkgs.callPackage ../../bun { };
+  bun-wrapped = pkgs.lib.mkWrapper-replit_ld_library_path bun;
 
   extensions = [ ".js" ".jsx" ".cjs" ".mjs" ".ts" ".tsx" ".mts" ];
 
@@ -15,8 +16,8 @@ in
 
   imports = [
     (import ../run-package-json {
-      runPackageJsonScript = "${bun}/bin/bun run";
-      runFileScript = "${bun}/bin/bun";
+      runPackageJsonScript = "${bun-wrapped}/bin/bun run";
+      runFileScript = "${bun-wrapped}/bin/bun";
     })
     (import ../typescript-language-server {
       nodepkgs = pkgs.nodePackages;
@@ -24,7 +25,7 @@ in
   ];
 
   replit.packages = [
-    bun
+    bun-wrapped
   ];
 
   replit.dev.languageServers.typescript-language-server.extensions = extensions ++ [ ".json" ];

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -2,26 +2,7 @@
 { pkgs, lib, ... }:
 
 let
-  nodejs-wrapped = pkgs.stdenvNoCC.mkDerivation {
-    name = "nodejs-wrapped";
-    buildInputs = [ pkgs.makeWrapper ];
-    buildCommand = ''
-      mkdir -p $out/bin
-      for bin in ${nodejs}/bin/*; do
-        local binName=$(basename $bin)
-        cat >$out/bin/$binName <<-EOF
-      #!${pkgs.bash}/bin/bash
-      if [ -n "\''${REPLIT_LD_LIBRARY_PATH-}" ]; then
-        export LD_LIBRARY_PATH="\$REPLIT_LD_LIBRARY_PATH:\$LD_LIBRARY_PATH"
-      fi
-      exec "$bin" "\$@"
-      EOF
-        chmod +x $out/bin/$binName
-      done
-    '';
-
-    inherit (nodejs) meta version;
-  };
+  nodejs-wrapped = pkgs.lib.mkWrapper-replit_ld_library_path nodejs;
 
   short-version = lib.versions.major nodejs.version;
 

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -68,6 +68,7 @@ in
   "bun-1.0:v15-20240106-a63003a" = { to = "bun-1.0:v16-20240116-9f73277"; auto = true; };
   "bun-1.0:v16-20240116-9f73277" = { to = "bun-1.0:v17-20240117-0bd73cd"; auto = true; };
   "bun-1.0:v17-20240117-0bd73cd" = { to = "bun-1.0:v20-20240213-5e75727"; auto = true; };
+  "bun-1.0:v20-20240213-5e75727" = { to = "bun-1.0:v21-20240213-3f08513"; auto = true; };
 
   # dart minor versions aren't forwards-compatible
   "dart-3.0:v1-20230623-0b7a606".to = "dart-3.1:v1-20231201-3b22c78";


### PR DESCRIPTION
Why
===

user asked for it

What changed
============

1. made an abstraction over the node wrapper generator for `REPLIT_LD_LIBRARY_PATH`
2. changed wrapped node to use abstraction
3. used abstraction for bun

Test plan
=========

with the bun module installed:
- in `.replit` set `REPLIT_LD_LIBRARY_PATH = "foo"`
- change `index.ts` to be `console.log(process.env.LD_LIBRARY_PATH)`
- running the program via run button results in `foo` being present
- running the program via `bun index.ts` has the same result

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
