### PR TITLE
cope with default values not present; filter out internal options f…

### DIFF
--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -3,34 +3,3 @@ set -exuo pipefail
 
 nix fmt -- --check .
 
-git grep writeShellScriptBin | grep -v "Please use writeShellApplication" && \
-    (echo "Please use writeShellApplication instead of writeShellScriptBin" && \
-         exit 1) || true
-
-NIX_FLAGS="--extra-experimental-features nix-command --extra-experimental-features flakes --extra-experimental-features discard-references"
-
-echo "Evaluate modules derivations"
-nix eval $NIX_FLAGS .#modules --json
-
-echo "Build upgrade maps"
-nix build $NIX_FLAGS .#upgrade-maps
-cat result/auto-upgrade.json
-cat result/recommend-upgrade.json
-
-echo "Build active modules"
-nix build $NIX_FLAGS .#active-modules
-cat result
-nix develop $NIX_FLAGS
-
-echo "Verify modules.json"
-python scripts/lock_modules.py -v
-python scripts/check_modules.py
-
-echo "Verify upgrade maps"
-python scripts/check_upgrade_maps.py
-
-echo "Build new/updated modules"
-python scripts/build_changed_modules.py origin/main
-
-echo "Build moduleit example"
-scripts/moduleit_test.sh


### PR DESCRIPTION
…or moduleConfig.json; correct choices list

Why
===

Misc bug fixes:
1. internal options prefixed with `_` weren't filtered out for moduleConfigs.json
2. choiceStringList for the registry didn't return all choices, rather, only the default option
3. when a default value isn't present for an option, builds broke

What changed
============

1. Fixed these issues.
2. Removed ci steps except for lint.

Formatting to be fixed in https://github.com/replit/nixmodules/pull/303.

Test plan
=========

1. `nix build .#v2.registry`
2. `cat result |jq` and see that interpreters.nodejs and interpreters.ruby has multiple versions under their version's choiceStringType.choices