### PR TITLE
feat/venv convergence

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -723,6 +723,10 @@
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/skrv8ld2jdmj26whfm4d305g2i1h2448-replit-module-python-3.10"
   },
+  "python-3.10:v53-20240229-f30b29f": {
+    "commit": "f30b29fe78f8eb856622890077ed62cbf6459f3a",
+    "path": "/nix/store/nl6y1ryla49fnnw6pyv9pqx9w1ga7l6k-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1099,6 +1103,10 @@
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/1h58qa8al88r0k6vax8fy40lx302bc55-replit-module-python-3.11"
   },
+  "python-3.11:v34-20240229-f30b29f": {
+    "commit": "f30b29fe78f8eb856622890077ed62cbf6459f3a",
+    "path": "/nix/store/1lq7lrfhip77gqbf0ap1xp6j1m37rbrr-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1230,6 +1238,10 @@
   "python-3.8:v33-20240304-83361d1": {
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/ncn4mbqr9xm7y477p6z3kqn9hwfb8n8x-replit-module-python-3.8"
+  },
+  "python-3.8:v34-20240229-f30b29f": {
+    "commit": "f30b29fe78f8eb856622890077ed62cbf6459f3a",
+    "path": "/nix/store/k49qc504s5nam82jl89c9wid8xknw24q-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1462,6 +1474,10 @@
   "python-with-prybar-3.10:v32-20240304-83361d1": {
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/ybhywmpb081ypzd8l45i0znwc5w2n1zd-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v33-20240229-f30b29f": {
+    "commit": "f30b29fe78f8eb856622890077ed62cbf6459f3a",
+    "path": "/nix/store/p59504fb64pg24crfcfwvsjcvdqnc55c-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/sitecustomize.py
+++ b/pkgs/modules/python/sitecustomize.py
@@ -1,27 +1,166 @@
 def pip_build_shebang(self, executable, post_interp):
     import os, sys
-    if os.name != 'posix':
+
+    if os.name != "posix":
         simple_shebang = True
     else:
         # Add 3 for '#!' prefix and newline suffix.
         shebang_length = len(executable) + len(post_interp) + 3
-        if sys.platform == 'darwin':
+        if sys.platform == "darwin":
             max_shebang_length = 512
         else:
             max_shebang_length = 127
-        simple_shebang = ((b' ' not in executable) and
-                          (shebang_length <= max_shebang_length))
+        simple_shebang = (b" " not in executable) and (
+            shebang_length <= max_shebang_length
+        )
 
     if simple_shebang:
-        result = b'#!/usr/bin/env python3' + post_interp + b'\n'
+        result = b"#!/usr/bin/env python3" + post_interp + b"\n"
     else:
-        result = b'#!/bin/sh\n'
+        result = b"#!/bin/sh\n"
         result += b"'''exec' python3" + post_interp + b' "$0" "$@"\n'
         result += b"' '''"
     return result
 
-import sys
-exe = sys.argv[0]
-if exe.endswith('/pip') or exe.endswith('/pip3') or exe.endswith('/.pip-wrapped'):
+
+def pip_should_patch():
+    import sys
+
+    exe = sys.argv[0]
+    argv0_pip = (
+        exe.endswith("/pip") or exe.endswith("/pip3") or exe.endswith("/.pip-wrapped")
+    )
+    maybe_pip = sys.argv[0:2] == ["-m", "install"]
+    return argv0_pip or maybe_pip
+
+
+def pip_patch():
     from pip._vendor.distlib.scripts import ScriptMaker
+
     ScriptMaker._build_shebang = pip_build_shebang
+
+
+def venv_setup_scaffolding(pythonlibs):
+    import os
+
+    lib64 = os.path.join(pythonlibs, "lib64")
+    os.makedirs(os.path.join(pythonlibs, "bin"), exist_ok=True)
+    os.makedirs(os.path.join(pythonlibs, "include"), exist_ok=True)
+    os.makedirs(os.path.join(pythonlibs, "lib"), exist_ok=True)
+    if not os.path.exists(lib64):
+        os.symlink("lib", lib64)
+
+
+def venv_setup_pyvenv_cfg(pythonlibs, real_executable):
+    import os, sys
+
+    pyvenv_cfg = os.path.join(pythonlibs, "pyvenv.cfg")
+    cfg_exists = os.path.exists(pyvenv_cfg)
+    mode = "r+" if cfg_exists else "w"
+    home = None
+    includeSSP = None
+    version = None
+    with open(pyvenv_cfg, mode) as handle:
+        if cfg_exists:
+            for line in handle.readlines():
+                [k, v] = line.split("=", 1)
+                k = k.strip()
+
+                if k == "home":
+                    home = v.strip()
+                elif k == "include-system-site-packages":
+                    includeSSP = v.strip()
+                elif k == "version":
+                    version = v.strip()
+
+        if home is None:
+            home = os.path.dirname(real_executable)
+            print(f"home = {home}", file=handle)
+        if version is None:
+            major = sys.version_info.major
+            minor = sys.version_info.minor
+            micro = sys.version_info.micro
+            version = f"{major}.{minor}.{micro}"
+            print(f"version = {version}", file=handle)
+            # What happens in the case of mismatch?
+            # Presumably need to rewrite the whole file.
+            # For now, ignore.
+        if includeSSP is None:
+            includeSSP = "true"
+            print(f"include-system-site-packages = {includeSSP}", file=handle)
+
+
+def venv_iterate_variants(pythonlibs):
+    import os, sys
+
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+    bin_path = os.path.join(pythonlibs, "bin")
+    for variant in ["python", f"python{major}", f"python{major}.{minor}"]:
+        yield variant, os.path.join(bin_path, variant)
+
+
+def venv_setup_python_links(pythonlibs, real_executable):
+    import os
+
+    for _, variant_path in venv_iterate_variants(pythonlibs):
+        if os.path.exists(variant_path):
+            if os.readlink(variant_path) != real_executable:
+                os.remove(variant_path)
+        if not os.path.exists(variant_path):
+            os.symlink(real_executable, variant_path)
+
+
+def venv_is_python_stale(pythonlibs):
+    import shutil
+
+    for variant, variant_path in venv_iterate_variants(pythonlibs):
+        # Variant does not exist
+        if not os.path.exists(variant_path):
+            return True
+        found = shutil.which(variant)
+        # Asked for a variant that we don't have anymore... can't do much
+        # This could happen if the user manually launches python from the
+        # nix store without it on their PATH.
+        if not found:
+            continue
+        # Variant points at a non-current Python
+        if os.path.realpath(found) != os.path.realpath(variant_path):
+            return True
+    return False
+
+
+def venv_should_patch(pythonlibs):
+    import os
+
+    # Don't patch if VIRTUAL_ENV doesn't match our .pythonlibs
+    # If the user is managing their own venv, don't touch it.
+    if os.environ.get("VIRTUAL_ENV") != pythonlibs:
+        return False
+
+    if not venv_is_python_stale(pythonlibs):
+        return False
+
+    return True
+
+
+def venv_patch(pythonlibs):
+    import os
+    import sys
+
+    real_executable = os.path.realpath(sys.executable)
+
+    venv_setup_scaffolding(pythonlibs)
+    venv_setup_pyvenv_cfg(pythonlibs, real_executable)
+    venv_setup_python_links(pythonlibs, real_executable)
+
+
+if __name__ == "sitecustomize":
+    if pip_should_patch():
+        pip_patch()
+
+    import os
+
+    pythonlibs = os.path.join(os.getenv("REPL_HOME", os.getcwd()), ".pythonlibs")
+    if venv_should_patch(pythonlibs):
+        venv_patch(pythonlibs)


### PR DESCRIPTION
Why
===

`.pythonlibs` can be made into a proper virtualenv with a few minor edits, most of which are fairly fault tolerant.

What changed
============

Add to `sitecustomize` some logic to determine whether we need to heal the `.pythonlibs` directory. This, combined with two envvars (
```
PATH="$REPL_HOME/.pythonlibs/bin:$PATH"
VIRTUAL_ENV="$REPL_HOME/.pythonlibs"
```
) lets us get rid of all of the other python envvars (`PYTHONHOME`, `PYTHONNOUSERSITE`, etc), as well as making the following work:

```
$ pip install --upgrade pip && pip ...
$ uv pip ...
```

Test plan
=========

```
$ pip install --upgrade pip && pip install --force-reinstall flask
$ flask --version

$ uv pip install flask
$ flask --version
```

Rollout
=======

There are some considerations here.

First, I am explicitly not setting `VIRTUAL_ENV` in this PR. There are a handful of repls out in the wild that got `VIRTUAL_ENV` in their `.replit` during the period of time it was in the public template, which is regrettable, so I'll let Ask know to keep an eye out.

Second, users may have voluntarily set `VIRTUAL_ENV` to `.pythonlibs` and established their own venv there. If that's the case, we don't touch it.

Third, we might consider rolling this out to explorers first, though if they encounter a bug and want to revert, their `.pythonlibs` will not get un-converted, so they'll still need help getting working again in that case.

- [x] This is fully backward and forward compatible
