### PR TITLE
Build changed modules in ci

### DIFF
--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -13,3 +13,5 @@ echo "Evaluate modules derivations"
 nix eval $NIX_FLAGS .#modules --json
 
 nix develop $NIX_FLAGS
+
+python scripts/build_changed_modules.py main


### PR DESCRIPTION
Why
===

After https://github.com/replit/nixmodules/pull/327 we need to update the CI check for building changed modules.

What changed
============

1. Updated build_changed_modules.py script to base the difference on the tuple `(module Id, sha from Nix store path)`
2. also added a check to make sure we didn't remove any module IDs (we could force upgrade them if we needed, but not out right remove)

Test plan
=========

1. Try making a subbranch of this, make a change to a module and push, see that the changed module is built in CI
2. Try removing a module from `pkgs/modules/default.nix` or `pkgs/historical-modules/default.nix` and see that CI fails