### PR TITLE
Add `defaultEntrypoints` field to `runnerOptions`

### DIFF
--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -188,6 +188,14 @@ let
         '';
       };
 
+      defaultEntrypoints = mkOption {
+        type = types.listOf (types.str);
+        default = [ ];
+        description = lib.mdDoc ''
+          The default entrypoint files to check if no entrypoint is explicitly defined.
+        '';
+      };
+
     } // fileTypeAttrs;
 
   runnerModule = { name, config, ... }: { options = runnerOptions; };

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -52,6 +52,7 @@ in
       language = "javascript";
       start = "${nodejs-wrapped}/bin/node $file";
       fileParam = true;
+      defaultEntrypoints = [ "index.js" "main.js" ];
     };
 
     dev.debuggers.nodeDAP = {

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -121,6 +121,7 @@ in
     fileParam = true;
     language = "python3";
     start = "${python3-wrapper}/bin/python3 $file";
+    defaultEntrypoints = [ "main.py" "app.py" "run.py" ];
   };
 
   replit.dev.debuggers = debuggerConfig;


### PR DESCRIPTION
Why
===

Right now, if no entrypoint file is defined in `.replit`, even if a language module is installed and a sensible default file to run exists, it is not run. 

What changed
============

Added `defaultEntrypoints` fields to `runnerOptions`. In the case that no entrypoint file is defined, the backend can check if one of these files exist, and if so, run it instead of failing.  

Test plan
=========

- Tested modified nixmodules in a repl

Rollout
=======

- [x] This is fully backward and forward compatible
