### PR TITLE
Switch nix lsp from nixd to nil

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,39 +77,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1714606777,
-        "narHash": "sha256-bMkNmAXLj8iyTvxaaD/StcLSadbj1chPcJOjtuVnLmA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "4d34ce6412bc450b1d4208c953dc97c7fc764f1a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1713493429,
-        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -175,28 +142,6 @@
         "type": "github"
       }
     },
-    "nixd": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1714622771,
-        "narHash": "sha256-fZs0u4ep+RH7U69Jo/GAjwd1iSVFSByeAOju8ucsPx8=",
-        "owner": "nix-community",
-        "repo": "nixd",
-        "rev": "af6bb716038eecf5bad0ead6ed14a4c1e5b74c13",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixd",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1687466461,
@@ -209,24 +154,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1714253743,
-        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -292,7 +219,6 @@
       "inputs": {
         "fenix": "fenix",
         "java-language-server": "java-language-server",
-        "nixd": "nixd",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar",

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,6 @@
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.nixd.url = "github:nix-community/nixd";
-  inputs.nixd.inputs.nixpkgs.follows = "nixpkgs";
   inputs.prybar.url = "github:replit/prybar";
   inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
   inputs.java-language-server.url = "github:replit/java-language-server";
@@ -15,7 +13,7 @@
   inputs.replit-rtld-loader.url = "github:replit/replit_rtld_loader";
   inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nixd, fenix, replit-rtld-loader, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, fenix, replit-rtld-loader, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -23,7 +21,6 @@
           self.overlays.default
           prybar.overlays.default
           java-language-server.overlays.default
-          nixd.overlays.default
           fenix.overlays.default
           replit-rtld-loader.overlays.default
         ];

--- a/pkgs/modules/nix/default.nix
+++ b/pkgs/modules/nix/default.nix
@@ -2,13 +2,13 @@
   id = "nix";
   name = "Nix";
   description = ''
-    Nixd: Nix language server
+    Nil: Nix language server
   '';
 
-  replit.dev.languageServers.nixd = {
-    name = "nixd";
+  replit.dev.languageServers.nil = {
+    name = "nil";
     language = "nix";
-    start = "${pkgs.nixd}/bin/nixd";
+    start = "${pkgs.nil}/bin/nil";
     extensions = [ ".nix" ];
 
     configuration = {


### PR DESCRIPTION
Why
===

[DX-679](https://linear.app/replit/issue/DX-679/installing-the-nix-module-brings-in-nixd-which-immediately-expands-to): Currently the nix lsp, `nixd`, uses >50% of replit CPU in the background. The proposed alternative, [`nil`](https://github.com/oxalica/nil), uses barely any CPU.

Resources using `nixd`
![Screenshot from 2024-06-12 15-23-57](https://github.com/replit/nixmodules/assets/20145996/aa013874-51c4-4c8b-ba50-c39675cd2b66)

Resources using `nil`
![Screenshot from 2024-06-12 15-23-08](https://github.com/replit/nixmodules/assets/20145996/140a18f5-91b7-4d37-ba65-029f74093611)


What changed
============

Switch nix lsp from `nixd` to `nil`.

Test plan
=========

- Tested modified nix module in a repl

Rollout
=======
It would be nice to have https://github.com/replit/repl-it-web/pull/45470 merged first, as it fixes an issue where `nil` will sporadically close due to receiving a `didSave` notification.

- [x] This is fully backward and forward compatible
