### PR TITLE
Moving sitecustomize into a venv-style directory

### DIFF
--- a/pkgs/modules/python/sitecustomize.nix
+++ b/pkgs/modules/python/sitecustomize.nix
@@ -8,5 +8,5 @@
 pkgs.writeTextFile {
   name = "sitecustomize";
   text = builtins.readFile ./sitecustomize.py;
-  destination = "/sitecustomize.py";
+  destination = "/lib/python3/site-packages/sitecustomize.py";
 }


### PR DESCRIPTION
Why
===

Try to work around pyright being overly nosy

What changed
============

Moving `sitepackages` into an environment-style path to get pyright to not traverse into `/nix`

Test plan
=========

It should be possible to run

```
/nix/store/...-pyright-extended-2.0.6/lib/index.js
```

without getting flagged for `takedown`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
