### PR TITLE
remove tsserver override

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -511,6 +511,10 @@
     "commit": "5b9002a74d16fa9d462dbc9ada6b8239ad06bed6",
     "path": "/nix/store/l5agplpqf0zijrr128kcnnsiq6mqgkr6-replit-module-nodejs-18"
   },
+  "nodejs-18:v39-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/ag63nz6mh2vmhigfy2xdgz67ha8arw35-replit-module-nodejs-18"
+  },
   "nodejs-19:v1-20230525-c48c43c": {
     "commit": "c48c43c6c698223ed3ce2abc5a2d708735a77d5b",
     "path": "/nix/store/qwhwjll9vns8vqcc6zjy5s4i3rzh05w3-replit-module-nodejs-19"
@@ -662,6 +666,10 @@
   "nodejs-20:v35-20240502-5b9002a": {
     "commit": "5b9002a74d16fa9d462dbc9ada6b8239ad06bed6",
     "path": "/nix/store/h8vb8cslw38cqpyrgp3z9aajb4a3jl01-replit-module-nodejs-20"
+  },
+  "nodejs-20:v36-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/i6j4jcx8wda1l4jj46pibv38bs09vmxp-replit-module-nodejs-20"
   },
   "php-8.1:v2-20230623-0b7a606": {
     "commit": "0b7a60667d2c29f2686211e952924a9693916a20",
@@ -1122,6 +1130,10 @@
   "web:v12-20240429-0325cbb": {
     "commit": "0325cbbddd2aae1706bed30d9cb67eafaba5d222",
     "path": "/nix/store/qc988ww5hwvr7imp5lmyyyh8cs29si1n-replit-module-web"
+  },
+  "web:v13-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/qaf17gq6y4p5wywnrl7l3xlg11gdljr8-replit-module-web"
   },
   "pyright-extended:v1-20230707-0c33b22": {
     "commit": "0c33b229d159ded681992f2220e273540b6708b7",
@@ -2035,6 +2047,10 @@
     "commit": "5b9002a74d16fa9d462dbc9ada6b8239ad06bed6",
     "path": "/nix/store/nhxl5crkrxj391jrwvkn3xw2i84cz7zg-replit-module-nodejs-with-prybar-18"
   },
+  "nodejs-with-prybar-18:v30-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/7v9b04qwncg51bv40jidfkfaf3nb542k-replit-module-nodejs-with-prybar-18"
+  },
   "zig-0.11:v1-20231014-15426ef": {
     "commit": "15426ef79793bf7c424eb40865d507eacfdd44e6",
     "path": "/nix/store/17ji0rxmrfz30sy2b60c65vjv5sh6ksz-replit-module-zig-0.11"
@@ -2519,6 +2535,10 @@
     "commit": "0325cbbddd2aae1706bed30d9cb67eafaba5d222",
     "path": "/nix/store/mhna1l4vk56f140cgwzyv4nzyxihrygs-replit-module-angular-node-20"
   },
+  "angular-node-20:v11-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/r5285xiqb6wxqszq6nvji6q2dv8q9s9i-replit-module-angular-node-20"
+  },
   "rust-nightly:v1-20240126-d98d19e": {
     "commit": "d98d19ee06a8b30ecabf9cf154fd403103c7fee6",
     "path": "/nix/store/f71v169hdnv8g9w5kjpmv9z4dhzpfzjp-replit-module-rust-nightly"
@@ -2599,6 +2619,10 @@
     "commit": "5b9002a74d16fa9d462dbc9ada6b8239ad06bed6",
     "path": "/nix/store/k9qgb3wyw916p7sdja4miab3q1r89r8a-replit-module-bun-1.1"
   },
+  "bun-1.1:v5-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/cwqc9538canmn0nkc647m1489wa9i3ry-replit-module-bun-1.1"
+  },
   "elixir-1_15:v1-20240405-1a3465a": {
     "commit": "1a3465a810464d932d1ea87a67d524bb99717288",
     "path": "/nix/store/28gq95h262zxsq5ybk3kkf9m5598bmlz-replit-module-elixir-1_15"
@@ -2622,6 +2646,10 @@
   "typescript-language-server:v2-20240429-0325cbb": {
     "commit": "0325cbbddd2aae1706bed30d9cb67eafaba5d222",
     "path": "/nix/store/z9d6ii0lm0y797ilqkm529j3gxk8n6k9-replit-module-typescript-language-server"
+  },
+  "typescript-language-server:v3-20240502-f4453db": {
+    "commit": "f4453db0f97e359429c7df8f5b02b247d310e72a",
+    "path": "/nix/store/wlpsyvr14ghqrw3pkdipk9lw6b8i58cy-replit-module-typescript-language-server"
   },
   "replit-rtld-loader:v1-20240430-a96eaf1": {
     "commit": "a96eaf11ab76e8b71bae880bc7484c21745903bc",

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -1,21 +1,7 @@
 { nodepkgs }:
 { pkgs, lib, ... }:
 let
-  typescript-language-server = nodepkgs.typescript-language-server.override {
-    # TODO: we can get rid of this patch once >=4.2.0 is in the nixpkgs-unstable we use.
-    # but we want this version because of https://github.com/typescript-language-server/typescript-language-server/pull/831
-    version = "4.2.0";
-    src = pkgs.fetchurl {
-      url = "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-4.2.0.tgz";
-      hash = "sha256-sg0O1uw6L3LDlPKTbXXsXVYwR+c7HH5c89xNIefEov8=";
-    };
-
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-    postInstall = ''
-      wrapProgram "$out/bin/typescript-language-server" \
-        --suffix PATH : ${pkgs.lib.makeBinPath [ nodepkgs.typescript ]}
-    '';
-  };
+  inherit (nodepkgs) typescript-language-server;
 in
 {
   id = lib.mkDefault "typescript-language-server";


### PR DESCRIPTION
Why
===

the `src` for typescript-language-server was overridden because the version of nixpkgs-unstable we were using didn't have a patch we needed

we've since updated nixpkgs-unstable quite a few revisions and now we're far past the requirement for removing this override, so now it's unoverridden

What changed
============

removed `src` override of typescript-language-server

Test plan
=========

1. open node 18 repl, lsp still works
2. open node 20 repl, lsp still works
3. open bun repl, lsp still works
4. open typescript repl, lsp still works

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
