### PR TITLE
Fix rtld bash

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -703,6 +703,10 @@
     "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
     "path": "/nix/store/3j7sf48iqd6zchiyzzjj4v8d1lrqk1qp-replit-module-python-3.10"
   },
+  "python-3.10:v48-20240216-a5950e9": {
+    "commit": "a5950e9e4d8c17f6dfd63693f36ac1e85f3ea85e",
+    "path": "/nix/store/vknwapxfy46mp4dcr0xi0rxnv7954wdw-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1055,6 +1059,10 @@
     "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
     "path": "/nix/store/pd19abi3b098aj865ba60mbh3xa429jn-replit-module-python-3.11"
   },
+  "python-3.11:v29-20240216-a5950e9": {
+    "commit": "a5950e9e4d8c17f6dfd63693f36ac1e85f3ea85e",
+    "path": "/nix/store/l5h3vlg39wpqwsd8579v11cq5q93qh64-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1166,6 +1174,10 @@
   "python-3.8:v28-20240215-6dbeaf8": {
     "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
     "path": "/nix/store/z8xcyky353mgnq3mizv0vnv7v84vmpm6-replit-module-python-3.8"
+  },
+  "python-3.8:v29-20240216-a5950e9": {
+    "commit": "a5950e9e4d8c17f6dfd63693f36ac1e85f3ea85e",
+    "path": "/nix/store/2wvgh9237372sknjvvh81chv9ln1c9n6-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1378,6 +1390,10 @@
   "python-with-prybar-3.10:v27-20240215-6dbeaf8": {
     "commit": "6dbeaf80e63ec12ac872efd31308074db0368630",
     "path": "/nix/store/x73n1qgd0pd01qi8xbkkbqm2ff2936ql-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v28-20240216-a5950e9": {
+    "commit": "a5950e9e4d8c17f6dfd63693f36ac1e85f3ea85e",
+    "path": "/nix/store/jjmi88hnxnnwp3dl9lys8s8jzaa27732-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -32,11 +32,11 @@ let
       ldLibraryPathConvertWrapper = pkgs.writeShellApplication {
         inherit name;
         text = ''
-          if test "$REPLIT_RTLD_LOADER" = "1" && test "$REPLIT_NIX_CHANNEL" != "legacy"
+          if test "''${REPLIT_RTLD_LOADER:-}" = "1" && test "''${REPLIT_NIX_CHANNEL:-}" != "legacy"
           then
             # activate RTLD loader!
             export LD_AUDIT="${pkgs.replit-rtld-loader}/rtld_loader.so"
-            export REPLIT_LD_LIBRARY_PATH=${python-ld-library-path}:''${REPLIT_LD_LIBRARY_PATH}
+            export REPLIT_LD_LIBRARY_PATH=${python-ld-library-path}:''${REPLIT_LD_LIBRARY_PATH:-}
           else
             export LD_LIBRARY_PATH=${python-ld-library-path}
             if [ -n "''${PYTHON_LD_LIBRARY_PATH-}" ]; then


### PR DESCRIPTION
Why
===

Found bug in bash wrapper script during testing:
https://replit.slack.com/archives/C04E0RA5WH5/p1708098655343509?thread_ts=1708097219.075359&cid=C04E0RA5WH5
The bash applications strictly prevents unbound variables from being used.

What changed
============

Use `:-` suffix to allow referencing the vars anyway.

Test plan
=========

1. create python repl
2. run it