### PR TITLE
Convert replit module to V2

### DIFF
--- a/pkgs/bundle-util/default.nix
+++ b/pkgs/bundle-util/default.nix
@@ -26,7 +26,7 @@
     }
     ```
   */
-  mkBundleModule = { id, name, description, submodules, pkgs, config }:
+  mkBundleModule = { id, name, description, submodules, pkgs, config, enableDefault ? false }:
     with pkgs.lib;
     let
       cfg = config.bundles.${id};
@@ -83,6 +83,7 @@
         bundles.${id} = {
           enable = mkModuleEnableOption {
             inherit name description;
+            default = enableDefault;
           };
 
           submodules = mkOption {

--- a/pkgs/modules/bundles/replit/default.nix
+++ b/pkgs/modules/bundles/replit/default.nix
@@ -1,0 +1,10 @@
+{ pkgs, config, ... }:
+pkgs.lib.mkBundleModule {
+  id = "replit";
+  name = "Replit Bundle";
+  description = "Tool bundle for working with Repls";
+  submodules = [
+    "languageServers.dotreplit-lsp"
+  ];
+  inherit pkgs config;
+}

--- a/pkgs/modules/bundles/replit/default.nix
+++ b/pkgs/modules/bundles/replit/default.nix
@@ -6,5 +6,6 @@ pkgs.lib.mkBundleModule {
   submodules = [
     "languageServers.dotreplit-lsp"
   ];
+  enableDefault = true;
   inherit pkgs config;
 }

--- a/pkgs/modules/languageServers/dotreplit-lsp/default.nix
+++ b/pkgs/modules/languageServers/dotreplit-lsp/default.nix
@@ -1,0 +1,59 @@
+{ pkgs, config, ... }:
+with pkgs.lib;
+let
+  cfg = config.languageServers.dotreplit-lsp;
+  # use changes from https://github.com/tamasfe/taplo/pull/510
+  # the above PR adds the `-c` flag to the `taplo lsp` command, which is
+  # necessary to support our schema. There are a couple of paths forward
+  # for replacing this derivation:
+  # option 1:
+  # - the above pr is merged
+  # - new taplo version is released https://github.com/tamasfe/taplo/pull/502 (with my change)
+  # - nixpkgs-unstable gets the updated version
+  # - we update to nixpkgs-unstable that contains the updated taplo version
+  # option 2:
+  # - given that taplo currently consumes >1 mb of memory, it'd be nice to have
+  #   a custom bin that wraps taplo-lsp crate that *only* provides lsp for .replit
+  #   files. this should reduce the amount of consumed memory by a good amount.
+  # - use the above custom bin
+  taplo = pkgs.rustPlatform.buildRustPackage rec {
+    pname = "taplo";
+    version = "0.patched";
+    src = pkgs.fetchFromGitHub {
+      owner = "cdmistman";
+      repo = "taplo";
+      rev = "22eff1f7775e48eee8b50518c67f992b4595ab61";
+      hash = "sha256-63fm8pH03TJd4QBuhIxtttoEAaBnc9TuHGKCMK4YGP0=";
+    };
+
+    cargoHash = "sha256-4OSCN2zCrlBHihZn7TCNZp4mCREpvrpKsfMSNP95GNc=";
+    buildFeatures = [ "lsp" ];
+  };
+
+  taplo-config = pkgs.writeText "taplo-config.toml" ''
+    include = ["**/.replit"]
+
+    [schema]
+    enabled = true
+    path = "/etc/replit/dotreplit.schema.json"
+  '';
+in
+{
+  options = {
+    languageServers.dotreplit-lsp = {
+      enable = mkModuleEnableOption {
+        name = ".replit Language Server";
+        description = "Autocompletion help and more for editing .replit";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    replit.dev.languageServers.dotreplit-lsp = {
+      name = ".replit LSP";
+      language = "dotreplit";
+      start = "${taplo}/bin/taplo lsp -c ${taplo-config} stdio";
+    };
+  };
+}
+

--- a/pkgs/modules/replit/default.nix
+++ b/pkgs/modules/replit/default.nix
@@ -39,9 +39,6 @@ let
 in
 
 {
-  id = "replit";
-  name = "Base Replit Tools";
-
   replit.dev.languageServers.dotreplit-lsp = {
     name = ".replit LSP";
     language = "dotreplit";

--- a/pkgs/overlay/default.nix
+++ b/pkgs/overlay/default.nix
@@ -33,9 +33,9 @@ final: prev: {
     };
 
     mkModuleEnableOption =
-      { name, description }: prev.lib.mkOption
+      { name, description, default ? false }: prev.lib.mkOption
         {
-          default = false;
+          inherit default;
           example = true;
           description = "Whether to enable ${name}.";
           type = prev.lib.types.bool;

--- a/pkgs/v2/default.nix
+++ b/pkgs/v2/default.nix
@@ -35,6 +35,8 @@ let
     (import ../modules/languageServers/pyright-extended)
     (import ../modules/debuggers/debugpy)
     (import ../modules/packagers/python)
+    (import ../modules/bundles/replit)
+    (import ../modules/languageServers/dotreplit-lsp)
   ];
 
   # Evaluates a set of modules with our special args
@@ -279,6 +281,7 @@ in
     bun = buildModule ./examples/bun.nix;
     nodejs = buildModule ./examples/nodejs.nix;
     python = buildModule ./examples/python.nix;
+    replit = buildModule ./examples/replit.nix;
   };
 
   inherit buildDotReplit registry;

--- a/pkgs/v2/examples/replit.nix
+++ b/pkgs/v2/examples/replit.nix
@@ -1,0 +1,3 @@
+{
+  bundles.replit.enable = true;
+}

--- a/pkgs/v2/examples/replit.nix
+++ b/pkgs/v2/examples/replit.nix
@@ -1,3 +1,3 @@
 {
-  bundles.replit.enable = true;
+  # bundles.replit.enable = false;
 }


### PR DESCRIPTION
Why
===

Convert replit module to V2 scheme.

What changed
============

1. Moved dotreplit-lsp over
2. Added a replit bundle
3. Set the default enable value for replit bundle to true. This gives users the ability to opt-out by setting `bundles.replit.enable = false`

Test
===

1. `nix build .#v2.examples.replit`
2. `ls result`