### PR TITLE
Get python38 actually building from unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,27 @@
             '';
           };
         };
+
+      } // rec {
+        python38 = pkgs.python310.override {
+          sourceVersion = {
+            major = "3";
+            minor = "8";
+            patch = "18";
+            suffix = "";
+          };
+          hash = "sha256-P/txzTSaMmunsvrcfn34a6V33ZxJF+UqhAGtvadAXj8=";
+        };
+        
+
+        python38Full = python38.override {
+          self = python38Full;
+          pythonAttr = "python38Full";
+          bluezSupport = true;
+          x11Support = true;
+        };
+
+        python38Packages = python38Full.pkgs;
       };
       formatter.x86_64-linux = pkgs.nixpkgs-fmt;
       packages.x86_64-linux = import ./pkgs {

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
           };
           hash = "sha256-P/txzTSaMmunsvrcfn34a6V33ZxJF+UqhAGtvadAXj8=";
         };
-        
+
 
         python38Full = python38.override {
           self = python38Full;

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -15,8 +15,8 @@ let
 
   modulesList = [
     (import ./python {
-      python = pkgs-23_05.python38Full;
-      pypkgs = pkgs-23_05.python38Packages;
+      python = pkgs.python38Full;
+      pypkgs = pkgs.python38Packages;
     })
     (import ./python {
       python = pkgs.python39Full;

--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -10,6 +10,12 @@ let
     # and we don't need the docs
     postBuild = "";
     postInstall = "";
+
+    nativeBuildInputs = [
+      pkgs.installShellFiles
+      pypkgs.setuptools
+      pypkgs.wheel
+    ];
   });
 
   config = pkgs.writeTextFile {


### PR DESCRIPTION
Why
===

https://github.com/replit/nixmodules/pull/371 actually didn't build python 3.8 from unstable. I missed something.

What changed
============

1. use override to actually create python38Full and python38Packages via overlay
2. use them to build the python-3.8 module

Test plan
=========

1. add `python-3.8` as a module in `modules`
2. `readelf -d $(python3 -c 'import sys; print(sys.executable)')`
3. you should see `glibc-2.39-52` in the `Library runpath`, not glibc-2.37...