### PR TITLE
Update nix channel for python; use stock pip; monkeypatch pip to chan…

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -711,6 +711,10 @@
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/55d7s1ydlwfbv03sfyd38vvszp16ddwk-replit-module-python-3.10"
   },
+  "python-3.10:v50-20240229-2250a9a": {
+    "commit": "2250a9afde519540b54c69522bc27f732654f294",
+    "path": "/nix/store/i0q9y4kjp4lz216n6qfkl9vs96arxjq2-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1075,6 +1079,10 @@
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/lyq6nk6k6lq2mfkzmvj1sjfi6li5fqsa-replit-module-python-3.11"
   },
+  "python-3.11:v31-20240229-2250a9a": {
+    "commit": "2250a9afde519540b54c69522bc27f732654f294",
+    "path": "/nix/store/qwq0j7j2ln63a3h0r033pm5llzw46aq0-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1194,6 +1202,10 @@
   "python-3.8:v30-20240222-aba8eb6": {
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/qfilaq2r60vp93bd9p2pg408k4j7vwkg-replit-module-python-3.8"
+  },
+  "python-3.8:v31-20240229-2250a9a": {
+    "commit": "2250a9afde519540b54c69522bc27f732654f294",
+    "path": "/nix/store/bk9v6p5an4gmnnqgymk3dw5rfi6m71ag-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1414,6 +1426,10 @@
   "python-with-prybar-3.10:v29-20240222-aba8eb6": {
     "commit": "aba8eb66f6ff96c4f341bb18d71c715a2501ec83",
     "path": "/nix/store/s8bna95gv43q864nl8jwxbmqshj1acgi-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v30-20240229-2250a9a": {
+    "commit": "2250a9afde519540b54c69522bc27f732654f294",
+    "path": "/nix/store/ja2dy1y3jzr71dx86011dvmdyp3vvf4n-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -11,6 +11,7 @@ let
     ];
     specialArgs = {
       inherit pkgs pkgs-23_05;
+      pkgs-unstable = pkgs;
       modulesPath = builtins.toString ./.;
     };
   });

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -16,12 +16,12 @@ let
       pypkgs = pkgs-23_05.python38Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python310Full;
-      pypkgs = pkgs-23_05.python310Packages;
+      python = pkgs.python310Full;
+      pypkgs = pkgs.python310Packages;
     })
     (import ./python {
-      python = pkgs-23_05.python311Full;
-      pypkgs = pkgs-23_05.python311Packages;
+      python = pkgs.python311Full;
+      pypkgs = pkgs.python311Packages;
     })
     (import ./python-with-prybar)
 

--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -1,46 +1,18 @@
 pkgs @ { pypkgs, ... }:
 
 let
-  pip = import ../../pip {
-    inherit pkgs pypkgs;
-  };
+  pip = pypkgs.pip;
 
-  config-cache-enabled = pkgs.writeTextFile {
+  config = pkgs.writeTextFile {
     name = "pip.conf";
     text = ''
       [global]
       user = yes
       disable-pip-version-check = yes
-      index-url = https://package-proxy.replit.com/pypi/simple/
-
-      [install]
-      use-feature = content-addressable-pool
-      content-addressable-pool-symlink = yes
-    '';
-  };
-
-  config-cache-disabled = pkgs.writeTextFile {
-    name = "pip.conf";
-    text = ''
-      [global]
-      user = yes
-      disable-pip-version-check = yes
+      break-system-packages = yes
     '';
   };
 in
 {
-  bin = pkgs.writeShellApplication {
-    name = "pip";
-    text = ''
-      flags=()
-      if [[ -n "''${__REPLIT_PIP_CACHE_ENABLE-}" ]]; then
-        export PIP_CONFIG_FILE=${config-cache-enabled}
-        flags+=("--cache-dir=''${HOME}/.cache/pip")
-      else
-        export PIP_CONFIG_FILE=${config-cache-disabled}
-      fi
-      exec "${pip}/bin/pip" "''${flags[@]}" "$@"
-    '';
-  };
-  inherit pip;
+  inherit pip config;
 }

--- a/pkgs/modules/python/sitecustomize.nix
+++ b/pkgs/modules/python/sitecustomize.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+# Use this sitecustomize.py (a directory containing it in PYTHONPATH) to
+# overwrite pip's shebang line treatment so it doesn't use hard-coded paths
+# to the python executable, so we could update Python without editing Repls
+# Using this approach also allows this scheme to work with a version of pip
+# which the user has installed into their .pythonlibs, which can happen if they
+# upgrade pip.
+pkgs.writeTextFile {
+  name = "sitecustomize";
+  text = ./sitecustomize.py;
+  destination = "/sitecustomize.py";
+}

--- a/pkgs/modules/python/sitecustomize.py
+++ b/pkgs/modules/python/sitecustomize.py
@@ -1,0 +1,27 @@
+def pip_build_shebang(self, executable, post_interp):
+    import os, sys
+    if os.name != 'posix':
+        simple_shebang = True
+    else:
+        # Add 3 for '#!' prefix and newline suffix.
+        shebang_length = len(executable) + len(post_interp) + 3
+        if sys.platform == 'darwin':
+            max_shebang_length = 512
+        else:
+            max_shebang_length = 127
+        simple_shebang = ((b' ' not in executable) and
+                          (shebang_length <= max_shebang_length))
+
+    if simple_shebang:
+        result = b'#!/usr/bin/env python3' + post_interp + b'\n'
+    else:
+        result = b'#!/bin/sh\n'
+        result += b"'''exec' python3" + post_interp + b' "$0" "$@"\n'
+        result += b"' '''"
+    return result
+
+import sys
+exe = sys.argv[0]
+if exe.endswith('/pip') or exe.endswith('/pip3') or exe.endswith('/.pip-wrapped'):
+    from pip._vendor.distlib.scripts import ScriptMaker
+    ScriptMaker._build_shebang = pip_build_shebang


### PR DESCRIPTION
…ge shebang line

Why
===

1. We want to upgrade [Python to nixpkgs-unstable ](https://linear.app/replit/issue/DX-466/upgrade-python-in-nix-modules-to-nixpkgs-unstable)
2. due to an [update in nixpkgs,](https://github.com/NixOS/nixpkgs/pull/245509) we had to change how we package pip, we chose to:
    a. use the stock pip instead of our custom one
    b. add back a customization for the shebang line via monkeypatching, via [python site customization](https://docs.python.org/3/library/site.html), which has the advantage of working for a pip that's been installed in .pythonlibs. Thanks @blast-hardcheese for this!

What changed
============

1. Use unstable channel for Python 3.10 and 3.11, but not 3.8.
2. Updated pip to use stock pip, plus site customization
3. set `break-system-packages = yes` to silence [this error](https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3)

Test plan
=========

1. create a Python Repl
2. `pip install gunicorn`
4. `cat .pythonlibs/bin/gunicorn` see that the shebang line starts with `#!/usr/bin/env python3`
5. make sure template tests (in particular pip and poetry tests) pass