### PR TITLE
Update python Nix channel (attempt 2)

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -711,6 +711,10 @@
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/55d7s1ydlwfbv03sfyd38vvszp16ddwk-replit-module-python-3.10"
   },
+  "python-3.10:v50-20240226-762a753": {
+    "commit": "762a7534c42e3300de266ae402de0e9ef98a007a",
+    "path": "/nix/store/4qv9bg202ylx62wy49xrd91d0mh54v7k-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1075,6 +1079,10 @@
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/lyq6nk6k6lq2mfkzmvj1sjfi6li5fqsa-replit-module-python-3.11"
   },
+  "python-3.11:v31-20240226-762a753": {
+    "commit": "762a7534c42e3300de266ae402de0e9ef98a007a",
+    "path": "/nix/store/xcg20afhkdnw0hznhjqn5hj73ab3n3ac-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1194,6 +1202,10 @@
   "python-3.8:v30-20240222-aba8eb6": {
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/qfilaq2r60vp93bd9p2pg408k4j7vwkg-replit-module-python-3.8"
+  },
+  "python-3.8:v31-20240226-762a753": {
+    "commit": "762a7534c42e3300de266ae402de0e9ef98a007a",
+    "path": "/nix/store/y4qjqnwp78zhm58g10shcss95plhvjc0-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1414,6 +1426,10 @@
   "python-with-prybar-3.10:v29-20240222-aba8eb6": {
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/s8bna95gv43q864nl8jwxbmqshj1acgi-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v30-20240226-762a753": {
+    "commit": "762a7534c42e3300de266ae402de0e9ef98a007a",
+    "path": "/nix/store/yavxaxinfvlc9wcdxfyimwcqrj5sydgp-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -12,16 +12,16 @@ let
 
   modulesList = [
     (import ./python {
-      python = pkgs-23_05.python38Full;
-      pypkgs = pkgs-23_05.python38Packages;
+      python = pkgs.python38Full;
+      pypkgs = pkgs.python38Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python310Full;
-      pypkgs = pkgs-23_05.python310Packages;
+      python = pkgs.python310Full;
+      pypkgs = pkgs.python310Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python311Full;
-      pypkgs = pkgs-23_05.python311Packages;
+      python = pkgs.python311Full;
+      pypkgs = pkgs.python311Packages;
     })
     (import ./python-with-prybar)
 

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -1,8 +1,6 @@
 { python, pypkgs }:
-{ pkgs-23_05, lib, ... }:
+{ pkgs, lib, ... }:
 let
-  pkgs = pkgs-23_05;
-
   pythonVersion = lib.versions.majorMinor python.version;
 
   pylibs-dir = ".pythonlibs";

--- a/pkgs/pip/default.nix
+++ b/pkgs/pip/default.nix
@@ -26,7 +26,7 @@ pypkgs.buildPythonPackage rec {
     name = "${pname}-${version}-source";
   };
 
-  nativeBuildInputs = [ pypkgs.bootstrapped-pip ];
+  nativeBuildInputs = [ ];
 
   # pip detects that we already have bootstrapped_pip "installed", so we need
   # to force it a little.


### PR DESCRIPTION
Why
===

Second attempt to update Nix channel to unstable for Python modules ([first attempt](https://github.com/replit/nixmodules/pull/259)). Will do it with a more minimal change this time: with a small tweak to pip (removing the buildInput, which was tested to work in dev). Also, it shouldn't cause breakage of [this kind](https://replit.slack.com/archives/C03KS2B221W/p1707315334964009) now that rtld loader has been deployed.

What changed
============

1. updated pkgs from 23_05 to unstable for all Python modules
2. removed `pypkgs.bootstrapped-pip` from pip as nativeBuildInput

Test plan
=========

Run the template tests in prerelease and see that python template tests still pass.