### PR TITLE
Revert "[nodejs,angular] stop adding local node_modules/.bin to path"

### DIFF
--- a/pkgs/modules/angular/default.nix
+++ b/pkgs/modules/angular/default.nix
@@ -35,7 +35,7 @@ in
     env = {
       XDG_CONFIG_HOME = "$REPL_HOME/.config";
       npm_config_prefix = "$REPL_HOME/.config/npm/node_global";
-      PATH = "$XDG_CONFIG_HOME/npm/node_global/bin";
+      PATH = "$XDG_CONFIG_HOME/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
     };
 
     dev.runners.dev-runner = {

--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -189,7 +189,7 @@ in
     env = {
       XDG_CONFIG_HOME = "$REPL_HOME/.config";
       npm_config_prefix = "$REPL_HOME/.config/npm/node_global";
-      PATH = "${npx-wrapper}/bin:$XDG_CONFIG_HOME/npm/node_global/bin";
+      PATH = "${npx-wrapper}/bin:$XDG_CONFIG_HOME/npm/node_global/bin:$REPL_HOME/node_modules/.bin";
     };
 
   };


### PR DESCRIPTION
Reverts replit/nixmodules#366

We found that this breaks all Typescript forks. We'll need to have a fix for those before we reland this.