### PR TITLE
dev-module-ids: add ruby

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,7 +7,7 @@ let
   revstring_long = self.rev or "dirty";
   revstring = builtins.substring 0 7 revstring_long;
 
-  dev-module-ids = [ "python-3.10" "python-3.12" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" ];
+  dev-module-ids = [ "python-3.10" "python-3.12" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" "ruby" ];
 
   mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
 


### PR DESCRIPTION
Why
===
* some of our tests use Ruby, having it in the disk would make those tests faster

What changed
===
* add ruby to the dev-module-ids

Test plan
===
* `nix build .#bundle-squashfs` builds