### PR TITLE
Updated nixpkgs-stable, nixd; added docker-compose module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,16 +82,31 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1685662779,
-        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "lastModified": 1714606777,
+        "narHash": "sha256-bMkNmAXLj8iyTvxaaD/StcLSadbj1chPcJOjtuVnLmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "rev": "4d34ce6412bc450b1d4208c953dc97c7fc764f1a",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1713493429,
+        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
         "type": "github"
       }
     },
@@ -163,16 +178,17 @@
     "nixd": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1693052712,
-        "narHash": "sha256-7wrP6s4OEuR7BUasy76n7j+c09rp7wyOq7YVYviXw9s=",
+        "lastModified": 1714622771,
+        "narHash": "sha256-fZs0u4ep+RH7U69Jo/GAjwd1iSVFSByeAOju8ucsPx8=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "f88accc8a8231efdae900ff6a14cb6301a73cff9",
+        "rev": "af6bb716038eecf5bad0ead6ed14a4c1e5b74c13",
         "type": "github"
       },
       "original": {
@@ -200,11 +216,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1685564631,
-        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {
@@ -217,11 +233,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1709780214,
-        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
+        "lastModified": 1715499532,
+        "narHash": "sha256-9UJLb8rdi2VokYcfOBQHUzP3iNxOPNWcbK++ENElpk0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
+        "rev": "af8b9db5c00f1a8e4b83578acc578ff7d823b786",
         "type": "github"
       },
       "original": {

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -44,6 +44,14 @@ let
       commit = "4c6f2315da24b84bd5e9dfedb952e41677724aaa";
     }
     {
+      moduleId = "haskell-ghc9.4";
+      commit = "4d6f7cd9fd685a3319ac7b6e3fc0789b430d6289";
+    }
+    {
+      moduleId = "elixir-1_15";
+      commit = "4d6f7cd9fd685a3319ac7b6e3fc0789b430d6289";
+    }
+    {
       moduleId = "nodejs-14";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
     }

--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -1,7 +1,16 @@
 pkgs @ { pypkgs, ... }:
 
 let
-  pip = pypkgs.pip;
+  pip = pypkgs.pip.overridePythonAttrs (old: rec {
+    outputs = [
+      "out"
+    ];
+    # Skip building the docs for pip because that was failing
+    # with a sphinx-build error with a version of nixpkgs-unstable for 3.10 (worked for >3.11)
+    # and we don't need the docs
+    postBuild = "";
+    postInstall = "";
+  });
 
   config = pkgs.writeTextFile {
     name = "pip.conf";

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -13,3 +13,5 @@ echo "Evaluate modules derivations"
 nix eval $NIX_FLAGS .#modules --json
 
 nix develop $NIX_FLAGS
+
+python scripts/build_changed_modules.py main


### PR DESCRIPTION
Why
===

We need the latest version of docker compose.

What changed
============

1. updated nixpkgs-unstable
3. updated nixd flake as well because it broke after the nixpkgs-unstable update

Test plan
=========

1. create a repl
2. add "docker" to `modules` array in `.replit`
3. try to use docker-compose in shell and see its version is 2.27.0.