### PR TITLE
[nodejs,angular] stop adding local node_modules/.bin to path

### DIFF
--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -35,7 +35,7 @@ in
     env = {
       XDG_CONFIG_HOME = "$REPL_HOME/.config";
       npm_config_prefix = "$REPL_HOME/.config/npm/node_global";
-      PATH = "$XDG_CONFIG_HOME/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
+      PATH = "$XDG_CONFIG_HOME/npm/node_global/bin";
     };
 
     dev.runners.dev-runner = {

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -189,7 +189,7 @@ in
     env = {
       XDG_CONFIG_HOME = "$REPL_HOME/.config";
       npm_config_prefix = "$REPL_HOME/.config/npm/node_global";
-      PATH = "${npx-wrapper}/bin:$XDG_CONFIG_HOME/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
+      PATH = "${npx-wrapper}/bin:$XDG_CONFIG_HOME/npm/node_global/bin";
     };
 
   };


### PR DESCRIPTION
Why
===
* We were having issues where our local node_modules bin had a "which" binary that did not behave well.
* It isn't typical for local node_modules/.bin to be on the path, if you want something on the path, you typically use npm install --global, which is still added to the PATH after this change.

What changed
===
* Remove $REPL_HOME/node_modules/.bin from PATH

Test plan
===
* Check template tester still passes
* Check PATH does not contain that path in nodejs Repls

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
