### PR TITLE
Bun update

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.21";
+  version = "1.1.23";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-KPq1T0jxN6ghFIoKRe3rQqUtI6qMuRdMzIFVSj+JMco=";
+    hash = "sha256-6b+X+ynbkECEOFssPUhiEiKOQDZ4xydZp5Ewd5kFAhY=";
   };
 }

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.1.23";
+  version = "1.1.24";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-6b+X+ynbkECEOFssPUhiEiKOQDZ4xydZp5Ewd5kFAhY=";
+    hash = "sha256-9HiIBnjPKC/dpGzJ1Y4goN3h+tjJz+4Sjq1DmWRT4cg=";
   };
 }


### PR DESCRIPTION
Why
===
~~We're two versions behind  🗣️🗣️🗣️🔥🔥🔥 😅~~
4mb smaller, 50% faster console.log, 30% faster fetch decompression...