### PR TITLE
fix for string list serialization in protobuf

### DIFF
--- a/pkgs/v2/default.nix
+++ b/pkgs/v2/default.nix
@@ -159,7 +159,9 @@ let
     else if isListOfStr option
     then
       {
-        stringListValue = option.value;
+        stringListValue = {
+          stringList = option.value;
+        };
       }
     else if type == "int"
     then


### PR DESCRIPTION
Why
===

Protobuf JSON serialization generated by Nix code was wrong. We need a nested object for string list value than wraps a string array. This broke the NixModulesChange event as well as the ModuleConfigGetRequest/Response.

What changed
============

Added the nested object.

Test plan
=========

1. have nixmodules v2 flag on
2. put `bundles.nodejs.enable = true` in `[moduleConfig]` section
3. wait for a NixModulesChange event that gives you moduleV2 field that is populated.