### PR TITLE
Interpolate displayVersion into the right place in the tree

### DIFF
--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -11,106 +11,193 @@ let
     {
       moduleId = "bun-1.0";
       commit = "fdbd39619614e07d1ff44cfe20de2ad56eb8a40f";
-      displayVersion = "1.0.23";
+      overrides = {
+        # /nix/store/cvz36f39793v9l361ibfxznjjmk4jpd6-replit-module-bun-1.0
+        # .runners["package.json"].displayVersion = "1.0.23";
+        displayVersion = "1";
+      };
     }
     {
       moduleId = "dart-2.18";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
-      displayVersion = "2.18.0";
+      overrides = {
+        # /nix/store/05i6y0nwn8zgm6250my14xbcialzak9b-replit-module-dart-2.18
+        # .runners.dart.displayVersion = "2.18.0";
+        displayVersion = "2";
+      };
     }
     {
       moduleId = "dart-3.0";
       commit = "0b7a60667d2c29f2686211e952924a9693916a20";
-      displayVersion = "3.2.4";
+      overrides = {
+        # /nix/store/0wr2lk1h8vqzs38pfwiil6cf6s5mn54j-replit-module-dart-3.2
+        # .runners.dart.displayVersion = "3.2.4";
+        displayVersion = "3";
+      };
     }
     {
       moduleId = "dart-3.1";
       commit = "3b22c787fd20b13fe5afb868589c574068303b5e";
-      displayVersion = "3.2.4";
+      # displayVersion = "3.2.4";
+      overrides = {
+        displayVersion = "3";
+      };
     }
     {
       moduleId = "dart-3.2";
       commit = "9e3a33995f94a52e61ae962777e9bcbe6d75885e";
-      displayVersion = "3.2.4";
+      # displayVersion = "3.2.4";
+      overrides = {
+        displayVersion = "3";
+      };
     }
     {
       moduleId = "dart-3.3";
       commit = "54ea6c58e71bf278c3ce8824de3dbbaa49662be4";
-      displayVersion = "3.3.4";
+      overrides = {
+        # /nix/store/ampsihgvns831ig1w0warbpq1pyj2cg0-replit-module-dart-3.3
+        # .runners.dart.displayVersion = "3.3.4";
+        displayVersion = "3";
+      };
     }
     {
       moduleId = "go-1.19";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
-      displayVersion = "1.19.3";
+      overrides = {
+        # /nix/store/7icmam9gmbfas0zbpm53f3ilw79kx0rj-replit-module-go-1.19
+        # .runners["go-run"].displayVersion = "1.19.3";
+        displayVersion = "1.19";
+      };
     }
     {
       moduleId = "go-1.20";
       commit = "b5aa5df636c4cd8cd1aea251e8dea4fc0aa51781";
-      displayVersion = "1.20.4";
+      overrides = {
+        # /nix/store/q6j9za8smkdbnlybg63qq5lmj7zbambr-replit-module-go-1.20
+        # .runners["go-run"].displayVersion = "1.20.4";
+        displayVersion = "1.20";
+      };
     }
     {
       moduleId = "haskell-ghc9.0";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
-      displayVersion = "9.0.2";
+      overrides = {
+        # /nix/store/h6hp6fd07dr8q9dhlz45nrs17wp2kmp4-replit-module-haskell-ghc9.0
+        # .runners.runghc.displayVersion = "9.0.2";
+        displayVersion = "9";
+      };
     }
     {
       moduleId = "haskell-ghc9.2";
       commit = "4c6f2315da24b84bd5e9dfedb952e41677724aaa";
-      displayVersion = "9.2.8";
+      overrides = {
+        # /nix/store/1r94iizf604jasg72f239fw0if4ldmd5-replit-module-haskell-ghc9.2
+        # .runners.runghc.displayVersion = "9.2.8";
+        displayVersion = "9";
+      };
     }
     {
       moduleId = "haskell-ghc9.4";
       commit = "4d6f7cd9fd685a3319ac7b6e3fc0789b430d6289";
-      displayVersion = "9.4.8";
+      overrides = {
+        # /nix/store/kkaxlri9s0bb7jydb1kpqzi2sjkf4rmj-replit-module-haskell-ghc9.4
+        # .runners.runghc.displayVersion = "9.4.8";
+        displayVersion = "9";
+      };
     }
     {
       moduleId = "elixir-1_15";
       commit = "4d6f7cd9fd685a3319ac7b6e3fc0789b430d6289";
-      displayVersion = "1.15.7";
+      overrides = {
+        # /nix/store/8nggvav01q7f1094m485nnd32094j522-replit-module-elixir-1_15
+        # .runners.elixir.displayVersion = "1.15.7";
+        displayVersion = "1";
+      };
     }
     {
       moduleId = "nodejs-14";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
-      displayVersion = "14.21.1";
+      overrides = {
+        displayVersion = "14";
+        runners = {
+          nodeJS = {
+            displayVersion = "14.21.1";
+          };
+        };
+      };
     }
     {
       moduleId = "nodejs-16";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
-      displayVersion = "16.18.1";
+      overrides = {
+        displayVersion = "16";
+        runners = {
+          nodeJS = {
+            displayVersion = "16.18.1";
+          };
+        };
+      };
     }
     {
       moduleId = "nodejs-19";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
-      displayVersion = "19.1.0";
+      overrides = {
+        displayVersion = "19";
+        runners = {
+          nodeJS = {
+            displayVersion = "19.1.0";
+          };
+        };
+      };
     }
     {
       moduleId = "php-8.1";
       commit = "0b7a60667d2c29f2686211e952924a9693916a20";
-      displayVersion = "8.1.20";
+      overrides = {
+        # /nix/store/xc89rlwnmg5vh66hvrv1saq6md6kp1g5-replit-module-php-8.1
+        # .runners.php.displayVersion = "8.1.20";
+        displayVersion = "8";
+      };
     }
     {
       moduleId = "r-4.2";
       commit = "1e1bb663068482cdb7c04bf585daed00205c0140";
-      displayVersion = "4.2.3";
+      overrides = {
+        # /nix/store/knizlzgmqgm488llvxxaai6kjb17mhm2-replit-module-r-4.2
+        # .runners.r.displayVersion = "4.2.3";
+        displayVersion = "4";
+      };
     }
     {
       moduleId = "swift-5.6";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
-      displayVersion = "5.6.2";
+      overrides = {
+        # /nix/store/f96l8blsvpx1dbgnxw2x611hhzbm199l-replit-module-swift-5.6
+        # .runners.swift.displayVersion = "5.6.2";
+        displayVersion = "5";
+      };
     }
     {
       moduleId = "vue-node-18";
       commit = "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7";
-      displayVersion = "18.18.2";
+      overrides = {
+        # /nix/store/623sn0cy54r5csab3d9fmg55di6r4dd3-replit-module-vue-node-18
+        # .runners["dev-runner"].displayVersion = "18.18.2";
+        displayVersion = "18";
+      };
     }
     {
       moduleId = "zig-0.11";
       commit = "15426ef79793bf7c424eb40865d507eacfdd44e6";
-      displayVersion = "0.11.0";
+      overrides = {
+        # /nix/store/65v1j76svgdi8bj3sxx5hfshbvdyissl-replit-module-zig-0.11
+        # .runners["zig-build-run"].displayVersion = "0.11.0";
+        displayVersion = "0";
+      };
     }
   ];
 
-  moduleFromHistory = { displayVersion, moduleId, commit, deployment ? false }:
+  moduleFromHistory = { moduleId, commit, deployment ? false, overrides }:
     let
       flake = getFlake "github:replit/nixmodules/${commit}";
       module =
@@ -123,7 +210,7 @@ let
       name = "replit-module-${moduleId}";
       buildCommand = ''
         set -x
-        ${pkgs.jq}/bin/jq --arg displayVersion "${displayVersion}" '.displayVersion |= $displayVersion' < ${module} > $out
+        ${pkgs.jq}/bin/jq --argjson overrides '${builtins.toJSON(overrides)}' '. * $overrides' < ${module} > $out
       '';
     };
 
@@ -140,7 +227,7 @@ let
     (acc: module:
       acc // ({
         ${module.moduleId} = moduleFromHistory {
-          inherit (module) moduleId commit displayVersion;
+          inherit (module) moduleId commit overrides;
           deployment = true;
         };
       })


### PR DESCRIPTION
Why
===

Top-level `displayVersion` is actually the semantically-relevant minified version, `.runner.[*].displayVersion` is the full version string

What changed
============

Interpolate values from the new `override` parameter

Test plan
=========

```
$ nix build .#'"nodejs-16"'
$ jq . < result | jq '.displayVersion, .runners.nodeJS.displayVersion'
"16"
"16.18.1"
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
