### PR TITLE
Remove unnecessary prettier flags

### DIFF
--- a/pkgs/modules/nodejs/default.nix
+++ b/pkgs/modules/nodejs/default.nix
@@ -170,7 +170,7 @@ in
       language = "javascript";
       extensions = [ ".js" ".jsx" ".ts" ".tsx" ".json" ".html" ];
       start = {
-        args = [ "${run-prettier}/bin/run-prettier" "--stdin-filepath" "-f" "$file" ];
+        args = [ "${run-prettier}/bin/run-prettier" ];
       };
       stdin = true;
       supportsRangeFormatting = true;


### PR DESCRIPTION
Why
===

Now that the frontend uses the new API for formatting with prettier, we don't need these legacy flags passed anymore: https://github.com/replit/repl-it-web/pull/45954

_Describe what prompted you to make this change, link relevant resources_

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

Tested in https://replit.com/@replit-dev/brady-nixmodules#replit.nix
```
nix build .#'"nodejs-20"'
ln -s result result.json
```

Add `result.json` to modules array in `.replit`
Able to format a typescript file with prettier

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
