### PR TITLE
[nodejs-22] init module

### DIFF
--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -44,6 +44,9 @@ let
     (import ./nodejs {
       nodejs = pkgs.nodejs_20;
     })
+    (import ./nodejs {
+      nodejs = pkgs.nodejs_22;
+    })
     (import ./nodejs-with-prybar)
 
     (import ./go {


### PR DESCRIPTION
Why
===

we're coming up on the end of nodejs 20's active lts lifetime and nodejs 18 is entering maintenance mode, the wheel in the sky keeps on turning

What changed
============

initialized nodejs 22 

Test plan
=========

template tester using nodejs 22 passes

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
