### PR TITLE
[ci] also trigger on pull_request

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,8 @@
 name: checks
 run-name: Check for errors
 on:
-  - push
+  pull_request:
+  push:
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,10 @@
 name: checks
 run-name: Check for errors
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Why
===
* We're having issues where community contributions can't be merged easily. It might be because there isn't a workflow for us to approve. Maybe triggering on pull request will help

What changed
===
* add on pull_request

Test plan
===
* See if we can approve workflows on https://github.com/replit/nixmodules/pull/358

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
