### PR TITLE
bun: update to 1.1.13

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.11";
+  version = "1.1.13";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-RfP4fnTqumZKMBvC3ze4Lb7cQuUVl/czL+8xqB00kPA=";
+    hash = "sha256-QC6dsWjRYiuBIojxPvs8NFMSU6ZbXbZ9Q/+u+45NmPc=";
   };
 }


### PR DESCRIPTION
For some reason, https://github.com/replit/nixmodules/pull/351 is not running its checks. To hopefully work around this, I'm opening this PR.