### PR TITLE
feat/Add python3.12 module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -2414,5 +2414,9 @@
   "elixir-1_15:v1-20240405-1a3465a": {
     "commit": "1a3465a810464d932d1ea87a67d524bb99717288",
     "path": "/nix/store/28gq95h262zxsq5ybk3kkf9m5598bmlz-replit-module-elixir-1_15"
+  },
+  "python-3.12:v1-20240405-c324627": {
+    "commit": "c324627af1dc9a364a83b4c32e0bf25d1899de08",
+    "path": "/nix/store/vf940dk54fl5jnvwj7xrvkd0qz4ry8y8-replit-module-python-3.12"
   }
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -23,6 +23,10 @@ let
       python = pkgs.python311Full;
       pypkgs = pkgs.python311Packages;
     })
+    (import ./python {
+      python = pkgs.python312Full;
+      pypkgs = pkgs.python312Packages;
+    })
     (import ./python-with-prybar)
 
     (import ./pyright-extended)

--- a/pkgs/poetry/poetry-py3.12.nix
+++ b/pkgs/poetry/poetry-py3.12.nix
@@ -1,0 +1,7 @@
+{ pkgs, python, pypkgs }:
+pkgs.callPackage ./poetry-in-venv.nix {
+  version = "1.5.4";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.4-python-3.12.0-bundle.tgz;
+  sha256 = "0xvlvg2ydkhggnqxzq2ximl5b5l2jr10gqkgi9w5763w7yys1lk3";
+  inherit python pypkgs;
+}

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -121,6 +121,7 @@ in
 // (fns.linearUpgrade "pyright-extended")
 // (fns.linearUpgrade "python-3.10")
 // (fns.linearUpgrade "python-3.11")
+// (fns.linearUpgrade "python-3.12")
 // (fns.linearUpgrade "python-3.8")
 // (fns.linearUpgrade "python-with-prybar-3.10")
 // (fns.linearUpgrade "qbasic")


### PR DESCRIPTION
Why
===

Python 3.12 exists, we should support it!

What changed
============

Python 3.12 was added!

Test plan
=========

Manual testing, including poetry (newly published against 3.12), pip, and language server

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
