### PR TITLE
Required field for options

### DIFF
--- a/pkgs/v2/default.nix
+++ b/pkgs/v2/default.nix
@@ -124,11 +124,12 @@ let
           description = option.description;
           type = option.type.functor.name;
           typeField = getTypeFieldForOption option;
+          maybeRequired = if hasAttr "default" option then { } else { required = true; };
         in
         acc ++ [
           ({
             inherit name description;
-          } // typeField)
+          } // typeField // maybeRequired)
         ]
       ) [ ]
       optionNames;
@@ -278,4 +279,6 @@ in
   };
 
   inherit buildDotReplit registry;
+
+  debug = (myEvalModules allModules).options;
 }

--- a/pkgs/v2/default.nix
+++ b/pkgs/v2/default.nix
@@ -279,6 +279,4 @@ in
   };
 
   inherit buildDotReplit registry;
-
-  debug = (myEvalModules allModules).options;
 }


### PR DESCRIPTION
Why / Changes
===

For the [version pinning proposal](https://docs.google.com/document/d/1NqiSSCfRXlWgNiZpZksWqOnWg0Lb5w7Ra8YRr7wtFvA/edit#heading=h.2whrioisgobc) the UI needs a way to tell whether a version field is required or not.

What changed
============

In conjunction with https://github.com/replit/goval/pull/13260. This will send a required = true field for a NixModuleOption in the case the option is mandatory.

Test plan
=========
1. `nix build .#v2.registry`
2. `cat result |jq|less` and see that `compilers.go`, `interpreters.nodejs`, `interpreters.bun` all have a required = true set in their version field.
