### PR TITLE
Added python 3.9 module

### DIFF
--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -19,6 +19,10 @@ let
       pypkgs = pkgs-23_05.python38Packages;
     })
     (import ./python {
+      python = pkgs.python39Full;
+      pypkgs = pkgs.python39Packages;
+    })
+    (import ./python {
       python = pkgs.python310Full;
       pypkgs = pkgs.python310Packages;
     })

--- a/pkgs/poetry/poetry-py3.9.nix
+++ b/pkgs/poetry/poetry-py3.9.nix
@@ -1,0 +1,7 @@
+{ pkgs, python, pypkgs }:
+pkgs.callPackage ./poetry-in-venv.nix {
+  version = "1.5.4";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.4-python-3.9.19-bundle.tgz;
+  sha256 = "sha256:134n1avv3adc3ypvd0hd4mkrkfdbb70qz8l1j0sx2q6h48nnb0pc";
+  inherit python pypkgs;
+}


### PR DESCRIPTION
Why
===

We need python 3.9 in some cases when testing against older software in our benchmark tests.

What changed
============

Added python 3.9.

Test plan
=========

1. create blank repl
2. add `python-3.9` to modules array in .replit
3. run `python` in shell and see it's python 3.9
4. check pip/poetry to make sure they can install stuff