### PR TITLE
chore/pyright 2.0.10

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -807,6 +807,10 @@
     "commit": "38cadddc1db3751ca73fcec17f92b43de3f8a528",
     "path": "/nix/store/292xrql88fxsbsp7kqamlfs1qr86zy9v-replit-module-python-3.10"
   },
+  "python-3.10:v58-20240322-590b495": {
+    "commit": "590b495cb4e99b838af40b3a86956429aea61d56",
+    "path": "/nix/store/zscg14wp6y04w8ssv68zs45y00k3gz75-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1047,6 +1051,10 @@
     "commit": "38cadddc1db3751ca73fcec17f92b43de3f8a528",
     "path": "/nix/store/7rr7amd1q8ddfy81bjad52ici8rlfl69-replit-module-pyright-extended"
   },
+  "pyright-extended:v17-20240322-590b495": {
+    "commit": "590b495cb4e99b838af40b3a86956429aea61d56",
+    "path": "/nix/store/qbshn4b98ympxpbari8yvxz7v8dl436r-replit-module-pyright-extended"
+  },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
@@ -1267,6 +1275,10 @@
     "commit": "38cadddc1db3751ca73fcec17f92b43de3f8a528",
     "path": "/nix/store/szjwb8mlchniz1s24imsi3yai9yv2gfy-replit-module-python-3.11"
   },
+  "python-3.11:v39-20240322-590b495": {
+    "commit": "590b495cb4e99b838af40b3a86956429aea61d56",
+    "path": "/nix/store/gb18nr8304p5symn2bpc83mxx4p9ah3z-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1418,6 +1430,10 @@
   "python-3.8:v38-20240319-38caddd": {
     "commit": "38cadddc1db3751ca73fcec17f92b43de3f8a528",
     "path": "/nix/store/asgh54hz6j4px76x3bdd57mwxpisabbn-replit-module-python-3.8"
+  },
+  "python-3.8:v39-20240322-590b495": {
+    "commit": "590b495cb4e99b838af40b3a86956429aea61d56",
+    "path": "/nix/store/cyrqpr2g8850jak3a8k7ff7ryisyi27s-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1686,6 +1702,10 @@
   "python-with-prybar-3.10:v37-20240319-38caddd": {
     "commit": "38cadddc1db3751ca73fcec17f92b43de3f8a528",
     "path": "/nix/store/yrqixwzal8psgz0j5k5ppx9gl8ll8hmz-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v38-20240322-590b495": {
+    "commit": "590b495cb4e99b838af40b3a86956429aea61d56",
+    "path": "/nix/store/l824j1mq8znf2hm09x78ic1i3jbabc30-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/pyright-extended/default.nix
+++ b/pkgs/pyright-extended/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, yapf, ... }:
 let
-  version = "2.0.9";
+  version = "2.0.10";
 in
 pkgs.stdenvNoCC.mkDerivation rec {
   pname = "pyright-extended";
@@ -8,7 +8,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
 
   src = pkgs.fetchurl {
     url = "https://registry.npmjs.org/@replit/pyright-extended/-/pyright-extended-${version}.tgz";
-    hash = "sha256-njW78ZaVe1CupkyfT0LZQD/6XwROu6w6nhJSUFKC3MA";
+    hash = "sha256-fDxuX1Yyo26m1RB+LQbMBrsqljLU/iOYy26scMTwinw=";
   };
 
   binPath = lib.makeBinPath [


### PR DESCRIPTION
Why
===

Primarily bringing in a fix for inotify watching too many files.

What changed
============

- https://github.com/replit/pyright-extended/pull/37
- https://github.com/replit/pyright-extended/pull/38
- https://github.com/replit/pyright-extended/pull/39

Test plan
=========

- Launch pyright-extended, observe that we do not use excessive file watchers

```bash
stats="$(
find /proc/*/fd -lname anon_inode:inotify -printf '%hinfo/%f\n' 2>/dev/null \
  | xargs grep -c '^inotify' \
  | sort -n -t: -k2 -r \
  | sed 's~/proc/~~; s~/fdinfo/[^:]*~~' \
  | column -s : -t
)"

(
pgrep -fla '/node.*/pyright-langserver.js' | cut -f 1,3 -d ' ' | sed 's~/.*/~~';
pgrep -fla '/node.*/tsserver.js' | cut -f 1,3 -d ' ' | sed 's~/.*/~~';
pgrep -fla '^webpack *$' | sed 's/ *$//';
) | while read line; do
    fields=( ${line} )
    watches=( $(grep "^${fields[0]}\b" <<< "$stats") )
    echo "${fields[0]} ${watches[1]:-0} ${fields[1]}"
done | sort -rnk 2 -t ' ' | column -t
```


Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
