### PR TITLE
Added display version field to top level modules where it's obvious w…

### DIFF
--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -4,6 +4,7 @@ in
 {
   id = "r-${r-version}";
   name = "R Tools";
+  displayVersion = r-version;
   description = ''
     R project for statistical computing.
   '';

--- a/pkgs/modules/c/default.nix
+++ b/pkgs/modules/c/default.nix
@@ -15,6 +15,7 @@ in
 {
   id = "c-clang${clang-version}";
   name = "C Tools (with Clang)";
+  displayVersion = clang-version;
   description = ''
     Tools for working with C programming language:
     * Clang compiler

--- a/pkgs/modules/clojure/default.nix
+++ b/pkgs/modules/clojure/default.nix
@@ -4,6 +4,7 @@ in
 {
   id = "clojure-${clojure-version}";
   name = "Clojure Tools";
+  displayVersion = clojure-version;
   description = ''
     Tools for working with Clojure. Includes:
     * Clojure

--- a/pkgs/modules/cpp/default.nix
+++ b/pkgs/modules/cpp/default.nix
@@ -13,6 +13,7 @@ in
 {
   id = "cpp-clang${clang-version}";
   name = "C++ Tools (with Clang)";
+  displayVersion = clang-version;
   description = ''
     Tools for working with C++:
     * Clang compiler

--- a/pkgs/modules/dart/default.nix
+++ b/pkgs/modules/dart/default.nix
@@ -3,6 +3,7 @@ let dart-version = lib.versions.majorMinor pkgs.dart.version;
 in {
   id = "dart-${dart-version}";
   name = "Dart Tools";
+  displayVersion = dart-version;
   description = ''
     Tools for working with Dart:
     * Dart

--- a/pkgs/modules/deno/default.nix
+++ b/pkgs/modules/deno/default.nix
@@ -10,6 +10,7 @@ in
 {
   id = "deno-${version}";
   name = "Deno Tools";
+  displayVersion = version;
   description = ''
     Tools for working with Deno:
     * Deno

--- a/pkgs/modules/dotnet/default.nix
+++ b/pkgs/modules/dotnet/default.nix
@@ -11,6 +11,7 @@ in
 {
   id = "dotnet-${dotnet-version}";
   name = ".NET 7 Tools";
+  displayVersion = dotnet-version;
   description = ''
     .NET 7 development tools:
     * .NET

--- a/pkgs/modules/elixir/default.nix
+++ b/pkgs/modules/elixir/default.nix
@@ -7,6 +7,7 @@ in
 {
   id = "elixir-${elixir-version}";
   name = "Elixir ${elixir-version} Tools";
+  displayVersion = elixir-version;
   description = ''
     Development tools for Elixir:
     * Elixir

--- a/pkgs/modules/gcloud/default.nix
+++ b/pkgs/modules/gcloud/default.nix
@@ -2,6 +2,7 @@
 {
   id = "gcloud";
   name = "Google Cloud Tools";
+  displayVersion = pkgs.lib.versions.majorMinor pkgs.google-cloud-sdk.version;
   description = ''
     Google Cloud developer tools:
     All of the tools developers and development teams need to be productive

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -6,6 +6,7 @@ in
 {
   id = "go-${goversion}";
   name = "Go Tools";
+  displayVersion = goversion;
   description = ''
     Go development tools. Includes:
     * Go compiler

--- a/pkgs/modules/haskell/default.nix
+++ b/pkgs/modules/haskell/default.nix
@@ -5,6 +5,7 @@ in
 {
   id = "haskell-ghc${ghc-version}";
   name = "Haskell Tools";
+  displayVersion = ghc-version;
   description = ''
     Haskell development tools. Includes:
     * GHCi - Glasgow Haskell Compiler

--- a/pkgs/modules/hermit/default.nix
+++ b/pkgs/modules/hermit/default.nix
@@ -33,6 +33,7 @@ in
 {
   id = "hermit-${version}";
   name = "Hermit Environment Manager";
+  displayVersion = version;
   description = "Hermit manages isolated, self-bootstrapping sets of tools in software projects.";
 
   replit.dev.packages = [

--- a/pkgs/modules/lua/default.nix
+++ b/pkgs/modules/lua/default.nix
@@ -4,6 +4,7 @@ in
 {
   id = "lua-${lua-version}";
   name = "Lua Tools";
+  displayVersion = lua-version;
   description = ''
     Lua development tools. Includes:
     * Lua

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -18,6 +18,7 @@ in
   id = lib.mkForce "nodejs-with-prybar-${nodeVersion}";
 
   name = lib.mkForce "Node.js ${nodeVersion} Tools (with Prybar)";
+  displayVersion = nodeVersion;
   description = lib.mkForce ''
     Node.js development tools with Prybar. Includes:
     * Node.js ${nodejs.version}

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -34,7 +34,7 @@ in
     * Prettier code formatter
     * jsdebug
   '';
-  displayVersion = nodejs.version;
+  displayVersion = short-version;
   imports = [
     (import ../typescript-language-server {
       inherit nodepkgs;

--- a/pkgs/modules/php/default.nix
+++ b/pkgs/modules/php/default.nix
@@ -5,6 +5,7 @@ in
 {
   id = "php-${php-version}";
   name = "PHP Tools";
+  displayVersion = php-version;
   description = ''
     PHP development tools. Includes:
     * PHP: Hypertext Preprocessor

--- a/pkgs/modules/pyright-extended/default.nix
+++ b/pkgs/modules/pyright-extended/default.nix
@@ -5,6 +5,7 @@ in
 {
   id = "pyright-extended";
   name = "pyright-extended LSP";
+  displayVersion = pyright-extended.version;
   description = ''
     Pyright with yapf and ruff
   '';

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -32,6 +32,8 @@ in
 
   name = lib.mkForce "Python ${pythonVersion} Tools (with Prybar)";
 
+  displayVersion = pythonVersion;
+
   description = lib.mkForce ''
     Development tools for Python with Prybar. Includes:
     * Python interpreter

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -104,7 +104,7 @@ in
 {
   id = "python-${pythonVersion}";
   name = "Python Tools";
-  displayVersion = python.version;
+  displayVersion = pythonVersion;
   description = ''
     Development tools for Python. Includes:
     * Python interpreter

--- a/pkgs/modules/ruby/default.nix
+++ b/pkgs/modules/ruby/default.nix
@@ -29,6 +29,7 @@ in
 {
   id = "ruby-${ruby-version}";
   name = "Ruby ${ruby-version} Tools";
+  displayVersion = ruby-version;
   description = ''
     Ruby development tools. Includes:
     * Ruby interpreter

--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -25,6 +25,7 @@ in
 {
   id = "rust-${rust-channel-name}";
   name = "Rust Tools (${rust-channel-name})";
+  displayVersion = rust-channel-name;
   description = ''
     Rust development tools. Includes:
     * Rust compiler

--- a/pkgs/modules/swift/default.nix
+++ b/pkgs/modules/swift/default.nix
@@ -19,6 +19,7 @@ in
 {
   id = "swift-${swift-version}";
   name = "Swift Tools";
+  displayVersion = swift-version;
   description = ''
     Swift development tools. Includes:
     * Swift compiler

--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -6,6 +6,7 @@ in
 {
   id = lib.mkDefault "typescript-language-server";
   name = lib.mkDefault "TypeScript Language Server";
+  displayVersion = lib.mkDefault (lib.versions.majorMinor typescript-language-server.version);
   description = lib.mkDefault ''
     TypeScript (& JavaScript) language server
   '';


### PR DESCRIPTION
…hat it should be

Why
===

It's nice to should some display version for a module for a UI when it makes sense:
https://replit.slack.com/archives/C06001SAVR8/p1715713173732029?thread_ts=1715711214.474379&cid=C06001SAVR8

What changed
============

Added a display version to each top level module. Usually the version or shorten version of the runtime or core tool in the module. If it's not clean what it should be, I left it out.