### PR TITLE
Revert "Required field for options"

### DIFF
--- a/pkgs/v2/default.nix
+++ b/pkgs/v2/default.nix
@@ -124,12 +124,11 @@ let
           description = option.description;
           type = option.type.functor.name;
           typeField = getTypeFieldForOption option;
-          maybeRequired = if hasAttr "default" option then { } else { required = true; };
         in
         acc ++ [
           ({
             inherit name description;
-          } // typeField // maybeRequired)
+          } // typeField)
         ]
       ) [ ]
       optionNames;


### PR DESCRIPTION
Reverts replit/nixmodules#316

Need pid1 deploy to work. Temporarily revert to unbreak things for staff.