### PR TITLE
add python 3.6 module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,6 +198,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-21_05": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1717399147,
@@ -261,6 +277,7 @@
         "java-language-server": "java-language-server",
         "nil": "nil",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-21_05": "nixpkgs-21_05",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "prybar": "prybar",
         "replit-rtld-loader": "replit-rtld-loader",

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "Nix expressions for defining Replit development environments";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs-21_05.url = "github:nixos/nixpkgs/release-21.05";
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.nil.url = "github:oxalica/nil";
@@ -15,7 +16,7 @@
   inputs.replit-rtld-loader.url = "github:replit/replit_rtld_loader";
   inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nixpkgs-21_05, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -33,6 +34,7 @@
         ];
       };
 
+      pkgs-21_05 = mkPkgs nixpkgs-21_05 "x86_64-linux";
       pkgs-23_05 = mkPkgs nixpkgs "x86_64-linux";
 
       patched-unstable = nixpkgs-unstable.legacyPackages.x86_64-linux.applyPatches {
@@ -104,6 +106,7 @@
       import ./pkgs/modules {
         inherit pkgs;
         inherit pkgs-23_05;
+        inherit pkgs-21_05;
       }
     );
 }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-23_05 }:
+{ pkgs, pkgs-21_05, pkgs-23_05 }:
 with builtins;
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
@@ -14,6 +14,11 @@ let
   historical = pkgs.callPackage ../historical-modules { };
 
   modulesList = [
+    (import ./python {
+      python = pkgs-21_05.pkgsStatic.python36Full;
+      pypkgs = pkgs-21_05.python36Packages;
+      modern = false;
+    })
     (import ./python {
       python = pkgs-23_05.python38Full;
       pypkgs = pkgs-23_05.python38Packages;


### PR DESCRIPTION
Why
===

why? why you ask me? spite, mostly.

What changed
============

1. added nixpkgs 21.11 input
2. python 3.6 module using ^
3. added `modern` parameter to python module
   a. `poetry` doesn't work with 3.6
   b. `debugpy` doesn't work with 3.6 (nix checks fail)

Test plan
=========

in a [repl](https://replit.com/t/replit/onreplit/repls/nixmodules-2) with this branch checked out:
1. `nix build '.#modules."python-3.6"'`
2. `mv result result.json`
3. remove the python module from `.replit` and add `result.json`
4. test python cli, lsp, `python -m venv .pythonlibs`, etc etc

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
