### PR TITLE
update fenix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1705559032,
-        "narHash": "sha256-Cb+Jd1+Gz4Wi+8elPnUIHnqQmE1qjDRZ+PsJaPaAffY=",
+        "lastModified": 1714631076,
+        "narHash": "sha256-at4+1R9gx3CGvX0ZJo9GwDZyt3RzOft7qDCTsYHjI4M=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e132ea0eb0c799a2109a91688e499d7bf4962801",
+        "rev": "22a9eb3f20dd340d084cee4426f386a90b1351ca",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1705523001,
-        "narHash": "sha256-TWq5vJ6m+9HGSDMsQAmz1TMegMi79R3TTyKjnPWsQp8=",
+        "lastModified": 1714572655,
+        "narHash": "sha256-xjD8vmit0Nz1qaSSSpeXOK3saSvAZtOGHS2SHZE75Ek=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9d9b34354d2f13e33568c9c55b226dd014a146a0",
+        "rev": "cfce2bb46da62950a8b70ddb0b2a12332da1b1e1",
         "type": "github"
       },
       "original": {

--- a/modules.json
+++ b/modules.json
@@ -2103,6 +2103,10 @@
     "commit": "0325cbbddd2aae1706bed30d9cb67eafaba5d222",
     "path": "/nix/store/i3h37g786y3h79gaifqa9l769qx123kw-replit-module-rust-stable"
   },
+  "rust-stable:v13-20240502-4c0bbb0": {
+    "commit": "4c0bbb07cf9a1649e85b4f20dfc49752cb238aab",
+    "path": "/nix/store/0ydvr08dsj1y89pc0dqmyvx7zffbl584-replit-module-rust-stable"
+  },
   "go-1.21:v1-20231024-b3ba53c": {
     "commit": "b3ba53c9295b9664fe1b4ea22b7cbaed35e23d86",
     "path": "/nix/store/zkbbhbrnarrnb914ynm47i40n0fc285x-replit-module-go-1.21"
@@ -2570,6 +2574,10 @@
   "rust-nightly:v8-20240429-0325cbb": {
     "commit": "0325cbbddd2aae1706bed30d9cb67eafaba5d222",
     "path": "/nix/store/0i9vx8k74wx9nbqdjqka9bk6s8z77x12-replit-module-rust-nightly"
+  },
+  "rust-nightly:v9-20240502-4c0bbb0": {
+    "commit": "4c0bbb07cf9a1649e85b4f20dfc49752cb238aab",
+    "path": "/nix/store/cxwik2l3qisxvjby7fjdwmfjdnq6fxym-replit-module-rust-nightly"
   },
   "hermit-0.38.2:v1-20240208-9bf7683": {
     "commit": "9bf76831508415761756fbb980dabe6d21b6394f",


### PR DESCRIPTION
Why
===

there have been some rust releases since the last time fenix was updated

What changed
============

updated fenix input and locked modules

Test plan
=========

rust-stable and rust-nightly modules still work as intended

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
