### PR TITLE
introducing: per-module checks

### DIFF
--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -637,6 +637,12 @@ in
       };
 
     };
+
+    checks = mkOption {
+      type = types.attrsOf types.package;
+      default = { };
+      description = "module tests";
+    };
   };
 
   config = {

--- a/pkgs/modules/interpreters/nodejs/default.nix
+++ b/pkgs/modules/interpreters/nodejs/default.nix
@@ -36,6 +36,14 @@ with pkgs.lib; {
   };
 
   config = mkIf cfg.enable {
+    checks.nodejs = pkgs.writeShellScript "nodejs-check" ''
+      output=$(${nodejs-wrapped}/bin/node --version)
+      if [ "$output" != "v${nodejs-wrapped.version}" ]; then
+        echo "Node.js version mismatch: expected v${nodejs-wrapped.version}, got $output"
+        exit 1
+      fi
+    '';
+
     replit = {
       packages = [
         nodejs-wrapped


### PR DESCRIPTION
Why
===

we want the testing story to be a lot better for v2 than it was for v1

this testing system allows us to write completely hermetic checks inline with the rest of the module declarations, while also allowing us to test various combinations of modules

the system is *very* bare-bones but i expect it to grow as we define needs

What changed
============

- added new `check` function as an output to `v2/default.nix`
- added new `checks` option 

Test plan
=========

for now, can be tested like so:
```sh
$ nix repl
> :lf github:replit/nixmodules/cad/module-checks
> :b packages.x86_64-linux.v2.check { interpreters.nodejs.enable = true; }
  out -> /nix/store/abc123-modules-checks
$ /nix/store/abc123-modules-checks
```

<img width="778" alt="image" src="https://github.com/replit/nixmodules/assets/23486351/4cda1065-01ce-4020-9e05-912a900677e3">

note that passing in 0 enabled modules will result in an empty checks file

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
