### PR TITLE
Revert "Revert "Introducing REPLIT_PYTHONPATH; avoid putting python's system libs in PYTHONPATH""

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -727,6 +727,10 @@
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/njkmnnqvaqq4cvg01s4zzl4lza7420qd-replit-module-python-3.10"
   },
+  "python-3.10:v54-20240315-89a269f": {
+    "commit": "89a269f8f4dd5a0718516cef3c1b255644f167ef",
+    "path": "/nix/store/q1n1980ff4wppawfb1rczblimp9hma2y-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1111,6 +1115,10 @@
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/3nnb5wwgzhy32vy1amsrxz6qcfkrnsar-replit-module-python-3.11"
   },
+  "python-3.11:v35-20240315-89a269f": {
+    "commit": "89a269f8f4dd5a0718516cef3c1b255644f167ef",
+    "path": "/nix/store/pb3k6w67zdpm2qbsh2p1d0d9i2gxpya5-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1246,6 +1254,10 @@
   "python-3.8:v34-20240311-46fe793": {
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/3sh8ardca3z0s2l2f7vcz8van84hmmpw-replit-module-python-3.8"
+  },
+  "python-3.8:v35-20240315-89a269f": {
+    "commit": "89a269f8f4dd5a0718516cef3c1b255644f167ef",
+    "path": "/nix/store/yk21ppv1kgndsh9mxj591dx5g2pp7yvy-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1482,6 +1494,10 @@
   "python-with-prybar-3.10:v33-20240311-46fe793": {
     "commit": "46fe79374aa5040f53b356290b471547ac2dc45c",
     "path": "/nix/store/cw9dx5zyikv7qfraks61zaalacw4bvdn-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v34-20240315-89a269f": {
+    "commit": "89a269f8f4dd5a0718516cef3c1b255644f167ef",
+    "path": "/nix/store/laf48zswad634qm1m8jcz36k9bzlpskz-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -154,7 +154,8 @@ in
     POETRY_USE_USER_SITE = "1";
     PIP_CONFIG_FILE = pip.config.outPath;
     PYTHONUSERBASE = userbase;
-    PYTHONPATH = "${sitecustomize}:${python}/lib/python${pythonVersion}:${userbase}/${python.sitePackages}:${pip.pip}/${python.sitePackages}";
+    PYTHONPATH = "${sitecustomize}:${pip.pip}/${python.sitePackages}";
+    REPLIT_PYTHONPATH = "${userbase}/${python.sitePackages}:${pypkgs.setuptools}/${python.sitePackages}";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.

--- a/pkgs/modules/python/sitecustomize.py
+++ b/pkgs/modules/python/sitecustomize.py
@@ -25,3 +25,9 @@ exe = sys.argv[0]
 if exe.endswith('/pip') or exe.endswith('/pip3') or exe.endswith('/.pip-wrapped'):
     from pip._vendor.distlib.scripts import ScriptMaker
     ScriptMaker._build_shebang = pip_build_shebang
+
+import os
+pythonpath = os.getenv('REPLIT_PYTHONPATH')
+if pythonpath:
+  paths = pythonpath.split(':')
+  sys.path.extend(paths)

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -57,7 +57,6 @@ let
       buildCommand = ''
         mkdir -p $out/bin
         makeWrapper ${ldLibraryPathConvertWrapper}/bin/${name} $out/bin/${name} \
-          --prefix PYTHONPATH : "${pypkgs.setuptools}/${python.sitePackages}" \
           --unset PYTHONNOUSERSITE
 
       '' + pkgs.lib.concatMapStringsSep "\n" (s: "ln -s $out/bin/${name} $out/bin/${s}") aliases;


### PR DESCRIPTION
Reverts replit/nixmodules#283. Re-lands https://github.com/replit/nixmodules/pull/281 introducing REPLIT_PYTHONPATH. It broke pip/poetry because pip was moved out of PYTHONPATH causing sitecustomize not to be able to find it. This moves pip back, but not the others.

## Test

Same procedure as in https://github.com/replit/nixmodules/pull/281