### PR TITLE
Removed the duplicate go: both resulted to the same output path

### DIFF
--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -43,7 +43,10 @@ let
     (import ./nodejs-with-prybar)
 
     (import ./go {
-      inherit (pkgs) go gopls;
+      go = pkgs.go_1_21;
+      gopls = pkgs.gopls.override {
+        buildGoModule = pkgs.buildGo121Module;
+      };
     })
 
     (import ./rust "stable")

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -45,12 +45,6 @@ let
     (import ./go {
       inherit (pkgs) go gopls;
     })
-    (import ./go {
-      go = pkgs.go_1_21;
-      gopls = pkgs.gopls.override {
-        buildGoModule = pkgs.buildGo121Module;
-      };
-    })
 
     (import ./rust "stable")
     (import ./rust "latest")


### PR DESCRIPTION
Why
===

Noticed we have 2 go modules in the list, but only one in the output with:

```
nix eval .#activeModules --json
```

Regardless of which I comment out, the output path is the same.

What changed
============

Removed the extra one.

Test plan
=========

Go should still work.