### PR TITLE
Language versions are required

### DIFF
--- a/pkgs/modules/compilers/go/default.nix
+++ b/pkgs/modules/compilers/go/default.nix
@@ -14,7 +14,6 @@ with pkgs.lib; {
       version = mkOption {
         type = types.enum [ go.version ];
         description = "Go version";
-        default = go.version;
       };
     };
   };

--- a/pkgs/modules/interpreters/bun/default.nix
+++ b/pkgs/modules/interpreters/bun/default.nix
@@ -17,7 +17,6 @@ with pkgs.lib; {
 
       version = mkOption {
         type = types.enum [ bun.version ];
-        default = bun.version;
         description = "Bun version";
       };
     };

--- a/pkgs/modules/interpreters/nodejs/default.nix
+++ b/pkgs/modules/interpreters/nodejs/default.nix
@@ -29,7 +29,6 @@ with pkgs.lib; {
 
       version = mkOption {
         type = types.enum [ "18" "20" ];
-        default = "20";
         description = "Node.js version";
       };
     };

--- a/pkgs/modules/interpreters/ruby/default.nix
+++ b/pkgs/modules/interpreters/ruby/default.nix
@@ -37,7 +37,6 @@ with pkgs.lib; {
 
       version = mkOption {
         type = types.enum [ "3.1" "3.2" ];
-        default = "3.2";
         description = "Ruby version";
       };
 

--- a/pkgs/v2/examples/bun.nix
+++ b/pkgs/v2/examples/bun.nix
@@ -1,3 +1,4 @@
 {
   bundles.bun.enable = true;
+  interpreters.bun.version = "1.0.26";
 }

--- a/pkgs/v2/examples/go.nix
+++ b/pkgs/v2/examples/go.nix
@@ -1,3 +1,4 @@
 {
   bundles.go.enable = true;
+  compilers.go.version = "1.21.4";
 }


### PR DESCRIPTION
Why
===

To make all language versions required, as proposed [in this doc](https://docs.google.com/document/d/1NqiSSCfRXlWgNiZpZksWqOnWg0Lb5w7Ra8YRr7wtFvA).

What changed
============

Made the version option of all interpreters and compilers required.

Test plan
=========

See that the examples under ./pkgs/v2/examples still build. Example:

```
nix build .#v2.examples.go
ls result
```

Check you can still build the registry:
```
nix build .#v2.registry
cat result |jq
```
