### PR TITLE
chore/Adding .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,5 @@
+entrypoint = "pkgs/default.nix"
+modules = []
+
+[nix]
+channel = "stable-23_11"


### PR DESCRIPTION
Why
===

Now that we've got nix [local overlay](https://github.com/NixLayeredStore/rfcs/blob/local-overlay-store/rfcs/0000-local-overlay-store.md) caching, it's more convenient to do nixmodules development inside a Repl.

What changed
============

Adding a basic `.replit`

Test plan
=========

N/A

Rollout
=======

N/A

- [x] This is fully backward and forward compatible
