### PR TITLE
bun: update to 1.1.8

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.6";
+  version = "1.1.8";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-IzjuIPXljt8EStcRdGj55SWIpqJdGQeVZVAS5u9sW+Y=";
+    hash = "sha256-JuDT+8FHbamdMVCDeSTGPYOvhPY2EZ9XeD2zjHEj36Y=";
   };
 }


### PR DESCRIPTION
Why
===

that one javascript runtime named after food is 2 point releases behind

What changed
============

update foody javascript runtime thingy

Test plan
=========

`bun --version` prints `1.1.8`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
