### PR TITLE
Bump pyright-extended

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -855,6 +855,10 @@
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/hsnw40xgc28vfxmkxib175iil1jbf4bz-replit-module-python-3.10"
   },
+  "python-3.10:v60-20240409-a3e9ece": {
+    "commit": "a3e9ece544688043e6e51bdc5831bd3b8551c2ae",
+    "path": "/nix/store/77y7whc4221y0wd2m97d5iyxia1lbb2x-replit-module-python-3.10"
+  },
   "qbasic:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/4n4raazspqy2zgawkkyaqc9xapl1f5sz-replit-module-qbasic"
@@ -1119,6 +1123,10 @@
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/xcsphyl6gnlf0fgjfw9n4naji899nxp7-replit-module-pyright-extended"
   },
+  "pyright-extended:v19-20240409-a3e9ece": {
+    "commit": "a3e9ece544688043e6e51bdc5831bd3b8551c2ae",
+    "path": "/nix/store/yy6a90dc76m9449lmbzl568wc30lh543-replit-module-pyright-extended"
+  },
   "svelte-kit-node-20:v1-20230724-46059dd": {
     "commit": "46059dda60c00cc603c38265f100f5236476ebc5",
     "path": "/nix/store/v1lrwh5r88hc56a6kkjyahahlg0wvqyb-replit-module-svelte-kit-node-20"
@@ -1355,6 +1363,10 @@
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/xwyff8ghwiv319m765svmvmndvxd12sy-replit-module-python-3.11"
   },
+  "python-3.11:v41-20240409-a3e9ece": {
+    "commit": "a3e9ece544688043e6e51bdc5831bd3b8551c2ae",
+    "path": "/nix/store/gs1jz928wra4kd9703q41508jgcsca72-replit-module-python-3.11"
+  },
   "python-3.8:v1-20230829-e1c0916": {
     "commit": "e1c0916e9629e64e596aa4730df2da68363ddeeb",
     "path": "/nix/store/rsycf8rjpznldnf51h83yl0mx3v3ddij-replit-module-python-3.8"
@@ -1514,6 +1526,10 @@
   "python-3.8:v40-20240329-787bc7d": {
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/zhyqxm7m9wpr97ci3kikc5h7n1y32dbw-replit-module-python-3.8"
+  },
+  "python-3.8:v41-20240409-a3e9ece": {
+    "commit": "a3e9ece544688043e6e51bdc5831bd3b8551c2ae",
+    "path": "/nix/store/52krhcd5xjgiklgyhac1a0dmgypck6vw-replit-module-python-3.8"
   },
   "bun-1.0:v1-20230911-f253fb1": {
     "commit": "f253fb1a97d9a1c950d90081ee1ccb290776cf8b",
@@ -1798,6 +1814,10 @@
   "python-with-prybar-3.10:v39-20240329-787bc7d": {
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/3kfjfj3pwv2xv69r5vm88mwd1fgihh50-replit-module-python-with-prybar-3.10"
+  },
+  "python-with-prybar-3.10:v40-20240409-a3e9ece": {
+    "commit": "a3e9ece544688043e6e51bdc5831bd3b8551c2ae",
+    "path": "/nix/store/3wl46vr1w6imyqxzgzbr331rzf0mxray-replit-module-python-with-prybar-3.10"
   },
   "nodejs-with-prybar-18:v1-20230928-1ea5ac0": {
     "commit": "1ea5ac0313085b2ac631b493c925d33489d58410",

--- a/pkgs/pyright-extended/default.nix
+++ b/pkgs/pyright-extended/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, yapf, ... }:
 let
-  version = "2.0.10";
+  version = "2.0.11";
 in
 pkgs.stdenvNoCC.mkDerivation rec {
   pname = "pyright-extended";
@@ -8,7 +8,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
 
   src = pkgs.fetchurl {
     url = "https://registry.npmjs.org/@replit/pyright-extended/-/pyright-extended-${version}.tgz";
-    hash = "sha256-fDxuX1Yyo26m1RB+LQbMBrsqljLU/iOYy26scMTwinw=";
+    hash = "sha256-bIHx9dCY8lOBsyoRm3WP7Vxt0VYMkYlO7wUeCTEGY10=";
   };
 
   binPath = lib.makeBinPath [


### PR DESCRIPTION
Why
===

This contains https://github.com/replit/pyright-extended/pull/40, which will resolve the inotify bug

What changed
============

Bumped pyright-extended

Test plan
=========

Test whether the following `analyze.sh` contains over 50k files when ran against a live pyright-extended repl:

```bash
stats="$(
find /proc/*/fd -lname anon_inode:inotify -printf '%hinfo/%f\n' 2>/dev/null \
  | xargs grep -c '^inotify' \
  | sort -n -t: -k2 -r \
  | sed 's~/proc/~~; s~/fdinfo/[^:]*~~' \
  | column -s : -t
)"

(
pgrep -fla '/node.*/pyright-langserver.js' | cut -f 1,3 -d ' ' | sed 's~/.*/~~';
pgrep -fla '/node.*/tsserver.js' | cut -f 1,3 -d ' ' | sed 's~/.*/~~';
pgrep -fla '^webpack *$' | sed 's/ *$//';
) | while read line; do
    fields=( ${line} )
    watches=( $(grep "^${fields[0]}\b" <<< "$stats") )
    echo "${fields[0]} ${watches[1]:-0} ${fields[1]}"
done | sort -rnk 2 -t ' ' | column -t
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
