### PR TITLE
[python] Delete temporary poetry workaround

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -699,6 +699,10 @@
     "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
     "path": "/nix/store/lzvx4znma7kxnz3whli3973y79b025j5-replit-module-python-3.10"
   },
+  "python-3.10:v47-20240215-6dbeaf8": {
+    "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
+    "path": "/nix/store/3j7sf48iqd6zchiyzzjj4v8d1lrqk1qp-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1047,6 +1051,10 @@
     "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
     "path": "/nix/store/kskbprw8x5phlc4vgx7r7m21kgnw86s4-replit-module-python-3.11"
   },
+  "python-3.11:v28-20240215-6dbeaf8": {
+    "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
+    "path": "/nix/store/pd19abi3b098aj865ba60mbh3xa429jn-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1154,6 +1162,10 @@
   "python-3.8:v27-20240214-9292ce3": {
     "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
     "path": "/nix/store/az4fpmwi6r0ixa5jc2an0scmsxxd18yc-replit-module-python-3.8"
+  },
+  "python-3.8:v28-20240215-6dbeaf8": {
+    "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
+    "path": "/nix/store/z8xcyky353mgnq3mizv0vnv7v84vmpm6-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1362,6 +1374,10 @@
   "python-with-prybar-3.10:v26-20240214-9292ce3": {
     "commit": "9292ce3724fa7ca7091d991f8cd02e9598ffad0e",
     "path": "/nix/store/za3mv2vs35ybvlhnjpcb374cfp2m15xb-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v27-20240215-6dbeaf8": {
+    "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
+    "path": "/nix/store/x73n1qgd0pd01qi8xbkkbqm2ff2936ql-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/poetry/poetry-in-venv.nix
+++ b/pkgs/poetry/poetry-in-venv.nix
@@ -47,12 +47,6 @@ pkgs.writeShellApplication {
     export POETRY_INSTALLER_PARALLEL="0"
     fi
 
-    # Temporarily work around upm locking infrastructute being very slow
-    # In replit, poetry is not currently configured in such a way that this
-    # would ever print any virtualenv paths.
-    if [ "$1" = env ] && [ "$2" = list ]; then
-      exit 0
-    fi
     ${poetry}/bin/poetry "$@"
   '';
 }


### PR DESCRIPTION
Why
===

This performance workaround is no longer needed

What changed
============

- Workaround was codified in https://github.com/replit/upm/pull/230/
- Recent work to make `VIRTUAL_ENV` set for Python modules will add an additional buffer before running this command

Test plan
=========

Run `upm show-package-dir`, see whether it runs `poetry env list --full-path`

Rollout
=======

- [ ] This is fully backward and forward compatible
