### PR TITLE
Introduce unified formatter interface; Use for `gofmt` and `prettier`

### DIFF
--- a/pkgs/formatter/default.nix
+++ b/pkgs/formatter/default.nix
@@ -1,0 +1,165 @@
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "parse-formatter-options";
+  runtimeInputs = [ pkgs.bash ];
+  text = ''
+    #!/bin/bash
+
+    # Initialize variables
+    apply="false"
+    file=""
+    insertFinalNewline="false"
+    insertSpaces="false"
+    rangeStart=""
+    rangeEnd=""
+    stdinMode="false"
+    tabSize=""
+    trimFinalNewlines="false"
+    trimTrailingWhitespace="false"
+
+    # Function to print usage
+    print_usage() {
+      echo "Usage: $0 [-a|--apply] -f|--file <filename> [--stdin] [--range-start <offset>] [--range-end <offset>] [--tab-size <number>] [--insert-spaces] [--trim-trailing-whitespace] [--insert-final-newline] [--trim-final-newlines]"
+      echo
+      echo "Options:"
+      echo "  -h, --help                     Show this help message and exit"
+      echo "  -a, --apply                    Apply edits directly to the file (optional)"
+      echo "  -f, --file <filename>          Specify the file to be formatted (required)"
+      echo "      --stdin                    Read file input from stdin (optional)"
+      echo "      --insert-final-newline     Insert a newline at the end of the file if one does not exist (optional)"
+      echo "      --insert-spaces            Prefer spaces over tabs (optional)"
+      echo "      --range-start <offset>     Specify the character offset for formatting (optional, requires --range-end)"
+      echo "      --range-end <offset>       Specify the character offset for formatting (optional, requires --range-start)"
+      echo "      --tab-size <number>        Size of a tab in spaces (optional)"
+      echo "      --trim-final-newlines      Trim all newlines after the final newline at the end of the file (optional)"
+      echo "      --trim-trailing-whitespace Trim trailing whitespace on a line (optional)"
+
+    }
+
+    # Function to check if a value is a number
+    is_number() {
+      [[ "$1" =~ ^[0-9]+$ ]]
+    }
+
+    # Parse command-line arguments
+    while [[ "$#" -gt 0 ]]; do
+      case $1 in
+        -a|--apply)
+          apply="true"
+          shift
+          ;;
+        -f|--file)
+          file="$2"
+          shift 2
+          ;;
+        -h|--help)
+          print_usage
+          exit 0
+          ;;
+        --stdin)
+          stdinMode="true"
+          shift
+          ;;
+        --range-start)
+          if is_number "$2"; then
+            rangeStart="$2"
+          else
+            echo "Error: --range-start must be a number."
+            print_usage
+            exit 1
+          fi
+          shift 2
+          ;;
+        --range-end)
+          if is_number "$2"; then
+            rangeEnd="$2"
+          else
+            echo "Error: --range-end must be a number."
+            print_usage
+            exit 1
+          fi
+          shift 2
+          ;;
+        --tab-size)
+          if is_number "$2"; then
+            tabSize="$2"
+          else
+            echo "Error: --tab-size must be a number."
+            print_usage
+            exit 1
+          fi
+          shift 2
+          ;;
+        --insert-spaces)
+          insertSpaces="true"
+          shift
+          ;;
+        --trim-trailing-whitespace)
+          trimTrailingWhitespace="true"
+          shift
+          ;;
+        --insert-final-newline)
+          insertFinalNewline="true"
+          shift
+          ;;
+        --trim-final-newlines)
+          trimFinalNewlines="true"
+          shift
+          ;;
+
+        # TODO: Legacy from frontend, clean up
+        --tab-width)
+          if is_number "$2"; then
+            tabSize="$2"
+          fi
+          shift 2
+          ;;
+        --use-tabs)
+          if "$2"; then
+            insertSpaces="false"
+          else
+            insertSpaces="true"
+          fi
+          shift 2
+          ;; 
+        --stdin-filepath)
+          stdinMode="true"
+          shift
+          ;;
+        
+        # Ignore all other arguments
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    # Validate required arguments
+    if [[ -z "$file" ]]; then
+      echo "Error: File argument is required."
+      print_usage
+      exit 1
+    fi
+
+    # Further validate that both rangeStart and rangeEnd are provided together, if at all
+    if [[ -n "$rangeStart" && -z "$rangeEnd" ]] || [[ -z "$rangeStart" && -n "$rangeEnd" ]]; then
+      echo "Error: Both --range-start and --range-end must be provided together."
+      print_usage
+      exit 1
+    fi
+
+
+    # Export for use in sub-scripts
+    export apply
+    export file
+    export insertFinalNewline
+    export insertSpaces
+    export rangeStart
+    export rangeEnd
+    export stdinMode
+    export tabSize
+    export trimFinalNewlines
+    export trimTrailingWhitespace
+  '';
+}

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -41,7 +41,7 @@ let
       $out/bin/run-gofmt -f main.go > output.go
       printf 'package main\n\nfunc main() {\n\tfmt.Println("hello world")\n}\n'> expected.go
       if ! diff expected.go output.go; then
-        echo "format output doesn't match expectation:"
+        echo "format output doesn't match expectation"
         exit 1
       fi
     '';

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -8,7 +8,7 @@ let
   };
   run-gofmt = pkgs.writeShellApplication {
     name = "run-gofmt";
-    runtimeInputs = [ pkgs.bash ];
+    runtimeInputs = [ pkgs.bash go ];
     extraShellCheckFlags = [ "-x" ];
     text = ''
       #!/bin/bash

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -31,20 +31,20 @@ let
       gofmt "''${gofmt_args[@]}"
     '';
     checkPhase = ''
-    cat > main.go << EOF
-    package   main
+      cat > main.go << EOF
+      package   main
 
-    func    main (  ){
-    fmt.Println(  "hello world"  )
-    }
-    EOF
-    $out/bin/run-gofmt -f main.go > output.go
-    printf 'package main\n\nfunc main() {\n\tfmt.Println("hello world")\n}\n'> expected.go
-    expected=$(cat expected.go)
-    if ! diff expected.go output.go; then
-      echo "format output doesn't match expectation:"
-      exit 1
-    fi
+      func    main (  ){
+      fmt.Println(  "hello world"  )
+      }
+      EOF
+      $out/bin/run-gofmt -f main.go > output.go
+      printf 'package main\n\nfunc main() {\n\tfmt.Println("hello world")\n}\n'> expected.go
+      expected=$(cat expected.go)
+      if ! diff expected.go output.go; then
+        echo "format output doesn't match expectation:"
+        exit 1
+      fi
     '';
   };
 

--- a/pkgs/modules/go/default.nix
+++ b/pkgs/modules/go/default.nix
@@ -40,7 +40,6 @@ let
       EOF
       $out/bin/run-gofmt -f main.go > output.go
       printf 'package main\n\nfunc main() {\n\tfmt.Println("hello world")\n}\n'> expected.go
-      expected=$(cat expected.go)
       if ! diff expected.go output.go; then
         echo "format output doesn't match expectation:"
         exit 1

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -19,6 +19,60 @@ let
       ${nodejs-wrapped}/bin/npx "$@"
     '';
   };
+
+  formatter = import ../../formatter {
+    inherit pkgs;
+  };
+  run-prettier = pkgs.writeShellApplication {
+    name = "run-prettier";
+    runtimeInputs = [ pkgs.bash nodepkgs.prettier ];
+    extraShellCheckFlags = [ "-x" ];
+    text = ''
+      #!/bin/bash
+
+      # Source the shared options parsing script
+      source ${formatter}/bin/parse-formatter-options "$@"
+
+      # Translate parsed arguments into prettier options
+      prettier_args=()
+
+      # Apply edit flag
+      if [[ "''${apply:=false}" == "true" ]]; then
+        prettier_args+=("--write")
+      fi
+
+      # Range options
+      if [[ -n "$rangeStart" && -n "$rangeEnd" ]]; then
+        prettier_args+=("--range-start" "$rangeStart" "--range-end" "$rangeEnd")
+      fi
+
+      # Tab size
+      if [[ -n "$tabSize" ]]; then
+        prettier_args+=("--tab-width" "$tabSize")
+      fi
+
+      # Insert spaces over tabs
+      if [[ "''${insertSpaces:=false}" == "true" ]]; then
+        prettier_args+=("--use-tabs" "false")
+      else
+        prettier_args+=("--use-tabs" "true")
+      fi
+
+      # Read file content from stdin if stdinMode is enabled
+      if [[ "''${stdinMode:=false}" == "true" ]]; then
+        prettier_args+=("--stdin-filepath")
+      fi
+
+      # Append the file path
+      prettier_args+=("$file")
+
+      # Execute the command
+      # Resolve to first prettier in path
+      prettier "''${prettier_args[@]}"
+    '';
+  };
+
+
 in
 
 {
@@ -105,8 +159,7 @@ in
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".html" ];
       start = {
-        # Resolve to first prettier in path
-        args = [ "prettier" "--stdin-filepath" "$file" ];
+        args = [ "${run-prettier}/bin/run-prettier" "--stdin-filepath" "-f" "$file" ];
       };
       stdin = true;
     };

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -76,7 +76,6 @@ let
       EOF
       $out/bin/run-prettier -f index.ts > output.ts
       printf 'function foo() {\n\treturn 10;\n}\n'> expected.ts
-      expected=$(cat expected.ts)
       if ! diff expected.ts output.ts; then
         echo "format output doesn't match expectation:"
         exit 1

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -77,7 +77,7 @@ let
       $out/bin/run-prettier -f index.ts > output.ts
       printf 'function foo() {\n\treturn 10;\n}\n'> expected.ts
       if ! diff expected.ts output.ts; then
-        echo "format output doesn't match expectation:"
+        echo "format output doesn't match expectation"
         exit 1
       fi
     '';

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -70,6 +70,18 @@ let
       # Resolve to first prettier in path
       prettier "''${prettier_args[@]}"
     '';
+    checkPhase = ''
+      cat > index.ts << EOF
+      function foo() { return 10}
+      EOF
+      $out/bin/run-prettier -f index.ts > output.ts
+      printf 'function foo() {\n\treturn 10;\n}\n'> expected.ts
+      expected=$(cat expected.ts)
+      if ! diff expected.ts output.ts; then
+        echo "format output doesn't match expectation:"
+        exit 1
+      fi
+    '';
   };
 
 


### PR DESCRIPTION
Why
===

As I was starting to write the pid2 formatter, I was realizing that I was going to have to duplicate some of the same hacks for prettier that I added to the frontend for pid1 (which formats via exec).

We have a unified interface on the frontend to initiate formatting, but individual formatters do not have a unified set of arguments. So in order to support some special arguments for prettier (like range formatting, and tab and spaces settings) I had to explicitly pass in arguments https://github.com/replit/repl-it-web/blob/b2f9ae504907d097e137c152eb295dd7cdaba78c/client/codemirror/formatter/useFormattingProviders.ts#L30

I was going to have to do the same thing in the pid2 formatter, unless I came up with a better solution. In the past I wrote a doc proposing [writing all formatters as language servers](https://docs.google.com/document/d/1P2cY82PskewlPwHdrQaS9UYs6oCDFoLcnRrPHi9D6PE/edit#heading=h.ypv7jza8mj4o) to solve this problem. However, that was likely going to be a lot of work. We can end up in the same place, with a unified interface for the frontend to call, by just writing some bash scripts.

Here's the way it works:
1. Define a common "formatter" interface and set of options that the frontend can send. For this I used the following:
  - `-f | --file`: filepath - required
  - `-a`: if the formatter should write the changes directly, rather than returning the formatted string via stdout
  - `--range-start`: an offset, for supporting range formatting
  - `--range-end`: see above
  - the various LSP [formatting options as defined in the spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions)
2. The frontend will pass its desired options according to the common spec
3. Each formatter, within nixmodules, will define its own script that will receive the parsed common options, and translate them to binary-specific options before calling its formatter binary. If it doesn't support one of the common options, it can just ignore it



_Describe what prompted you to make this change, link relevant resources_

What changed
============

I've implemented the above for both formatters we have in nixmodules today, gofmt and prettier. Both should be implemented in a backwards-compatible way to work with the current frontend setup. After this rolls out theres some frontend cleanup that can be done, that will then allow me to remove some of the TODOs in this PR.

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

I built both nodejs-20 and go locally using 
```
nix build .#custom-bundle
```

I then inspected the active modules using 
```
nix eval .#activeModules --json | jq
```

and manually ran the built formatter scripts against some typescript and go files to confirm they worked.



Tested e2e with frontend here https://replit.com/@replit-dev/brady-nixmodules#index.ts
```
nix build .#'"nodejs-20"'
ln -s result result.json
```
Add `result.json` to modules array in .replit
Able to format a typescript file with prettier 

```
nix build .#'"go-1.21"'
ln -s result result.json
```
Able to format a golang file with gofmt. The nice thing is this actually fixes a bug with gofmt that currently formats _all_ files, instead of just your active one.
 

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
