### PR TITLE
Th sitecustomize subdir

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -719,6 +719,10 @@
     "commit": "fc137ca591a3c0e819099783a09b6ba567c1f246",
     "path": "/nix/store/z7v403js03f8xhd3vpg41iwkzfgb5ahc-replit-module-python-3.10"
   },
+  "python-3.10:v52-20240304-83361d1": {
+    "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
+    "path": "/nix/store/skrv8ld2jdmj26whfm4d305g2i1h2448-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1091,6 +1095,10 @@
     "commit": "fc137ca591a3c0e819099783a09b6ba567c1f246",
     "path": "/nix/store/23arrv6v0shfxnz040zq34yidk6wmglr-replit-module-python-3.11"
   },
+  "python-3.11:v33-20240304-83361d1": {
+    "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
+    "path": "/nix/store/1h58qa8al88r0k6vax8fy40lx302bc55-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1218,6 +1226,10 @@
   "python-3.8:v32-20240301-fc137ca": {
     "commit": "fc137ca591a3c0e819099783a09b6ba567c1f246",
     "path": "/nix/store/sg7cz4ahsk8cyk6abb53v4zn3g11z6mg-replit-module-python-3.8"
+  },
+  "python-3.8:v33-20240304-83361d1": {
+    "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
+    "path": "/nix/store/ncn4mbqr9xm7y477p6z3kqn9hwfb8n8x-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1446,6 +1458,10 @@
   "python-with-prybar-3.10:v31-20240301-fc137ca": {
     "commit": "fc137ca591a3c0e819099783a09b6ba567c1f246",
     "path": "/nix/store/xwnn358yvr2vwvd47awaj9d9w1kgq6wv-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v32-20240304-83361d1": {
+    "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
+    "path": "/nix/store/ybhywmpb081ypzd8l45i0znwc5w2n1zd-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/sitecustomize.nix
+++ b/pkgs/modules/python/sitecustomize.nix
@@ -5,8 +5,12 @@
 # Using this approach also allows this scheme to work with a version of pip
 # which the user has installed into their .pythonlibs, which can happen if they
 # upgrade pip.
-pkgs.writeTextFile {
-  name = "sitecustomize";
-  text = builtins.readFile ./sitecustomize.py;
-  destination = "/sitecustomize.py";
-}
+let
+  dirpath = "lib/python/site-packages";
+  textFile = pkgs.writeTextFile {
+    name = "sitecustomize";
+    text = builtins.readFile ./sitecustomize.py;
+    destination = "/${dirpath}/sitecustomize.py";
+  };
+in
+"${textFile}/${dirpath}"


### PR DESCRIPTION
Why
===

We found that the sitecustomize.py setup we added makes pyright hang when starting up, and we had failed lsp tests. 
https://replit.slack.com/archives/C06KAKG35QS/p1709318856982249?thread_ts=1709316270.385049&cid=C06KAKG35QS

What changed
============

Moved sitecustomize.py to a subdirectory `lib/python/site-packages` to prevent pyright from trying to walk up and list the files in `/nix/store`

Test plan
=========

Same as in https://github.com/replit/nixmodules/pull/275