### PR TITLE
Mark prettier as supporting range formatting

### DIFF
--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -305,6 +305,13 @@ let
           Whether to pass in file contents from stdin or from $file parameter.
         '';
       };
+
+      supportsRangeFormatting = mkOption {
+        type = types.bool;
+        description = lib.mdDoc ''
+          Whether the formatter support
+        '';
+      };
     } // fileTypeAttrs;
   };
 

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -308,6 +308,7 @@ let
 
       supportsRangeFormatting = mkOption {
         type = types.bool;
+        default = false;
         description = lib.mdDoc ''
           Whether the formatter supports range formatting
         '';

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -309,7 +309,7 @@ let
       supportsRangeFormatting = mkOption {
         type = types.bool;
         description = lib.mdDoc ''
-          Whether the formatter support
+          Whether the formatter supports range formatting
         '';
       };
     } // fileTypeAttrs;

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -162,6 +162,7 @@ in
         args = [ "${run-prettier}/bin/run-prettier" "--stdin-filepath" "-f" "$file" ];
       };
       stdin = true;
+      supportsRangeFormatting = true;
     };
 
     dev.packagers.upmNodejs = {


### PR DESCRIPTION
Why
===

Right now we [hack this in on the frontend](https://github.com/replit/repl-it-web/blob/0d65a50cc638fa9e47ec71dcafb36e4ad73a517e/client/codemirror/formatter/useFormattingProviders.ts#L138). But ideally this would be defined by the nixmodule and flow through.

I'll need to make a proto change to pass this from goval --> web. This is assuming it's safe to add new members here prior to making the goval change.

_Describe what prompted you to make this change, link relevant resources_

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
