### PR TITLE
Fix call to moduleFromHistory

### DIFF
--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -140,7 +140,7 @@ let
     (acc: module:
       acc // ({
         ${module.moduleId} = moduleFromHistory {
-          inherit (module) moduleId commit;
+          inherit (module) moduleId commit displayVersion;
           deployment = true;
         };
       })


### PR DESCRIPTION
Why
===

Forgot to update call site when updating param list after https://github.com/replit/nixmodules/pull/343. Broke oci images.

What changed
============

Added displayVersion.

Test plan
=========

OCI images build.