### PR TITLE
Consistent nodejs names versions

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,7 +7,7 @@ let
   revstring_long = self.rev or "dirty";
   revstring = builtins.substring 0 7 revstring_long;
 
-  dev-module-ids = [ "python-3.10" "nodejs-18" "nodejs-20" "nodejs-with-prybar-18" "docker" "python-with-prybar-3.10" ];
+  dev-module-ids = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" ];
 
   mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,7 +7,7 @@ let
   revstring_long = self.rev or "dirty";
   revstring = builtins.substring 0 7 revstring_long;
 
-  dev-module-ids = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" ];
+  dev-module-ids = [ "python-3.10" "nodejs-18" "nodejs-20" "nodejs-with-prybar-18" "docker" "python-with-prybar-3.10" ];
 
   mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
 

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -181,16 +181,6 @@ let
       };
     }
     {
-      moduleId = "vue-node-18";
-      commit = "3ea4bcdbdc3c5e3c09b37b07edcd61781f9695f7";
-      overrides = {
-        # /nix/store/623sn0cy54r5csab3d9fmg55di6r4dd3-replit-module-vue-node-18
-        # .runners["dev-runner"].displayVersion = "18.18.2";
-        name = "Vue Tools with Node.js";
-        displayVersion = "18";
-      };
-    }
-    {
       moduleId = "zig-0.11";
       commit = "15426ef79793bf7c424eb40865d507eacfdd44e6";
       overrides = {

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -118,6 +118,7 @@ let
       moduleId = "nodejs-14";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
       overrides = {
+        name = "Node.js Tools";
         displayVersion = "14";
         runners = {
           nodeJS = {
@@ -130,6 +131,7 @@ let
       moduleId = "nodejs-16";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
       overrides = {
+        name = "Node.js Tools";
         displayVersion = "16";
         runners = {
           nodeJS = {
@@ -142,6 +144,7 @@ let
       moduleId = "nodejs-19";
       commit = "f4cd419a646009297c049a2f1eec434381e08f13";
       overrides = {
+        name = "Node.js Tools";
         displayVersion = "19";
         runners = {
           nodeJS = {
@@ -183,6 +186,7 @@ let
       overrides = {
         # /nix/store/623sn0cy54r5csab3d9fmg55di6r4dd3-replit-module-vue-node-18
         # .runners["dev-runner"].displayVersion = "18.18.2";
+        name = "Vue Tools with Node.js";
         displayVersion = "18";
       };
     }

--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -11,7 +11,8 @@ in
 
 {
   id = "angular-node-20";
-  name = "Angular with Node.js 20 Tools";
+  name = "Angular Tools with Node.js";
+  displayVersion = "20";
   description = ''
     Angular development tools including Node.js, Bun, pnpm, yarn, Angular language server.
   '';

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -99,7 +99,12 @@ let
     )
     (import ./swift)
     (import ./svelte-kit)
-    (import ./vue)
+    (import ./vue {
+      nodejs = pkgs.nodejs_20;
+    })
+    (import ./vue {
+      nodejs = pkgs.nodejs_18;
+    })
     (import ./web)
     (import ./hermit)
     (import ./typescript-language-server {

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -17,7 +17,7 @@ in
 
   id = lib.mkForce "nodejs-with-prybar-${nodeVersion}";
 
-  name = lib.mkForce "Node.js ${nodeVersion} Tools (with Prybar)";
+  name = lib.mkForce "Node.js Tools (with Prybar)";
   displayVersion = nodeVersion;
   demoted = true;
   description = lib.mkForce ''

--- a/pkgs/modules/svelte-kit/default.nix
+++ b/pkgs/modules/svelte-kit/default.nix
@@ -2,7 +2,8 @@
 
 {
   id = "svelte-kit-node-20";
-  name = "SvelteKit with Node.js 20 Tools";
+  name = "SvelteKit Tools with Node.js";
+  displayVersion = "20";
   description = ''
     Svelte Kit development tools. Includes Node.js, Svelte language server.
   '';

--- a/pkgs/modules/vue/default.nix
+++ b/pkgs/modules/vue/default.nix
@@ -12,7 +12,8 @@ in
 
 {
   id = "vue-node-20";
-  name = "Vue with Node.js 20 Tools";
+  name = "Vue Tools with Node.js";
+  displayVersion = "20";
   description = ''
     Vue.js development tools. Includes Node.js, Bun, pnpm, yarn, Vue language tools.
   '';

--- a/pkgs/modules/vue/default.nix
+++ b/pkgs/modules/vue/default.nix
@@ -1,19 +1,22 @@
-{ pkgs, ... }:
+{ nodejs }:
+{ pkgs, lib, ... }:
 
 let
-  nodejs = pkgs.nodejs_20;
   nodepkgs = nodejs.pkgs;
+  node-version = lib.versions.major nodejs.version;
 
-  vue-language-server = pkgs.callPackage ../../vue-language-server { };
+  vue-language-server = pkgs.callPackage ../../vue-language-server {
+    inherit nodejs;
+  };
 
   language = "vue";
   extensions = [ ".vue" ".js" ".mjs" ".cjs" ".jsx" ".ts" ".tsx" ".json" ".html" ".css" ];
 in
 
 {
-  id = "vue-node-20";
+  id = "vue-node-${node-version}";
   name = "Vue Tools with Node.js";
-  displayVersion = "20";
+  displayVersion = node-version;
   description = ''
     Vue.js development tools. Includes Node.js, Bun, pnpm, yarn, Vue language tools.
   '';

--- a/pkgs/vue-language-server/default.nix
+++ b/pkgs/vue-language-server/default.nix
@@ -1,6 +1,7 @@
 # TODO: upstream this file into nixpkgs
 { buildNpmPackage
 , fetchurl
+, nodejs
 }:
 
 buildNpmPackage rec {
@@ -22,5 +23,7 @@ buildNpmPackage rec {
   meta = {
     mainProgram = "vue-language-server";
   };
+
+  inherit nodejs;
 }
 


### PR DESCRIPTION
Why
===

Inconsistent Node.js and related module names and display versions:

![image](https://github.com/replit/nixmodules/assets/54303/6cb2abe1-1940-436e-9cd4-174c921da869)

What changed
============

1. Removed the version number from the name for all cases, so it's not duplicated with the display version
2. Moved vue-node-18 out of historical and into active. Fewer historical modules the better, I think.

Test plan
=========

That list should look a lot cleaner.