### PR TITLE
bun: update to 1.1.11

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.8";
+  version = "1.1.11";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-JuDT+8FHbamdMVCDeSTGPYOvhPY2EZ9XeD2zjHEj36Y=";
+    hash = "sha256-RfP4fnTqumZKMBvC3ze4Lb7cQuUVl/czL+8xqB00kPA=";
   };
 }


### PR DESCRIPTION
Why
===

bun 1.1.11 almost rhymes if you squint hard enough

What changed
============

bun to 1.1.11

Test plan
=========

`bun --version` prints the right version

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
