### PR TITLE
[ruby] revert rexml change in upstream

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,16 @@
 
       pkgs-23_05 = mkPkgs nixpkgs "x86_64-linux";
 
-      pkgs = mkPkgs nixpkgs-unstable "x86_64-linux";
+      patched-unstable = nixpkgs-unstable.legacyPackages.x86_64-linux.applyPatches {
+        name = "nixpkgs-unstable-patched";
+        src = nixpkgs-unstable;
+        patches = [
+          # rexml breaks this version of nixpkgs
+          ./patches/rexml.patch
+        ];
+      };
+
+      pkgs = mkPkgs patched-unstable "x86_64-linux";
     in
     {
       overlays.default = final: prev: {

--- a/patches/rexml.patch
+++ b/patches/rexml.patch
@@ -1,0 +1,17 @@
+diff --git a/pkgs/top-level/ruby-packages.nix b/pkgs/top-level/ruby-packages.nix
+index 0528d45bef84e1..18819de3029c53 100644
+--- a/pkgs/top-level/ruby-packages.nix
++++ b/pkgs/top-level/ruby-packages.nix
+@@ -3127,9 +3127,9 @@
+     platforms = [];
+     source = {
+       remotes = ["https://rubygems.org"];
+-      sha256 = "sha256-CQioY4HZ+XOCRoDfTgp1QidmJy8DscDknbfnnCPbETU=";
++      sha256 = "05i8518ay14kjbma550mv0jm8a6di8yp5phzrd8rj44z9qnrlrp0";
+       type = "gem";
+     };
+-    version = "3.2.8";
++    version = "3.2.6";
+   };
+   rmagick = {
+     dependencies = ["observer" "pkg-config"];


### PR DESCRIPTION
Why
===
* [a change](https://github.com/NixOS/nixpkgs/pull/312320) to rexml broke ruby 3.2 because it needed a newer version of rexml than is provide:
needed: >3.0.9
got:/nix/store/8fg60ic5fbj9qncw1m760z08zljich6q-ruby-3.2.2/lib/ruby/gems/3.2.0/gems/strscan-3.0.5/

What changed
===
* reverse that change

Test plan
===
* solagraph works on ruby 3.2

```
[ryantm@replit1:~/p/replit/nixmodules]$ /nix/store/assiad6yc2nminnvjjarfviza49mncrh-ruby3.2-solargraph-0.50.0/bin/solargraph stdio
Solargraph is listening on stdio PID=3385015
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
