### PR TITLE
Python to use rtld loader

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,6 +252,26 @@
         "type": "github"
       }
     },
+    "replit-rtld-loader": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1707923725,
+        "narHash": "sha256-FkahFyXa4OAE18HZz47da9IVCbV3t8EyClaVTvCWEkk=",
+        "owner": "replit",
+        "repo": "replit_rtld_loader",
+        "rev": "25fe9a9118525d458b44d689832d62b592d93a98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "replit",
+        "repo": "replit_rtld_loader",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "fenix": "fenix",
@@ -260,6 +280,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar",
+        "replit-rtld-loader": "replit-rtld-loader",
         "ztoc-rs": "ztoc-rs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,10 @@
   inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs";
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
   inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.replit-rtld-loader.url = "github:replit/replit_rtld_loader";
+  inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, fenix, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, fenix, replit-rtld-loader, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -23,6 +25,7 @@
           java-language-server.overlays.default
           nixd.overlays.default
           fenix.overlays.default
+          replit-rtld-loader.overlays.default
         ];
         # replbox has an unfree license
         config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
@@ -49,9 +52,9 @@
                 echo "No bin directory found in ${package}"
                 exit 1
               fi
-          
+
               mkdir -p $out/bin
-          
+
               for bin in ${package}/bin/*; do
                 local binName=$(basename $bin)
                 cat >$out/bin/$binName <<-EOF

--- a/modules.json
+++ b/modules.json
@@ -695,6 +695,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/hb9chj2ccfxnyv8m0hch8cwcbj9575dx-replit-module-python-3.10"
   },
+  "python-3.10:v46-20240214-9292ce3": {
+    "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
+    "path": "/nix/store/lzvx4znma7kxnz3whli3973y79b025j5-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1039,6 +1043,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/11ihbg6c0y98bnlp4i76l99ffr1qx6lr-replit-module-python-3.11"
   },
+  "python-3.11:v27-20240214-9292ce3": {
+    "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
+    "path": "/nix/store/kskbprw8x5phlc4vgx7r7m21kgnw86s4-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1142,6 +1150,10 @@
   "python-3.8:v26-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/qb49aj99v1y8zy9pdg77z9ldqhvrl976-replit-module-python-3.8"
+  },
+  "python-3.8:v27-20240214-9292ce3": {
+    "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
+    "path": "/nix/store/az4fpmwi6r0ixa5jc2an0scmsxxd18yc-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1346,6 +1358,10 @@
   "python-with-prybar-3.10:v25-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/h114hwqcfpnh1b4i5lihddw149n8pm8r-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v26-20240214-9292ce3": {
+    "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
+    "path": "/nix/store/za3mv2vs35ybvlhnjpcb374cfp2m15xb-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -32,12 +32,19 @@ let
       ldLibraryPathConvertWrapper = pkgs.writeShellApplication {
         inherit name;
         text = ''
-          export LD_LIBRARY_PATH=${python-ld-library-path}
-          if [ -n "''${PYTHON_LD_LIBRARY_PATH-}" ]; then
-            export LD_LIBRARY_PATH=''${PYTHON_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
-          fi
-          if [ -n "''${REPLIT_LD_LIBRARY_PATH-}" ]; then
-            export LD_LIBRARY_PATH=''${REPLIT_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
+          if test "$REPLIT_RTLD_LOADER" = "1" && test "$REPLIT_NIX_CHANNEL" != "legacy"
+          then
+            # activate RTLD loader!
+            export LD_AUDIT="${pkgs.replit-rtld-loader}/rtld_loader.so"
+            export REPLIT_LD_LIBRARY_PATH=${python-ld-library-path}:''${REPLIT_LD_LIBRARY_PATH}
+          else
+            export LD_LIBRARY_PATH=${python-ld-library-path}
+            if [ -n "''${PYTHON_LD_LIBRARY_PATH-}" ]; then
+              export LD_LIBRARY_PATH=''${PYTHON_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
+            fi
+            if [ -n "''${REPLIT_LD_LIBRARY_PATH-}" ]; then
+              export LD_LIBRARY_PATH=''${REPLIT_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
+            fi
           fi
           exec "${bin}" "$@"
         '';


### PR DESCRIPTION
Why
===

Use RTLD loader instead of LD_LIBRARY_PATH to avoid glibc and other shared library version mismatch issues.

Depends on https://github.com/replit/goval/pull/12350

What changed
============

1. if the pid1-replit-rtld-loader flag is on, and the Nix channel in .replit is not the legacy channel (we know the glibc in that version crashes with LD_AUDIT), then enable RTLD loader in lieu of setting LD_LIBRARY_PATH

Test plan
=========

Revisit scenarios 1, 2, 4 in [this doc](https://docs.google.com/document/d/1llRzZdBZIKDFk5n5NQromYMCeDaYUCB9pVLy2vahTH4) and see that they are fixed. When https://github.com/replit/goval/pull/12312 is in and Python in nixmodules is upgraded to latest Nix channel, all 5 should be fixed.