### PR TITLE
Replit RTLD loader module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -2606,5 +2606,9 @@
   "typescript-language-server:v2-20240429-0325cbb": {
     "commit": "0325cbbddd2aae1706bed30d9cb67eafaba5d222",
     "path": "/nix/store/z9d6ii0lm0y797ilqkm529j3gxk8n6k9-replit-module-typescript-language-server"
+  },
+  "replit-rtld-loader:v1-20240430-a96eaf1": {
+    "commit": "a96eaf11ab76e8b71bae880bc7484c21745903bc",
+    "path": "/nix/store/j30nan72mgq5d3n4vn62y5yknfcz5qvl-replit-module-replit-rtld-loader"
   }
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -73,8 +73,10 @@ rec {
 
   bundle-image-tarball = pkgs.callPackage ./bundle-image-tarball { inherit bundle-image revstring; };
 
+  dev-module-ids = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" ];
+
   bundle-squashfs = bundle-squashfs-fn {
-    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" ];
+    moduleIds = dev-module-ids;
     diskName = "disk.sqsh";
   };
 
@@ -83,7 +85,7 @@ rec {
     # publish your feature branch first and make sure modules.json is current, then
     # in goval dir (next to nixmodules), run `make custom-nixmodules-disk` to use this disk in conman
     # There is no need to check in changes to this.
-    moduleIds = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" ];
+    moduleIds = dev-module-ids;
     diskName = "disk.sqsh";
   };
 
@@ -96,7 +98,7 @@ rec {
       flake.modules.${shortModuleId})
     all-modules;
 
-  custom-bundle-phony-ocis = mkPhonyOCIs { moduleIds = [ "nodejs-18" "nodejs-20" ]; };
+  custom-bundle-phony-ocis = mkPhonyOCIs { moduleIds = dev-module-ids; };
 
   all-phony-oci-bundles = mapAttrs
     (moduleId: module:

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -101,6 +101,7 @@ let
     (import ./typescript-language-server {
       nodepkgs = pkgs.nodePackages;
     })
+    (import ./replit-rtld-loader)
   ];
 
   modules = builtins.listToAttrs (

--- a/pkgs/modules/replit-rtld-loader/default.nix
+++ b/pkgs/modules/replit-rtld-loader/default.nix
@@ -1,0 +1,13 @@
+{ lib, pkgs, ... }:
+{
+  id = "replit-rtld-loader";
+  name = "Replit RTLD Loader";
+  description = ''
+    The Replit RTLD Loader allows dynamically loaded shared libraries (.so) to work seamlessly in Repls.
+  '';
+
+  replit.env = {
+    LD_AUDIT = "${pkgs.replit-rtld-loader}/rtld_loader.so";
+  };
+}
+

--- a/pkgs/upgrade-maps/mapping.nix
+++ b/pkgs/upgrade-maps/mapping.nix
@@ -80,6 +80,7 @@ in
   # pid1 auto-loads the replit module by attempting to resolve `replit`. If this line is
   # removed, then the `replit` module will fail to resolve in pid1.
   "replit" = { to = "replit:v1-20231211-d5ddcff"; auto = true; };
+  "replit-rtld-loader" = { to = "replit-rtld-loader:v1-20240430-a96eaf1"; auto = true; };
 
   "rust" = { to = "rust-1.69:v1-20230525-c48c43c"; auto = true; };
   "rust-1.69:v1-20230525-c48c43c" = { to = "rust-1.69:v2-20230623-0b7a606"; auto = true; };


### PR DESCRIPTION
Why
===

We need a way to deliver RTLD loader globally to all repls, but the previous attempt had issues in deployment. The new strategy is to deliver it via a Nixmodule which is conditionally turned on via a flag.

What changed
============

1. Added a module for delivering the RTLD loader
2. Added a upgrade map entry for it so we can activate it using a bare module name

Test plan
=========

See test plan in https://github.com/replit/goval/pull/13414