### PR TITLE
Updated python3.8 to unstable channel

### DIFF
--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -3,7 +3,7 @@
 let
   pythonVersion = lib.versions.majorMinor python.version;
 
-  pkgs = if pythonVersion == "3.8" then pkgs-23_05 else pkgs-unstable;
+  pkgs = pkgs-unstable;
 
   pylibs-dir = ".pythonlibs";
 


### PR DESCRIPTION
Why
===

Python 3.8 is on an older Nix channel. This can cause GLIBC errors if `replit.nix` is using a newer channel.

What changed
============

Use unstable for Python 3.8.

Test plan
=========

1. create a repl
2. add `python-3.8` to its modules list
3. try running a program
4. try installing a pypi package