### PR TITLE
Bun update

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.18";
+  version = "1.1.21";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-n/HcFSSNtnmzEa4nBuzn8LuJ/IQ3/QUlTt3OO5T/ACQ=";
+    hash = "sha256-KPq1T0jxN6ghFIoKRe3rQqUtI6qMuRdMzIFVSj+JMco=";
   };
 }


### PR DESCRIPTION
Why
===
In these few new versions, bun has become faster and smaller for Linux.

- [x] This is fully backward and forward compatible
