### PR TITLE
Display versions for historical modules

### DIFF
--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -36,6 +36,7 @@ let
     {
       moduleId = "dart-3.3";
       commit = "54ea6c58e71bf278c3ce8824de3dbbaa49662be4";
+      displayVersion = "3.3.4";
     }
     {
       moduleId = "go-1.19";

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -10,78 +10,97 @@ let
     {
       moduleId = "bun-1.0";
       commit = "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f";
+      displayVersion = "1.0.23";
     }
     {
       moduleId = "dart-2.18";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
+      displayVersion = "2.18.0";
     }
     {
       moduleId = "dart-3.0";
       commit = "0b7a60667d2c29f2686211e952924a9693916a20";
+      displayVersion = "3.2.4";
     }
     {
       moduleId = "dart-3.1";
       commit = "3b22c787fd20b13fe5afb868589c574068303b5e";
+      displayVersion = "3.2.4";
     }
     {
       moduleId = "dart-3.2";
       commit = "9e3a33995f94a52e61ae962777e9bcbe6d75885e";
+      displayVersion = "3.2.4";
     }
     {
       moduleId = "go-1.19";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
+      displayVersion = "1.19.3";
     }
     {
       moduleId = "go-1.20";
       commit = "b5aa5df636c4cd8cd1aea251e8dea4fc0aa51781";
+      displayVersion = "1.20.4";
     }
     {
       moduleId = "haskell-ghc9.0";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
+      displayVersion = "9.0.2";
     }
     {
       moduleId = "haskell-ghc9.2";
       commit = "4c6f2315da24b84bd5e9dfedb952e41677724aaa";
+      displayVersion = "9.2.8";
     }
     {
       moduleId = "haskell-ghc9.4";
       commit = "4d6f7cd9fd685a3319ac7b6e3fc0789b430d6289";
+      displayVersion = "9.4.8";
     }
     {
       moduleId = "elixir-1_15";
       commit = "4d6f7cd9fd685a3319ac7b6e3fc0789b430d6289";
+      displayVersion = "1.15.7";
     }
     {
       moduleId = "nodejs-14";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
+      displayVersion = "14.21.1";
     }
     {
       moduleId = "nodejs-16";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
+      displayVersion = "16.18.1";
     }
     {
       moduleId = "nodejs-19";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
+      displayVersion = "19.1.0";
     }
     {
       moduleId = "php-8.1";
       commit = "0b7a60667d2c29f2686211e952924a9693916a20";
+      displayVersion = "8.1.20";
     }
     {
       moduleId = "r-4.2";
       commit = "1e1bb663068482cdb7c04bf585daed00205c0140";
+      displayVersion = "4.2.3";
     }
     {
       moduleId = "swift-5.6";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
+      displayVersion = "5.6.2";
     }
     {
       moduleId = "vue-node-18";
       commit = "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7";
+      displayVersion = "18.18.2";
     }
     {
       moduleId = "zig-0.11";
       commit = "15426ef79793bf7c424eb40865d507eacfdd44e6";
+      displayVersion = "0.11.0";
     }
   ];
 

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -118,15 +118,11 @@ let
       # 2. parse the JSON file
       # 3. add the displayVersion field
       # 4. return a new derivation that builds the modified JSON contents
+      moduleJSON = fromJSON (builtins.unsafeDiscardStringContext (readFile module.outPath)) // {
+        inherit displayVersion;
+      };
     in
-    pkgs.stdenv.mkDerivation {
-      name = "replit-module-debug-${moduleId}";
-      dontUnpack = true;
-      buildInputs = [ pkgs.jq ];
-      installPhase = ''
-        cat ${module} | ${pkgs.jq}/bin/jq '. += {"displayVersion": "${displayVersion}"}' > $out
-      '';
-    };
+    pkgs.writeText "replit-module-${moduleId}" (toJSON moduleJSON);
 
   modules = foldl'
     (acc: module:

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -118,11 +118,15 @@ let
       # 2. parse the JSON file
       # 3. add the displayVersion field
       # 4. return a new derivation that builds the modified JSON contents
-      moduleJSON = fromJSON (builtins.unsafeDiscardStringContext (readFile module.outPath)) // {
-        inherit displayVersion;
-      };
     in
-    pkgs.writeText "replit-module-${moduleId}" (toJSON moduleJSON);
+    pkgs.stdenv.mkDerivation {
+      name = "replit-module-debug-${moduleId}";
+      dontUnpack = true;
+      buildInputs = [ pkgs.jq ];
+      installPhase = ''
+        cat ${module} | ${pkgs.jq}/bin/jq '. += {"displayVersion": "${displayVersion}"}' > $out
+      '';
+    };
 
   modules = foldl'
     (acc: module:

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -11,7 +11,7 @@ let
     deployment = true;
   };
   apply-upgrade-map = import ../upgrade-map;
-  historical = import ../historical-modules;
+  historical = pkgs.callPackage ../historical-modules { };
 
   modulesList = [
     (import ./python {


### PR DESCRIPTION
Why
===

Our historical modules don't have a display version because it was added later, before some of them had that.

What changed
============

For each historical module, replace the returned derivation with one that injects a display version to the generated output JSON file.

Test plan
=========

1. `nix build .#'"nodejs-16"' && cat result |jq` and see that it has a displayVersion.
