### PR TITLE
Add back shell completions for pip

### DIFF
--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -1,23 +1,22 @@
-{ pkgs, pkgs-23_05, lib, ... }:
+{ pkgs, lib, ... }:
 let
-  python = pkgs-23_05.python310Full;
+  python = pkgs.python310Full;
 
-  pypkgs = pkgs-23_05.python310Packages;
+  pypkgs = pkgs.python310Packages;
 
   pythonVersion = lib.versions.majorMinor python.version;
 
   pythonUtils = import ../../python-utils {
-    inherit python pypkgs;
-    pkgs = pkgs-23_05;
+    inherit python pypkgs pkgs;
   };
 
   pythonWrapper = pythonUtils.pythonWrapper;
 
   prybar-python-version = lib.strings.concatStrings (lib.strings.splitString "." pythonVersion);
 
-  stderred = pkgs-23_05.callPackage ../../stderred { };
+  stderred = pkgs.callPackage ../../stderred { };
 
-  run-prybar-bin = pkgs-23_05.writeShellApplication {
+  run-prybar-bin = pkgs.writeShellApplication {
     name = "run-prybar";
     text = ''
       ${stderred}/bin/stderred -- ${pkgs.prybar."prybar-python${prybar-python-version}"}/bin/prybar-python${prybar-python-version} -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i "''$1"

--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -9,7 +9,12 @@ let
     # with a sphinx-build error with a version of nixpkgs-unstable for 3.10 (worked for >3.11)
     # and we don't need the docs
     postBuild = "";
-    postInstall = "";
+    postInstall = ''
+      installShellCompletion --cmd pip \
+        --bash <($out/bin/pip completion --bash --no-cache-dir) \
+        --fish <($out/bin/pip completion --fish --no-cache-dir) \
+        --zsh <($out/bin/pip completion --zsh --no-cache-dir)
+    '';
   });
 
   config = pkgs.writeTextFile {


### PR DESCRIPTION
Why
===

Mistakenly removed the shell completion installation for pip in https://github.com/replit/nixmodules/pull/331. As mentioned in https://github.com/replit/nixmodules/pull/331/files/0048f80a70c784126f840cb8f80b201b172f5329

What changed
============

Added them back. Source: https://github.com/NixOS/nixpkgs/blob/9ddcaffecdf098822d944d4147dd8da30b4e6843/pkgs/development/python-modules/pip/default.nix#L96

Test plan
=========

pip still works.