### PR TITLE
Submodules rename to dependencies

### DIFF
--- a/pkgs/bundle-util/default.nix
+++ b/pkgs/bundle-util/default.nix
@@ -2,8 +2,8 @@
   /*
     This utility creates a module that implements a bundle, which has
     these features:
-    1. if the bundle is enabled, it enables by default a list of submodules
-    2. exposes its submodules as a list of module ID strings via the `submodules`
+    1. if the bundle is enabled, it enables by default a list of dependencies
+    2. exposes its dependencies as a list of module ID strings via the `dependencies`
     option
 
     Example:
@@ -15,7 +15,7 @@
     id = "nodejs";
     name = "Node.js Tools Bundle";
     description = "Development tools for the Node.js JavaScript runtime";
-    submodules = [
+    dependencies = [
     "interpreters.nodejs"
     "languageServers.typescript-language-server"
     "debuggers.node-dap"
@@ -26,13 +26,13 @@
     }
     ```
   */
-  mkBundleModule = { id, name, description, submodules, pkgs, config }:
+  mkBundleModule = { id, name, description, dependencies, pkgs, config }:
     with pkgs.lib;
     let
       cfg = config.bundles.${id};
       /*
       enablePath - generates an enable config defaulted to true
-        for a submodules identified as 'elems' and merges it with an existing config.
+        for dependency identified as 'elems' and merges it with an existing config.
       elems - result of spliting a module ID on "." e.g. ["interpreters" "nodejs"]
       config - an existing nested config, e.g.
         {
@@ -57,7 +57,7 @@
           });
       /*
       mkBundleConfig - creates nested config of enable values defaulted to true
-        from the passed in submodules list. e.g.
+        from the passed in dependencies list. e.g.
 
         mkBundleConfig ['a.b' 'c.d'] =>
         {
@@ -69,14 +69,14 @@
           };
         }
       */
-      mkBundleConfig = submodules:
+      mkBundleConfig = dependencies:
         foldl'
           (config: moduleId:
             let elems = strings.splitString "." moduleId;
             in enablePath elems config
           )
           { }
-          submodules;
+          dependencies;
     in
     {
       options = {
@@ -85,14 +85,14 @@
             inherit name description;
           };
 
-          submodules = mkOption {
+          dependencies = mkOption {
             type = types.listOf types.str;
             description = "Modules included with this bundle";
-            default = submodules;
+            default = dependencies;
           };
         };
       };
 
-      config = mkIf cfg.enable (mkBundleConfig submodules);
+      config = mkIf cfg.enable (mkBundleConfig dependencies);
     };
 }

--- a/pkgs/modules/bundles/bun/default.nix
+++ b/pkgs/modules/bundles/bun/default.nix
@@ -3,7 +3,7 @@ pkgs.lib.mkBundleModule {
   id = "bun";
   name = "Bun Tools Bundle";
   description = "Development tools for the Bun JavaScript runtime";
-  submodules = [
+  dependencies = [
     "interpreters.bun"
     "languageServers.typescript-language-server"
     "packagers.bun"

--- a/pkgs/modules/bundles/go/default.nix
+++ b/pkgs/modules/bundles/go/default.nix
@@ -3,7 +3,7 @@ pkgs.lib.mkBundleModule {
   id = "go";
   name = "Go Tools Bundle";
   description = "Development tools for the Go programming language";
-  submodules = [
+  dependencies = [
     "compilers.go"
     "languageServers.gopls"
     "formatters.gofmt"

--- a/pkgs/modules/bundles/nodejs/default.nix
+++ b/pkgs/modules/bundles/nodejs/default.nix
@@ -3,7 +3,7 @@ pkgs.lib.mkBundleModule {
   id = "nodejs";
   name = "Node.js Tools Bundle";
   description = "Development tools for the Node.js JavaScript runtime";
-  submodules = [
+  dependencies = [
     "interpreters.nodejs"
     "languageServers.typescript-language-server"
     "debuggers.node-dap"

--- a/pkgs/modules/bundles/ruby/default.nix
+++ b/pkgs/modules/bundles/ruby/default.nix
@@ -3,7 +3,7 @@ pkgs.lib.mkBundleModule {
   id = "ruby";
   name = "Ruby Tools Bundle";
   description = "Developer tools for the Ruby programming language";
-  submodules = [
+  dependencies = [
     "interpreters.ruby"
     "languageServers.solargraph"
     "packagers.rubygems"

--- a/pkgs/modules/bundles/web/default.nix
+++ b/pkgs/modules/bundles/web/default.nix
@@ -3,7 +3,7 @@ pkgs.lib.mkBundleModule {
   id = "web";
   name = "Web Tools Bundle";
   description = "Tools for web development";
-  submodules = [
+  dependencies = [
     "languageServers.typescript-language-server"
     "languageServers.html-language-server"
     "languageServers.css-language-server"


### PR DESCRIPTION
Why
===

I realized that we may use dependencies between modules more than I thought we were going to use it. For example, if you want to add the upm Node.js packager, you'll need to install Node.js. So really the packager depends on the runtime. It seems wrong to say the runtime in a submodule of the packager. So let's rename it.

What changed
============

Renamed submodule to dependencies in all the places.

Test plan
=========

1. `nix build .#v2.registry && cat result |jq|less`
2. See that `bundles.bun` and any bundle for that matter, contains a dependencies option, containing a list of module IDs
