### PR TITLE
Unify typescript-language-server

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,4 +11,6 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - run: scripts/ci_check.sh

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,4 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Run the Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       - run: scripts/ci_check.sh

--- a/modules.json
+++ b/modules.json
@@ -475,6 +475,10 @@
     "commit": "269b32382cc6fdc0a16d065c63c10e965527cba4",
     "path": "/nix/store/2zyllffdkaxsni14ifwps03hsay32dgq-replit-module-nodejs-18"
   },
+  "nodejs-18:v36-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/gh3pvs6gwkvarr3fs0vhglvyp28rzk4j-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -614,6 +618,10 @@
   "nodejs-20:v32-20240401-269b323": {
     "commit": "269b32382cc6fdc0a16d065c63c10e965527cba4",
     "path": "/nix/store/1sa4wmq19l8langdhsj6zk25brsqpn30-replit-module-nodejs-20"
+  },
+  "nodejs-20:v33-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/44k9ir9qnz6s4przgb9z2hg8akwcmjcw-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -1050,6 +1058,10 @@
   "web:v10-20240329-787bc7d": {
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/787w1dmlbhym7gc615rm2c3ybxwjmp4n-replit-module-web"
+  },
+  "web:v11-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/iwirag6asm7m5phivyrifqczn01zjq1z-replit-module-web"
   },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
@@ -1923,6 +1935,10 @@
     "commit": "269b32382cc6fdc0a16d065c63c10e965527cba4",
     "path": "/nix/store/yv3dg8cxva7inn2ixxqzmqm37scb7v4s-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v27-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/sza7zbjl68jsbzinkd4a85m0k32n5mf8-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -2355,6 +2371,10 @@
     "commit": "787bc7deb9231b61fe65b63da126238620125705",
     "path": "/nix/store/34njljilglxhjq41m6xzv09sajrfq613-replit-module-angular-node-20"
   },
+  "angular-node-20:v9-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/9ggsywz4140np41adsy4cg2h2qzly2vm-replit-module-angular-node-20"
+  },
   "rust-nightly:v1-20240126-d98d19e": {
     "commit": "d98d19ee06a8b30ecabf9cf154fd403103c7fee6",
     "path": "/nix/store/f71v169hdnv8g9w5kjpmv9z4dhzpfzjp-replit-module-rust-nightly"
@@ -2411,6 +2431,10 @@
     "commit": "269b32382cc6fdc0a16d065c63c10e965527cba4",
     "path": "/nix/store/gx88wz4j8fkk28vbfjkkhdj1y5hlq8if-replit-module-bun-1.1"
   },
+  "bun-1.1:v2-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/1d0rqfhy6bjy2qqi44cnxzmfy5x1iarx-replit-module-bun-1.1"
+  },
   "elixir-1_15:v1-20240405-1a3465a": {
     "commit": "1a3465a810464d932d1ea87a67d524bb99717288",
     "path": "/nix/store/28gq95h262zxsq5ybk3kkf9m5598bmlz-replit-module-elixir-1_15"
@@ -2418,5 +2442,9 @@
   "python-3.12:v1-20240405-c324627": {
     "commit": "c324627af1dc9a364a83b4c32e0bf25d1899de08",
     "path": "/nix/store/vf940dk54fl5jnvwj7xrvkd0qz4ry8y8-replit-module-python-3.12"
+  },
+  "typescript-language-server:v1-20240429-4b1b00e": {
+    "commit": "4b1b00e30b587621b4b1b87dbd4bb8114381c5f9",
+    "path": "/nix/store/3dgs275c04a82xb842f45l2klamzl276-replit-module-typescript-language-server"
   }
 }

--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -34,8 +34,6 @@ in
       PATH = "$XDG_CONFIG_HOME/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
     };
 
-    dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".mjs" ".mts" ".cjs" ".cts" ".es6" ];
-
     dev.runners.dev-runner = {
       name = "package.json watch script";
       inherit language;

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -28,8 +28,6 @@ in
     bun-wrapped
   ];
 
-  replit.dev.languageServers.typescript-language-server.extensions = extensions ++ [ ".json" ];
-
   replit.runners."package.json" = {
     language = "javascript";
     inherit extensions;

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -98,6 +98,9 @@ let
     (import ./vue)
     (import ./web)
     (import ./hermit)
+    (import ./typescript-language-server {
+      nodepkgs = pkgs.nodePackages;
+    })
   ];
 
   modules = builtins.listToAttrs (

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -43,8 +43,6 @@ in
       nodepkgs.prettier
     ];
 
-    dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".mjs" ".cjs" ".es6" ];
-
     runners.nodeJS = {
       name = "Node.js";
       displayVersion = nodejs.version;

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -1,5 +1,5 @@
 { nodepkgs }:
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   typescript-language-server = nodepkgs.typescript-language-server.override {
     # TODO: we can get rid of this patch once >=4.2.0 is in the nixpkgs-unstable we use.
@@ -18,6 +18,8 @@ let
   };
 in
 {
+  id = lib.mkDefault "typescript-language-server";
+  name = lib.mkDefault "TypeScript Language Server";
   replit.dev.languageServers.typescript-language-server = {
     name = "TypeScript Language Server";
     displayVersion = typescript-language-server.version;
@@ -27,5 +29,7 @@ in
     initializationOptions = {
       tsserver.fallbackPath = "${nodepkgs.typescript}/lib/node_modules/typescript/lib";
     };
+
+    extensions = [ ".js" ".jsx" ".ts" ".tsx" ".mjs" ".mts" ".cjs" ".cts" ".es6" ".json" ];
   };
 }

--- a/pkgs/modules/web/default.nix
+++ b/pkgs/modules/web/default.nix
@@ -8,9 +8,6 @@
     })
   ];
 
-
-  replit.dev.languageServers.typescript-language-server.extensions = [ ".js" ".jsx" ".ts" ".tsx" ".mjs" ".mts" ".cjs" ".cts" ".es6" ];
-
   replit.dev.languageServers.html = {
     name = "HTML Language Server";
     language = "html";
@@ -89,7 +86,7 @@
           # Configure linting
           # ignore = don't show any warning or error
           # warning = show yellow underline
-          # error = show red underline 
+          # error = show red underline
           lint = {
             # Invalid number of parameters
             argumentsInColorFunction = "error";

--- a/scripts/build_changed_modules.py
+++ b/scripts/build_changed_modules.py
@@ -54,7 +54,6 @@ def main():
     referenced_path = current_modules[module_registry_id]['path']
     assert actual_path == referenced_path, 'output path for %s does not match: %s vs %s' % (module_registry_id, actual_path, referenced_path)
     print('%s ok' % module_registry_id)
-    nix_collect_garbage()
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Why
===

As a result of https://github.com/replit/goval/pull/13404, LSPs will be automatically de-dupped by unique LSP IDs (attr names in the languageServers attrset). This means if you install multiple modules that include the typescript-language-server, only one will be used. For this reason, we don't want to have different configs for typescript-language-server depending on its parent module, because then one of the will get discarded in this situation.

What changed
============

1. Have one universal config (the file extensions list is the o[nly value that's relevant), and parent modules just import typescript-language-server without modification.
2. also add typescript-language-server as a top-level module: might as well.

Test plan
=========

1. create node.js repl
2. open a .json file, it will have lsp support via typescript-language-server