### PR TITLE
Use `nixpkgs-fmt` as formatter for the nix LSP

### DIFF
--- a/pkgs/modules/nix/default.nix
+++ b/pkgs/modules/nix/default.nix
@@ -11,8 +11,6 @@
     start = "${pkgs.nil}/bin/nil";
     extensions = [ ".nix" ];
 
-    configuration = {
-      options.enable = false;
-    };
+    configuration.nil.formatting.command = [ "${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt" ];
   };
 }


### PR DESCRIPTION
Why
===

By default, `nil` does not have a formatter defined. This pr adds `nixpkgs-fmt` as the formatter used by the `nil` LSP.

What changed
============

`nil` is now configured to use `nixpkgs-fmt` for formatting `.nix` files.

Test plan
=========

- Tested modified nixmodules in a repl

Rollout
=======
- [x] This is fully backward and forward compatible
