### PR TITLE
Better packager names for UI display

### DIFF
--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -17,7 +17,7 @@ in
   };
 
   replit.dev.packagers.r = {
-    name = "R";
+    name = "R packager";
     language = "r";
     features = {
       packageSearch = true;

--- a/pkgs/modules/bun/default.nix
+++ b/pkgs/modules/bun/default.nix
@@ -40,7 +40,7 @@ in
   };
 
   replit.dev.packagers.bun = {
-    name = "bun";
+    name = "Bun packager";
     language = "bun";
     features = {
       packageSearch = true;

--- a/pkgs/modules/dart/default.nix
+++ b/pkgs/modules/dart/default.nix
@@ -29,7 +29,7 @@ in {
   };
 
   replit.dev.packagers.dart-pub = {
-    name = "dart pub";
+    name = "Dart pub";
     language = "dart-pub";
     features = {
       packageSearch = true;

--- a/pkgs/modules/dotnet/default.nix
+++ b/pkgs/modules/dotnet/default.nix
@@ -38,7 +38,7 @@ in
   };
 
   replit.dev.packagers.dotnet = {
-    name = ".NET";
+    name = ".NET packager";
     language = "dotnet";
     features = {
       packageSearch = true;

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -118,7 +118,7 @@ in
     };
 
     dev.packagers.upmNodejs = {
-      name = "UPM for Node.js";
+      name = "Node.js packager (npm, yarn, pnpm, bun)";
       language = "nodejs";
       features = {
         packageSearch = true;

--- a/pkgs/modules/php/default.nix
+++ b/pkgs/modules/php/default.nix
@@ -32,7 +32,7 @@ in
   };
 
   replit.dev.packagers.php = {
-    name = "PHP";
+    name = "PHP Composer";
     language = "php";
     features = {
       packageSearch = true;

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -138,7 +138,7 @@ in
   };
 
   replit.dev.packagers.upmPython = {
-    name = "Python";
+    name = "Python packager (poetry, pip)";
     language = "python3";
     ignoredPackages = [ "unit_tests" ];
     ignoredPaths = [ pylibs-dir ];

--- a/pkgs/modules/ruby/default.nix
+++ b/pkgs/modules/ruby/default.nix
@@ -58,7 +58,7 @@ in
   };
 
   replit.packagers.ruby = {
-    name = "Ruby";
+    name = "Rubygems";
     language = "ruby";
     features = {
       packageSearch = true;

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -63,7 +63,7 @@ in
   };
 
   replit.dev.packagers.rust = {
-    name = "Rust";
+    name = "Cargo";
     language = "rust";
     features = {
       packageSearch = true;


### PR DESCRIPTION
Why
===

In the dependencies pane, the packagers have bad names which don't necessarily indicate that it is a packager:
![image](https://github.com/replit/nixmodules/assets/54303/83466722-027b-4ba0-9ace-7fb9dd31ba50)

What changed
============

Updated the names so that it's clear they are a packager.

Test plan
=========

The UI's packager names should update to the new ones.