### PR TITLE
Fix registry ids

### DIFF
--- a/pkgs/v2/default.nix
+++ b/pkgs/v2/default.nix
@@ -52,20 +52,21 @@ let
     foldl' (acc: attrName:
       let
         value = options.${attrName};
+        newPath = path ++ [attrName];
       in
         if hasEnableOption value
         then
           let
             enable = value.enable;
             module = {
-              id = concatStringsSep "." path;
+              id = concatStringsSep "." newPath;
               name = enable.moduleName;
               description = enable.moduleDescription;
               options = getModuleOptions value;
             };
           in acc ++ [module]
         else
-          acc ++ (getModulesFromOptions value (path ++ [attrName]))
+          acc ++ (getModulesFromOptions value newPath)
     ) [] (attrNames options);
 
   # given an option, return an attrset containing the type field to use for the


### PR DESCRIPTION
Why
===

The registry ids were missing the last element. This fixes.

What changed
============

Fix.

Test plan
=========

1. `nix build .#v2.registry`
2. `cat result |jq` and see the ids have 2 parts separated by a dot. not just one.