### PR TITLE
Add `python-3.12`

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,7 +7,7 @@ let
   revstring_long = self.rev or "dirty";
   revstring = builtins.substring 0 7 revstring_long;
 
-  dev-module-ids = [ "python-3.10" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" ];
+  dev-module-ids = [ "python-3.10" "python-3.12" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" ];
 
   mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
 


### PR DESCRIPTION
Why
===

The agent _really_ wants to use python-3.12.

What changed
============

Added `python-3.12` to the list of development modules.

Test plan
=========

Start conman, be able to install the python-3.12 module.

Rollout
=======

- [X] This is fully backward and forward compatible