### PR TITLE
bun: update to 1.1.13

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.11";
+  version = "1.1.13";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-RfP4fnTqumZKMBvC3ze4Lb7cQuUVl/czL+8xqB00kPA=";
+    hash = "sha256-QC6dsWjRYiuBIojxPvs8NFMSU6ZbXbZ9Q/+u+45NmPc=";
   };
 }


### PR DESCRIPTION
This update has some WebSocket memory leak fixes which I need.

- [x] This is fully backward and forward compatible
