### PR TITLE
Th more display versions

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -55,6 +55,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/8737vy3r6zsjdyw480grjpyvzbv39gw7-replit-module-c-clang14"
   },
+  "c-clang14:v9-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/1c1axbdqk7vn01k5swb3nfjv0a8vinlj-replit-module-c-clang14"
+  },
   "clojure-1.11:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/giqq76fl3yphzsm6rkl1qxqh4mszknpl-replit-module-clojure-1.11"
@@ -78,6 +82,10 @@
   "clojure-1.11:v6-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/a0rn6xkzh736i9wfaljpm2arz9xkyyj0-replit-module-clojure-1.11"
+  },
+  "clojure-1.11:v7-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/p5vlhd2prx28117p6b8cis6nmg7n2naw-replit-module-clojure-1.11"
   },
   "cpp-clang14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -111,6 +119,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/wgnb6pyh3imjq5bxnlgzq1xdkj5b14pf-replit-module-cpp-clang14"
   },
+  "cpp-clang14:v9-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/lh5ps5z7z1alri6pvysmnrympswv1wx3-replit-module-cpp-clang14"
+  },
   "dart-2.18:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/mhl58f8y3z6jv0javkmx28y5h9aacw39-replit-module-dart-2.18"
@@ -142,6 +154,10 @@
   "dotnet-7.0:v6-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/vkw95ydpdsaixvjrpr9kc55hqashx0zb-replit-module-dotnet-7.0"
+  },
+  "dotnet-7.0:v7-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/c11nixfjyqx5wnv9m3hr8l59r0arfi97-replit-module-dotnet-7.0"
   },
   "go-1.19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -215,6 +231,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/m1ss7zjq696hn0vwlzvxjyhzvlbq2x5l-replit-module-java-graalvm22.3"
   },
+  "java-graalvm22.3:v12-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/5ksm513f0j76x2l928m3l655wgdpxrhb-replit-module-java-graalvm22.3"
+  },
   "lua-5.2:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/d6a5wl9pyla9si60plaxzmhqggywkcxy-replit-module-lua-5.2"
@@ -238,6 +258,10 @@
   "lua-5.2:v6-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/3l56r4d9bv413k5ywcgv8mm4yf3m7csy-replit-module-lua-5.2"
+  },
+  "lua-5.2:v7-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/c9mchky23jr1kdf42dfslnj275gh84hx-replit-module-lua-5.2"
   },
   "nodejs-14:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
@@ -387,6 +411,10 @@
     "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
     "path": "/nix/store/4pfjrkgk5vlpv38v86r3hr20y101c2k1-replit-module-nodejs-18"
   },
+  "nodejs-18:v32-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/9imqn7wnxyrgiibax7f81slw4bixnfhr-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -510,6 +538,10 @@
   "nodejs-20:v28-20240213-3f08513": {
     "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
     "path": "/nix/store/vd4fm7m4s33jgxamy58aplxpygmrrgva-replit-module-nodejs-20"
+  },
+  "nodejs-20:v29-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/vwpwhi0fvx1qwrd3xpsdy7scmppz07af-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -723,6 +755,10 @@
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/skrv8ld2jdmj26whfm4d305g2i1h2448-replit-module-python-3.10"
   },
+  "python-3.10:v53-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/7s4d5lzgs844czgn0sjl76sc7lzqqbyk-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -799,6 +835,10 @@
     "commit": "98f4cde081b4f2921b16bea2096c4f32639f37bb",
     "path": "/nix/store/7bzxkbsi76ck2c64ilxidgrdwrq5j725-replit-module-ruby-3.1"
   },
+  "ruby-3.1:v10-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/h1ngh9rl9g9rl7zqwm8brqp4kkfx9r1s-replit-module-ruby-3.1"
+  },
   "rust-1.69:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/xkp307fdmgwn8dnbqadzlrb8fr0bvkx4-replit-module-rust-1.69"
@@ -839,6 +879,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/5lgc7fprybd0dynsadx2fvq7m480fsaq-replit-module-swift-5.8"
   },
+  "swift-5.8:v7-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/9nfk0n06pkw3mna6x06xdmqq7pzydd7k-replit-module-swift-5.8"
+  },
   "web:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/7lhwlqy8nmrmc27n68ia16q6bn27cwk5-replit-module-web"
@@ -866,6 +910,10 @@
   "web:v7-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/7xfkqia0q89pcxbnnwb5lbxxas991hrj-replit-module-web"
+  },
+  "web:v8-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/w1lwsfw337aywvzg54asy1s7r305xgr6-replit-module-web"
   },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
@@ -915,6 +963,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/r1q474ry0wlmz67wa3p1bwpjbiqrjkgc-replit-module-pyright-extended"
   },
+  "pyright-extended:v13-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/6fhqqanznkyvzvcp86mdafhlidwxqlc5-replit-module-pyright-extended"
+  },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
@@ -946,6 +998,10 @@
   "svelte-kit-node-20:v8-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/5ly9kwdviay14gg2glv1xkl80y0r0v4w-replit-module-svelte-kit-node-20"
+  },
+  "svelte-kit-node-20:v9-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/35gmry2hxvcad998vw2a94ri4dbm1s5r-replit-module-svelte-kit-node-20"
   },
   "gcloud:v1-20230815-e6e4431": {
     "commit": "e6e4431a8f1d71ec0664ce97828bede1608dcfd1",
@@ -1099,6 +1155,10 @@
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/1h58qa8al88r0k6vax8fy40lx302bc55-replit-module-python-3.11"
   },
+  "python-3.11:v34-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/vkbs6zhc4361ph5nmpkxm9myvhvdkpar-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1231,6 +1291,10 @@
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/ncn4mbqr9xm7y477p6z3kqn9hwfb8n8x-replit-module-python-3.8"
   },
+  "python-3.8:v34-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/56laqlk54wpiqcfh9fyxn7ksb3n9yfnv-replit-module-python-3.8"
+  },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/qf9aiylryg8lq5q4z7fcj11824k9rf17-replit-module-bun-1.0"
@@ -1315,6 +1379,10 @@
     "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
     "path": "/nix/store/i0kdqzjl5piv5ddi8s85dydjc6376w93-replit-module-bun-1.0"
   },
+  "bun-1.0:v22-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/w8k8j10wlz0f0dwfgz0ljk9ddba4115k-replit-module-bun-1.0"
+  },
   "rust-1.72:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
     "path": "/nix/store/3siflmi2j4ikwnd35rlnc6g44nbsdpgs-replit-module-rust-1.72"
@@ -1338,6 +1406,10 @@
   "nix:v5-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/i90lbgfqvryw83shy1vcsxqi3mkgqwvg-replit-module-nix"
+  },
+  "nix:v6-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/gfqakxbldf4aiqx68z3kgwcf60cxhm7s-replit-module-nix"
   },
   "python-with-prybar-3.10:v2-20230925-77b13e4": {
     "commit": "77b13e434deb254c3792ddd97191586c193a83a6",
@@ -1463,6 +1535,10 @@
     "commit": "83361d1559967490d89db53c8dc51f3e8d206170",
     "path": "/nix/store/ybhywmpb081ypzd8l45i0znwc5w2n1zd-replit-module-python-with-prybar-3.10"
   },
+  "python-with-prybar-3.10:v33-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/jg194vswpyjyqmgr5yi4cbvmkpz8csl7-replit-module-python-with-prybar-3.10"
+  },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",
     "path": "/nix/store/8v3laig35f30bvgw8mwjcsznk06l7vf3-replit-module-nodejs-with-prybar-18"
@@ -1551,6 +1627,10 @@
     "commit": "3f085139f58cca1b48081dfcffacfdeeb17ce71d",
     "path": "/nix/store/j67mvs3xg8xjng8wkarl2fphh85zk2mz-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v23-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/iklhiwkiym4d95bnm01fgxggjcykbhbb-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -1583,6 +1663,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/9sl10as4lqa0f8qmzf2i05i2718amwr9-replit-module-rust-stable"
   },
+  "rust-stable:v8-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/liply9a7fi20rjzfsl3rgw8fj3xfbfk3-replit-module-rust-stable"
+  },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
@@ -1602,6 +1686,10 @@
   "go-1.21:v5-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/qhp8azymk20wjz1w5awpr82h9d9m9p73-replit-module-go-1.21"
+  },
+  "go-1.21:v6-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/60vvbqb2p3bchwzqdpc1id9gbvprclnn-replit-module-go-1.21"
   },
   "docker:v1-20231026-3990bf0": {
     "commit": "3990bf05353ec3cffd54b8376616fdf6165d4580",
@@ -1675,6 +1763,10 @@
     "commit": "98f4cde081b4f2921b16bea2096c4f32639f37bb",
     "path": "/nix/store/cag0688y6kq7hsa0s76bhg249ybjaf2d-replit-module-ruby-3.2"
   },
+  "ruby-3.2:v8-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/zq2i9fm4c2b5xv2cq1yr6c5mc9swnlpg-replit-module-ruby-3.2"
+  },
   "dart-3.1:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/ra46cfdhzrp1gn6rh4l5nnycn3vjv18l-replit-module-dart-3.1"
@@ -1695,6 +1787,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/i4708nb102dc1zriq51izrz7mk1xznwv-replit-module-haskell-ghc9.4"
   },
+  "haskell-ghc9.4:v5-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/sf0c00hl01xixn4y8w71sgi5lcz4hyg5-replit-module-haskell-ghc9.4"
+  },
   "php-8.2:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/8whfz8mxysaz299a54kvpm0a96gc89v3-replit-module-php-8.2"
@@ -1711,6 +1807,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/z03aivbdsfzj18gxq7jzk5zpmqhs9p73-replit-module-php-8.2"
   },
+  "php-8.2:v5-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/qjb4i6jbbn7q5bpaarmz6hyvrd72snak-replit-module-php-8.2"
+  },
   "r-4.3:v1-20231201-3b22c78": {
     "commit": "3b22c787fd20b13fe5afb868589c574068303b5e",
     "path": "/nix/store/naz6n9b9fd8swy5yb2i9sn4haw4h3c48-replit-module-r-4.3"
@@ -1726,6 +1826,10 @@
   "r-4.3:v4-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/ywqj5dsha9ar22mj24miyc8b8pvpd81z-replit-module-r-4.3"
+  },
+  "r-4.3:v5-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/x9waybm274bw018vmhvghyijv2xl9f6i-replit-module-r-4.3"
   },
   "replit:v1-20231211-d5ddcff": {
     "commit": "d5ddcff9419456ecf54d2582c4b1cc4242198ac0",
@@ -1747,6 +1851,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/2awisfflrn4n3v7083w5qr8chgxqxz1x-replit-module-replit"
   },
+  "replit:v6-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/kwkwzc57y4i7f9hn9rl0sr196j1ik7wp-replit-module-replit"
+  },
   "bash:v1-20231215-e6d471c": {
     "commit": "e6d471c9fd81b6ca469e1c42692953146c7cfb20",
     "path": "/nix/store/0j5kz53myr8kycfc4w1vkfccz4m5rsyv-replit-module-bash"
@@ -1763,6 +1871,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/mn21mqnii6m2vn4d5zhs6yfssmi6kkgz-replit-module-bash"
   },
+  "bash:v5-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/rdjjdy1as8dqb22ma66i6klxjls6d8mw-replit-module-bash"
+  },
   "deno-1:v1-20231215-5d427a8": {
     "commit": "5d427a83eae4fc1be41c3842b294c98f41271462",
     "path": "/nix/store/z02na0yx2xlnrkaaf1k515ddnib8hd2h-replit-module-deno-1"
@@ -1778,6 +1890,10 @@
   "deno-1:v4-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/rmv0hwj7iaicabq1i7wc06val212wa0h-replit-module-deno-1"
+  },
+  "deno-1:v5-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/hlfpla31nbkn090r2kwjrfy0x20vd9dk-replit-module-deno-1"
   },
   "vue-node-20:v1-20231220-a18bbd4": {
     "commit": "a18bbd4b3508bf0c247a67f407cbd9023b8d2ebb",
@@ -1799,6 +1915,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/gmq3avvi8gflwva26h3ghpmf1yz84rms-replit-module-vue-node-20"
   },
+  "vue-node-20:v6-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/dnm14w8yl3zwql0wybknc69x87chrxfx-replit-module-vue-node-20"
+  },
   "vue-node-18:v1-20240116-3ea4bcd": {
     "commit": "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7",
     "path": "/nix/store/87p91q8irymjmykl8bc3ccq62i00qv78-replit-module-vue-node-18"
@@ -1814,6 +1934,10 @@
   "dart-3.2:v3-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/431b32bhh50k25cxvppspy6smschm7rz-replit-module-dart-3.2"
+  },
+  "dart-3.2:v4-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/kd0q02bm890cgw77xyhhal8x7n3lkf6a-replit-module-dart-3.2"
   },
   "angular-node-20:v1-20231220-48a5a72": {
     "commit": "48a5a72ac95590da6719cf0c7f2dc728b1087903",
@@ -1835,6 +1959,10 @@
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/n6rshi31l1bhdcdyhz072bri6zrp0v81-replit-module-angular-node-20"
   },
+  "angular-node-20:v6-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/m3qiq405hcrfrxp8dmzczagnrzxlp8f7-replit-module-angular-node-20"
+  },
   "rust-nightly:v1-20240126-d98d19e": {
     "commit": "d98d19ee06a8b30ecabf9cf154fd403103c7fee6",
     "path": "/nix/store/f71v169hdnv8g9w5kjpmv9z4dhzpfzjp-replit-module-rust-nightly"
@@ -1846,6 +1974,10 @@
   "rust-nightly:v3-20240209-9e3a339": {
     "commit": "9e3a33995f94a52e61ae962777e9bcbe6d75885e",
     "path": "/nix/store/ib074ai3cmi4rszc8i9b38yjnxhamlc6-replit-module-rust-nightly"
+  },
+  "rust-nightly:v4-20240306-f3ca166": {
+    "commit": "f3ca166fb944feb0226949a1f0c735edc40acbce",
+    "path": "/nix/store/c2rhivl2vq6zsys52dwajkanh0jznz7k-replit-module-rust-nightly"
   },
   "hermit-0.38.2:v1-20240208-9bf7683": {
     "commit": "9bf76831508415761756fbb980dabe6d21b6394f",

--- a/pkgs/moduleit/example.nix
+++ b/pkgs/moduleit/example.nix
@@ -100,8 +100,9 @@ in
     };
 
     packagers.upmNodejs = {
-      name = "UPM for Node.js";
+      name = "Node.js packager";
       language = "nodejs";
+      displayVersion = "Node ${pkgs.nodejs_20.version}";
       features = {
         packageSearch = true;
         guessImports = true;

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -206,7 +206,6 @@ let
         description = lib.mdDoc ''
           The display version of the language server.
         '';
-        default = "";
       };
 
       language = mkOption {
@@ -266,7 +265,6 @@ let
         description = lib.mdDoc ''
           The display version of the formatter.
         '';
-        default = "";
       };
 
       language = mkOption {
@@ -441,7 +439,7 @@ let
         description = lib.mdDoc ''
           The display version of the language server.
         '';
-        default = "";
+
       };
 
       language = mkOption {

--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -16,6 +16,7 @@ in
   replit.dev.packagers.r = {
     name = "R";
     language = "r";
+    displayVersion = r-version;
     features = {
       packageSearch = true;
       guessImports = false;

--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -45,6 +45,7 @@ in
     dev.languageServers.angular-language-server = {
       name = "Angular Language Server";
       inherit language;
+      displayVersion = angular-language-server.version;
       start = "${angular-language-server}/bin/ngserver --stdio --tsProbeLocations node_modules,${nodepkgs.typescript}/lib/node_modules/typescript/lib --ngProbeLocations node_modules,${angular-language-server}/lib/node_modules/@angular/language-server/node_modules";
       extensions = [ ".html" ];
     };

--- a/pkgs/modules/bash/default.nix
+++ b/pkgs/modules/bash/default.nix
@@ -13,6 +13,7 @@
     name = "Bash Language Server";
     language = "bash";
     extensions = [ ".sh" ".bash" ];
+    displayVersion = pkgs.nodePackages.bash-language-server.version;
 
     start = "${pkgs.nodePackages.bash-language-server}/bin/bash-language-server start";
   };

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -6,11 +6,11 @@ let
 
   extensions = [ ".js" ".jsx" ".cjs" ".mjs" ".ts" ".tsx" ".mts" ];
 
-  community-version = lib.versions.majorMinor bun.version;
+  bun-version = lib.versions.majorMinor bun.version;
 in
 
 {
-  id = "bun-${community-version}";
+  id = "bun-${bun-version}";
   name = "Bun Tools";
   displayVersion = bun.version;
 
@@ -38,6 +38,7 @@ in
   replit.dev.packagers.bun = {
     name = "bun";
     language = "bun";
+    displayVersion = bun.version;
     features = {
       packageSearch = true;
       guessImports = true;

--- a/pkgs/modules/c/default.nix
+++ b/pkgs/modules/c/default.nix
@@ -45,6 +45,7 @@ in
   replit.dev.languageServers.ccls = {
     name = "ccls";
     language = "c";
+    displayVersion = pkgs.ccls.version;
     start = "${pkgs.ccls}/bin/ccls";
   };
 

--- a/pkgs/modules/clojure/default.nix
+++ b/pkgs/modules/clojure/default.nix
@@ -17,6 +17,8 @@ in
     name = "Clojure LSP";
     language = "clojure";
 
+    displayVersion = pkgs.clojure-lsp.version;
+
     start = "${pkgs.clojure-lsp}/bin/clojure-lsp";
   };
 }

--- a/pkgs/modules/cpp/default.nix
+++ b/pkgs/modules/cpp/default.nix
@@ -32,6 +32,7 @@ in
   replit.dev.languageServers.ccls = {
     name = "ccls";
     language = "cpp";
+    displayVersion = pkgs.ccls.version;
     start = "${pkgs.ccls}/bin/ccls";
   };
 

--- a/pkgs/modules/dart/default.nix
+++ b/pkgs/modules/dart/default.nix
@@ -15,16 +15,18 @@ in {
     start = "${pkgs.dart}/bin/dart main.dart";
   };
 
-  replit.dev.languageServers.dart-pub = {
-    name = "dart";
+  replit.dev.languageServers.dart-lsp = {
+    name = "dart LSP";
     language = "dart";
 
+    displayVersion = "Dart ${pkgs.dart.version}";
     start = "${pkgs.dart}/bin/dart language-server";
   };
 
   replit.dev.packagers.dart-pub = {
     name = "dart pub";
     language = "dart-pub";
+    displayVersion = "Dart ${pkgs.dart.version}";
     features = {
       packageSearch = true;
       guessImports = false;

--- a/pkgs/modules/deno/default.nix
+++ b/pkgs/modules/deno/default.nix
@@ -26,6 +26,7 @@ in
   replit.dev.languageServers.deno = {
     name = "deno";
     language = "javascript";
+    displayVersion = "Deno ${version}";
     inherit extensions;
     start = "${deno}/bin/deno lsp --quiet";
   };

--- a/pkgs/modules/dotnet/default.nix
+++ b/pkgs/modules/dotnet/default.nix
@@ -29,12 +29,14 @@ in
     name = "OmniSharp";
     language = "dotnet";
 
+    displayVersion = pkgs.omnisharp-roslyn.version;
     start = "${pkgs.omnisharp-roslyn}/bin/OmniSharp --languageserver";
   };
 
   replit.dev.packagers.dotnet = {
     name = ".NET";
     language = "dotnet";
+    displayVersion = dotnet.version;
     features = {
       packageSearch = true;
       guessImports = false;

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -26,6 +26,7 @@ in
   replit.dev.formatters.go-fmt = {
     name = "go fmt";
     language = "go";
+    displayVersion = "Go ${go.version}";
 
     start = "${go}/bin/go fmt";
     stdin = false;
@@ -34,6 +35,8 @@ in
   replit.dev.languageServers.gopls = {
     name = "gopls";
     language = "go";
+
+    displayVersion = gopls.version;
 
     start = "${gopls}/bin/gopls";
   };

--- a/pkgs/modules/haskell/default.nix
+++ b/pkgs/modules/haskell/default.nix
@@ -31,6 +31,7 @@ in
   replit.dev.languageServers.haskell-language-server = {
     name = "Haskell Language Server";
     language = "haskell";
+    displayVersion = pkgs.haskellPackages.haskell-language-server.version;
 
     start = "${pkgs.haskellPackages.haskell-language-server}/bin/haskell-language-server --lsp";
   };

--- a/pkgs/modules/java/default.nix
+++ b/pkgs/modules/java/default.nix
@@ -53,6 +53,7 @@ in
   replit.dev.packagers.maven = {
     name = "Maven";
     language = "java-maven";
+    displayVersion = pkgs.maven.version;
     features = {
       enabledForHosting = false;
       packageSearch = true;

--- a/pkgs/modules/lua/default.nix
+++ b/pkgs/modules/lua/default.nix
@@ -20,6 +20,7 @@ in
   replit.dev.languageServers.sumneko = {
     name = "lua-language-server";
     language = "lua";
+    displayVersion = pkgs.sumneko-lua-language-server.version;
 
     start = "${pkgs.sumneko-lua-language-server}/bin/lua-language-server";
   };

--- a/pkgs/modules/nix/default.nix
+++ b/pkgs/modules/nix/default.nix
@@ -5,6 +5,7 @@
   replit.dev.languageServers.nixd = {
     name = "nixd";
     language = "nix";
+    displayVersion = pkgs.nixd.version;
     start = "${pkgs.nixd}/bin/nixd";
     extensions = [ ".nix" ];
 

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -99,7 +99,7 @@ in
 
     dev.formatters.prettier = {
       name = "Prettier";
-      displayVersion = nodepkgs.prettier.version;
+      displayVersion = "${nodepkgs.prettier.version} (Node ${lib.versions.majorMinor nodejs.version})";
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".html" ];
       start = {
@@ -109,9 +109,10 @@ in
       stdin = true;
     };
 
-    dev.packagers.upmNodejs = {
-      name = "UPM for Node.js";
+    dev.packagers.nodejsPackager = {
+      name = "Node.js packager";
       language = "nodejs";
+      displayVersion = "Node ${lib.versions.majorMinor nodejs.version}";
       features = {
         packageSearch = true;
         guessImports = true;

--- a/pkgs/modules/php/default.nix
+++ b/pkgs/modules/php/default.nix
@@ -22,12 +22,15 @@ in
     name = "phpactor";
     language = "php";
 
+    displayVersion = pkgs.phpactor.version;
+
     start = "${pkgs.phpactor}/bin/phpactor language-server";
   };
 
   replit.dev.packagers.php = {
-    name = "PHP";
+    name = "Composer";
     language = "php";
+    displayVersion = pkgs.phpPackages.composer.version;
     features = {
       packageSearch = true;
       guessImports = false;

--- a/pkgs/modules/pyright-extended/default.nix
+++ b/pkgs/modules/pyright-extended/default.nix
@@ -8,6 +8,7 @@ in
   replit.languageServers.pyright-extended = {
     name = "pyright-extended";
     language = "python3";
+    displayVersion = pyright-extended.version;
     start = "${pyright-extended}/bin/langserver.index.js --stdio";
   };
 }

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -129,9 +129,10 @@ in
     start = "${pyright-extended}/bin/langserver.index.js --stdio";
   };
 
-  replit.dev.packagers.upmPython = {
-    name = "Python";
+  replit.dev.packagers.pythonPackager = {
+    name = "Python 3 Packager";
     language = "python3";
+    displayVersion = pythonVersion;
     ignoredPackages = [ "unit_tests" ];
     ignoredPaths = [ pylibs-dir ];
     features = {

--- a/pkgs/modules/replit/default.nix
+++ b/pkgs/modules/replit/default.nix
@@ -45,6 +45,7 @@ in
   replit.dev.languageServers.dotreplit-lsp = {
     name = ".replit LSP";
     language = "dotreplit";
+    displayVersion = "latest";
     start = "${taplo}/bin/taplo lsp -c ${taplo-config} stdio";
   };
 }

--- a/pkgs/modules/ruby/default.nix
+++ b/pkgs/modules/ruby/default.nix
@@ -47,12 +47,15 @@ in
     name = "Solargraph: A Ruby Language Server";
     language = "ruby";
 
+    displayVersion = "${rubyPackages.solargraph.version} (Ruby ${ruby-version})";
+
     start = "${rubyPackages.solargraph}/bin/solargraph stdio";
   };
 
-  replit.packagers.ruby = {
-    name = "Ruby";
+  replit.packagers.gem = {
+    name = "Gem";
     language = "ruby";
+    displayVersion = "Ruby ${ruby-version}";
     features = {
       packageSearch = true;
       guessImports = true;

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -38,6 +38,7 @@ in
     name = "rust-analyzer";
     language = "rust";
 
+    displayVersion = rust-channel-name;
     start = "${channel.toolchain}/bin/rust-analyzer";
 
     initializationOptions = {
@@ -48,6 +49,7 @@ in
   replit.dev.packagers.rust = {
     name = "Rust";
     language = "rust";
+    displayVersion = rust-channel-name;
     features = {
       packageSearch = true;
       guessImports = false;

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -26,6 +26,7 @@
       name = "Svelte Language Server";
       language = "svelte";
       extensions = [ ".svelte" ".js" ".ts" ];
+      displayVersion = pkgs.nodePackages.svelte-language-server.version;
       start = "${pkgs.nodePackages.svelte-language-server}/bin/svelteserver --stdio";
     };
   };

--- a/pkgs/modules/swift/default.nix
+++ b/pkgs/modules/swift/default.nix
@@ -36,6 +36,7 @@ in
   replit.dev.languageServers.sourcekit = {
     name = "SourceKit";
     language = "swift";
+    displayVersion = "Swift ${swift-version}";
 
     start = "${pkgs.swift}/bin/sourcekit-lsp";
   };

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -1,5 +1,5 @@
 { nodepkgs }:
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   typescript-language-server = nodepkgs.typescript-language-server.override {
     # TODO: we can get rid of this patch once >=4.2.0 is in the nixpkgs-unstable we use.
@@ -20,7 +20,7 @@ in
 {
   replit.dev.languageServers.typescript-language-server = {
     name = "TypeScript Language Server";
-    displayVersion = typescript-language-server.version;
+    displayVersion = "${typescript-language-server.version} (Node ${lib.versions.majorMinor nodepkgs.nodejs.version})";
     language = "javascript";
     start = "${typescript-language-server}/bin/typescript-language-server --stdio";
 

--- a/pkgs/modules/vue/default.nix
+++ b/pkgs/modules/vue/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
   nodejs = pkgs.nodejs_20;
@@ -31,6 +31,7 @@ in
     dev.languageServers.vue-language-server = {
       name = "Vue Language Server";
       inherit language extensions;
+      displayVersion = "${vue-language-server.version} (Node ${lib.versions.majorMinor nodejs.version})";
       start = "${vue-language-server}/bin/vue-language-server --stdio";
 
       initializationOptions = {

--- a/pkgs/modules/web/default.nix
+++ b/pkgs/modules/web/default.nix
@@ -15,6 +15,7 @@
     name = "HTML Language Server";
     language = "html";
     extensions = [ ".html" ];
+    displayVersion = pkgs.nodePackages.vscode-langservers-extracted.version;
 
     start = "${pkgs.nodePackages.vscode-langservers-extracted}/bin/vscode-html-language-server --stdio";
 
@@ -66,6 +67,7 @@
     name = "CSS Language Server";
     language = "css";
     extensions = [ ".css" ".less" ".scss" ];
+    displayVersion = pkgs.nodePackages.vscode-langservers-extracted.version;
 
     start = "${pkgs.nodePackages.vscode-langservers-extracted}/bin/vscode-css-language-server --stdio";
 
@@ -89,7 +91,7 @@
           # Configure linting
           # ignore = don't show any warning or error
           # warning = show yellow underline
-          # error = show red underline 
+          # error = show red underline
           lint = {
             # Invalid number of parameters
             argumentsInColorFunction = "error";


### PR DESCRIPTION
Why
===

We want to have display versions for all language servers, formatters, and packagers.

https://linear.app/replit/issue/DX-504/add-display-version-to-all-formatters-languageservers-and-packagers

What changed
============

Added reasonable display versions to those.

Test plan
=========

1. `nix develop`
2. `nix build .#registry`
3. `python scripts/show_reg.py`