### PR TITLE
rust: improve nightly module displayVersion

### DIFF
--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -21,11 +21,14 @@ let
     pkgs.fenix.targets.wasm32-wasi.${fenix-channel-name}.rust-std
     pkgs.fenix.targets.wasm32-unknown-unknown.${fenix-channel-name}.rust-std
   ];
+
+  # TODO: fenix doesn't give the rustc stable version :(
+  displayVersion = if fenix-channel-name == "stable" then "stable" else channel.cargo.version;
 in
 {
   id = "rust-${rust-channel-name}";
   name = "Rust Tools (${rust-channel-name})";
-  displayVersion = rust-channel-name;
+  inherit displayVersion;
   description = ''
     Rust development tools. Includes Rust compiler, Cargo, Rust analyzer.
   '';


### PR DESCRIPTION
Why
===

showing just `nightly` for the rust nightly module's displayVersion isn't too helpful. let's show the date of the nightly release instead

unfortunately i can't show the release version of the stable toolchain :( [fenix doesn't expose the toolchain's release version and i'm not sure it's actively maintained anymore](https://github.com/nix-community/fenix/pull/118)

What changed
============

for rust-nightly module's displayVersion, instead of showing `nightly` show `toolchain.cargo.version` (rustc's version attr doesn't exist since it gets [overwritten](https://github.com/nix-community/fenix/blob/main/lib/mk-toolchain.nix#L135-L138))

Test plan
=========

- `nix build .#rust-nightly && jq .displayVersion result` shows a date instead of `"nightly"`
- `nix build .#rust-stable && jq .displayVersion result` still shows `"stable"`

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
