### PR TITLE
Introducing REPLIT_PYTHONPATH; avoid putting python's system libs in PYTHONPATH

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -727,6 +727,10 @@
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/njkmnnqvaqq4cvg01s4zzl4lza7420qd-replit-module-python-3.10"
   },
+  "python-3.10:v54-20240312-53a08a2": {
+    "commit": "53a08a23d7154937437e54e52158f5f948887e63",
+    "path": "/nix/store/1ivb7i0aqwj0yqzlfmwl1g3dm5w836wa-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1111,6 +1115,10 @@
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/3nnb5wwgzhy32vy1amsrxz6qcfkrnsar-replit-module-python-3.11"
   },
+  "python-3.11:v35-20240312-53a08a2": {
+    "commit": "53a08a23d7154937437e54e52158f5f948887e63",
+    "path": "/nix/store/g5xl71fmqmhg91dgpzsj2d03f693z0zi-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1246,6 +1254,10 @@
   "python-3.8:v34-20240311-46fe793": {
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/3sh8ardca3z0s2l2f7vcz8van84hmmpw-replit-module-python-3.8"
+  },
+  "python-3.8:v35-20240312-53a08a2": {
+    "commit": "53a08a23d7154937437e54e52158f5f948887e63",
+    "path": "/nix/store/rzhvnjbl8rqf95gpfzv44xcw1zc271xa-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1482,6 +1494,10 @@
   "python-with-prybar-3.10:v33-20240311-46fe793": {
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/cw9dx5zyikv7qfraks61zaalacw4bvdn-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v34-20240312-53a08a2": {
+    "commit": "53a08a23d7154937437e54e52158f5f948887e63",
+    "path": "/nix/store/k7hpsmwxcv836jyk2s33vq5r940m4h9j-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -154,7 +154,8 @@ in
     POETRY_USE_USER_SITE = "1";
     PIP_CONFIG_FILE = pip.config.outPath;
     PYTHONUSERBASE = userbase;
-    PYTHONPATH = "${sitecustomize}:${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}:${pip.pip}/${python.sitePackages}";
+    PYTHONPATH = "${sitecustomize}";
+    REPLIT_PYTHONPATH = "${userbase}/${python.sitePackages}:${pip.pip}/${python.sitePackages}:${pypkgs.setuptools}/${python.sitePackages}";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.

--- a/pkgs/modules/python/sitecustomize.py
+++ b/pkgs/modules/python/sitecustomize.py
@@ -25,3 +25,9 @@ exe = sys.argv[0]
 if exe.endswith('/pip') or exe.endswith('/pip3') or exe.endswith('/.pip-wrapped'):
     from pip._vendor.distlib.scripts import ScriptMaker
     ScriptMaker._build_shebang = pip_build_shebang
+
+import os
+pythonpath = os.getenv('REPLIT_PYTHONPATH')
+if pythonpath:
+  paths = pythonpath.split(':')
+  sys.path.extend(paths)

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -57,7 +57,6 @@ let
       buildCommand = ''
         mkdir -p $out/bin
         makeWrapper ${ldLibraryPathConvertWrapper}/bin/${name} $out/bin/${name} \
-          --prefix PYTHONPATH : "${pypkgs.setuptools}/${python.sitePackages}" \
           --unset PYTHONNOUSERSITE
 
       '' + pkgs.lib.concatMapStringsSep "\n" (s: "ln -s $out/bin/${name} $out/bin/${s}") aliases;


### PR DESCRIPTION
Why
===

This fixes the python error:
```
    assert _sre.MAGIC == MAGIC, "SRE module mismatch"
           ^^^^^^^^^^^^^^^^^^^
AssertionError: SRE module mismatch
```
which occurs often when a user is using a Python Repl, and then adds a Nix dependency in replit.nix that is either a Python app or is another version of Python itself.
Exhibits:
* https://replit.slack.com/archives/C03KS2B221W/p1709838919631539
* https://replit.slack.com/archives/C03KS2B221W/p1709739288354329
* https://replit.slack.com/archives/C03KS2B221W/p1708711425824829

## Explanation

1. The standard regular expression library in Python `re` uses an internal library called `_sre` which is built-in to the Python interpreter. Both `re` and `_sre` contain in them a magic number, which `re` verifies are the same before any operations. If they are different, it fails loudly.
2. in [the python module we add the standard library path](https://github.com/replit/nixmodules/blob/main/pkgs/modules/python/default.nix#L157)  to `PYTHONPATH` ahead of `.pythonlibs/...` to prevent a pypi package of the same name from taking precedence over a standard lib, known example is [uuid](https://pypi.org/project/uuid/)
3. when you combine 1 and 2 and then try to run a different version of python from the one coming from the module, we get this error because `re` was found on `PYTHONPATH` via the standard lib path of "our" python, but the running python is different and therefore its `_sre` module has a different magic number from the loaded `re` library.

This problem is similar to the LD_LIBRARY_PATH problem: the precedence is wrong. Python already has its own standard libs in `sys.path`, we only added it to prevent `.pythonlibs` from having higher precedence to it. What we want is to add `.pythonlibs` to `PYTHONPATH` but in a way that has lower precedence than what Python already has setup by default.

What changed
============

1. Added support for `REPLIT_PYTHONPATH` in sitecustomize.py
2. Use PYTHONPATH only to deliver sitecustomize.py; use `REPLIT_PYTHONPATH` for everything else
3. Stop putting the python standard lib in the path, Python already has it by default, now only put:
   * `.pythonlibs/...`
   * pip's lib path so users can still do `python -m pip install ...`
   * setuptools lib path so certain libraries depending on it as a post install step can work (I am still not sure this is the right thing to do)
5. Move the PYTHONPATH usage in python-utils out to top level but convert to `REPLIT_PYTHONPATH`

Test plan
=========

1. Create a python repl
2. Add pkgs.magic-wormhole
3. run `wormhole` and it should work
4. Try the same with pkgs.gcloud
6. Adde pkgs.python312 (from unstable)
7. run python3.12 and it should work

Regression test with template tester.