### PR TITLE
Added internal and demoted flags

### DIFF
--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -622,6 +622,23 @@ in
       default = "";
     };
 
+    internal = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether this module is for Replit internal use.
+      '';
+    };
+
+    demoted = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether this module demoted.
+      '';
+    };
+
+
     replit = replitOptions // {
       dev = replitOptions;
     } // {
@@ -672,6 +689,8 @@ in
           id = config.id;
           name = config.name;
           displayVersion = config.displayVersion;
+          internal = config.internal;
+          demoted = config.demoted;
           description = config.description;
           env = envWithMergedPath allEnv (lib.makeBinPath allPackages);
           initializers = allInitializers;
@@ -699,6 +718,8 @@ in
           name = config.name;
           displayVersion = config.displayVersion;
           description = config.description;
+          internal = config.internal;
+          demoted = config.demoted;
           env = envWithMergedPath config.replit.env (lib.makeBinPath config.replit.packages);
           initializers = config.replit.initializers;
           inherit runners;

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -634,7 +634,7 @@ in
       type = types.bool;
       default = false;
       description = lib.mdDoc ''
-        Whether this module demoted.
+        Whether this module is demoted.
       '';
     };
 

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -165,6 +165,7 @@ in
 {
   id = "docker";
   name = "Support for Docker containers";
+  internal = true;
   description = ''
     Docker support for Replit. Includes: Docker, Docker Compose, Moby, Containerd, runc, Buildkid.
   '';

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -19,6 +19,7 @@ in
 
   name = lib.mkForce "Node.js ${nodeVersion} Tools (with Prybar)";
   displayVersion = nodeVersion;
+  demoted = true;
   description = lib.mkForce ''
     Node.js tools with the Prybar interpreter. Prybar is an interactive console that allows you to type and evaluate JavaScript code in a prompt after hitting "Run".
   '';

--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -34,6 +34,8 @@ in
 
   displayVersion = pythonVersion;
 
+  demoted = true;
+
   description = lib.mkForce ''
     Python tools with the Prybar interpreter. Prybar is an interactive console that allows you to type and evaluate Python code in a prompt after hitting "Run".
   '';


### PR DESCRIPTION
Why
===

1. We'd like to hide the docker module from general users because it won't work for them
2. We'd like to show the prybar modules less prominently than the main python and Node.js modules

What changed
============

1. added an internal flag and used it for docker
2. added a demoted flag and used it for prybar modules

Test plan
=========

1. `nix build .#docker && cat result |jq` and see that its internal field is true
2. `nix build .#'"python-with-prybar-3.10"' && cat result |jq` and see it's demoted field is true