### PR TITLE
feat/add uv

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1725194671,
-        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
+        "lastModified": 1725369773,
+        "narHash": "sha256-gT+rUDbw+TQuszQEzMUJWTW7QYtccZ5xxWmKOSrPvEw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "rev": "8b4061fd60ccc3b3f44b73faa7c983eacf7a6f7b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1721025077,
-        "narHash": "sha256-q7UlaKzIXuGNGlM+1REjR2iRO842Orzm00GRniyNdtA=",
+        "lastModified": 1725517947,
+        "narHash": "sha256-sB8B3M6CS0Y0rnncsCPz0htg6LoC1RbI2Mq9K88tSOk=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "22d6920811da3d6f6fbf1efc5af4e9c3e5025d30",
+        "rev": "96072c2af73da16c7db013dbb8c8869000157235",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688568849,
-        "narHash": "sha256-3oOgfV0T9tD3RyXUc/miXcXoNt9JkYkL1Jdg+rl+2lg=",
+        "lastModified": 1697466147,
+        "narHash": "sha256-3AhaAwFYglnvtv4Cyeq3/cooQUIVTE+vID+TSZsFAfQ=",
         "owner": "replit",
         "repo": "java-language-server",
-        "rev": "a8429dbed50f2de324e44a1b81dc2b94a248adc6",
+        "rev": "ba33f337ad1967f2b1b0990801701c2c531369f6",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717086091,
-        "narHash": "sha256-GmsEQa4HZeMfec37LZnwG/Lt/XmqFLXsjv5QWojeNiM=",
+        "lastModified": 1723948777,
+        "narHash": "sha256-rX14joTzvRUiCfmCT0LUMV3Mxi79VJANcKB/kkh7Qys=",
         "owner": "oxalica",
         "repo": "nil",
-        "rev": "ab3ddb8f063774cf7e22eb610f5ecfdb77309f3c",
+        "rev": "4f3081d1f10bb61f197b780e67f426e53f818691",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687466461,
-        "narHash": "sha256-oupXI7g7RPzlpGUfAu1xG4KBK53GrZH8/xeKgKDB4+Q=",
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ecb441f22067ba1d6312f4932a7c64efa8d19a7b",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1725369773,
-        "narHash": "sha256-gT+rUDbw+TQuszQEzMUJWTW7QYtccZ5xxWmKOSrPvEw=",
+        "lastModified": 1725503534,
+        "narHash": "sha256-hd1eRyPtTkRnAPYpnEfzugQwAifVYMmOR3z+MTTSw+g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8b4061fd60ccc3b3f44b73faa7c983eacf7a6f7b",
+        "rev": "fcb54ddcc974cff59bdfb7c1ac9e080299763d2d",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694708807,
-        "narHash": "sha256-Fb8L0Sl5kP9mDJMaAjt5igruA/fpa34KHuHUhy8wraI=",
+        "lastModified": 1724945235,
+        "narHash": "sha256-kc9RbxSHWvABobPhfa1+NjxaRUg8rnl7aEn+czcTTO8=",
         "owner": "replit",
         "repo": "prybar",
-        "rev": "59b47997a2e2d121679315efcc35f33b157182e7",
+        "rev": "cdd0ba192a7c9f4d6a33c1fcba73c41425ef3d10",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708616763,
-        "narHash": "sha256-PsKc1HWgvVhQTVRGuXMekMfxZ+yLARwouXVZLkstgCY=",
+        "lastModified": 1713277918,
+        "narHash": "sha256-87q8ZaQW0qyCvg6QqTHUuvXeB5OtXHEAwwUWZ5gf0A0=",
         "owner": "replit",
         "repo": "replit_rtld_loader",
-        "rev": "766ffc13d940fd9d294b4124faef07f371bd6205",
+        "rev": "4eba5ae8b825a724ccdfaa12ad637e9a9754629a",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1720953053,
-        "narHash": "sha256-zNaYyxBHmrfk4EfqvxUU97iOw1uchnBuytqgt/Zm8LA=",
+        "lastModified": 1725444219,
+        "narHash": "sha256-VjItfg2kZJ2to3bnNlkWAClKQLssIi86QcE1/vcRvv0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "e9afba57a5a8780285f530172e3ceea1f9c7eff7",
+        "rev": "50882fbfa204027c84753e6d51a1a12884dc1b19",
         "type": "github"
       },
       "original": {
@@ -286,21 +286,17 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "nil",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nil",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1718331519,
-        "narHash": "sha256-6Ru37wS8uec626nHVIh6hSpCYB7eNc3RPFa2U//bhw4=",
+        "lastModified": 1722824458,
+        "narHash": "sha256-2k3/geD5Yh8JT1nrGaRycje5kB0DkvQA/OUZoel1bIU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "419e7fae2731f41dd9b3e34dfe8802be68558b92",
+        "rev": "a8a937c304e62a5098c6276c9cdf65c19a43b1a5",
         "type": "github"
       },
       "original": {
@@ -361,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692732389,
-        "narHash": "sha256-32ODTGZ5Mgj9zoTerSbzVUFRnvDTvCeIGwxmDsf2DTU=",
+        "lastModified": 1724710535,
+        "narHash": "sha256-iw6I7yhXBbanIUi3VHXIveXDXF9BrakwAflQ76/pxDg=",
         "owner": "replit",
         "repo": "ztoc-rs",
-        "rev": "a170dec3756c013c365340273052286aa7b6a38a",
+        "rev": "977661eba22f474a9fddd1ff1fcd63b6acadc902",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1717399147,
-        "narHash": "sha256-eCWaE/q1VItpFAxxLVt171MdtDcjEnwi6QB/yuF73JU=",
+        "lastModified": 1725194671,
+        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4a4ecb0ab415c9fccfb005567a215e6a9564cdf5",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,15 @@
         name = "nixpkgs-unstable-patched";
         src = nixpkgs-unstable;
         patches = [
-          # rexml breaks this version of nixpkgs
-          ./patches/rexml.patch
+          # rexml broke solargraph at some point in the past.
+          # Attempting to run:
+          #   echo 'x = (5 + "hey")' > main.rb
+          #   /nix/store/.../ruby /nix/store/.../bin/solargraph typecheck main.rb
+          # curently emits a bunch of "Unrecognized RBS type:" warnings, followed by
+          # "0 problems found."
+          # This patch used to apply, but even when massaged to apply to the
+          # current unstable HEAD, still produces the same result:
+          # ./patches/rexml.patch
         ];
       };
 

--- a/pkgs/modules/R/default.nix
+++ b/pkgs/modules/R/default.nix
@@ -9,6 +9,10 @@ in
     R project for statistical computing.
   '';
 
+  replit.packages = [
+    pkgs.R
+  ];
+
   replit.runners.r = {
     name = "R";
     language = "r";

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -161,6 +161,7 @@ in
     PYTHONUSERBASE = userbase;
     PYTHONPATH = "${sitecustomize}:${pip.pip}/${python.sitePackages}";
     REPLIT_PYTHONPATH = "${userbase}/${python.sitePackages}:${pypkgs.setuptools}/${python.sitePackages}";
+    UV_PROJECT_ENVIRONMENT = "$REPL_HOME/.pythonlibs";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -113,6 +113,7 @@ in
     python3-wrapper
     pip-wrapper
     poetry-wrapper
+    pkgs.uv
   ];
 
   replit.runners.python = {

--- a/pkgs/upgrade-map/default.nix
+++ b/pkgs/upgrade-map/default.nix
@@ -12,7 +12,12 @@ let
     "bun-0.7" = "bun-1.0";
     "dart-3.0" = "dart-3.1";
     "dart-3.1" = "dart-3.2";
+    "dart-3.2" = "dart-3.3";
+    "dart-3.3" = "dart-3.4";
+    "dart-3.4" = "dart-3.5";
+    "elixir-1_16" = "elixir-1_17";
     "go" = "go-1.19";
+    "r-4.3" = "r-4.4";
     "rust" = "rust-1.69";
     "rust-1.69" = "rust-1.70";
     "rust-1.70" = "rust-1.72";

--- a/scripts/build_changed_modules.py
+++ b/scripts/build_changed_modules.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import argparse
 import re
+from textwrap import dedent
 
 nix_store_path_pattern = re.compile(r'/nix/store/([0-9a-z]+)')
 
@@ -46,7 +47,10 @@ def verify_no_existing_modules_removed(upstream_module_versions, current_module_
   upstream_modules = {version[0] for version in upstream_module_versions}
   modules = {version[0] for version in current_module_versions}
   diff = upstream_modules - modules
-  assert len(diff) == 0, "module(s) deleted: %r" % diff
+  assert len(diff) == 0, dedent(f"""\
+    module(s) deleted: {repr(diff)}
+      You may want to add new entries to ./pkgs/upgrade-map
+    """)
 
 def main():
   parser = argparse.ArgumentParser(

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -17,4 +17,4 @@ nix eval "${NIX_FLAGS[@]}" .#modules --json
 
 nix develop "${NIX_FLAGS[@]}" --command echo Hello, world
 
-python scripts/build_changed_modules.py main
+nix-shell -p python312 --command 'python scripts/build_changed_modules.py main'

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -10,7 +10,6 @@ git grep writeShellScriptBin | grep -v "Please use writeShellApplication" && \
 NIX_FLAGS=(
     --extra-experimental-features nix-command
     --extra-experimental-features flakes
-    --extra-experimental-features discard-references
 )
 
 echo "Evaluate modules derivations"

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -16,6 +16,6 @@ NIX_FLAGS=(
 echo "Evaluate modules derivations"
 nix eval "${NIX_FLAGS[@]}" .#modules --json
 
-nix develop "${NIX_FLAGS[@]}"
+nix develop "${NIX_FLAGS[@]}" --command echo Hello, world
 
 python scripts/build_changed_modules.py main

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -7,11 +7,15 @@ git grep writeShellScriptBin | grep -v "Please use writeShellApplication" && \
     (echo "Please use writeShellApplication instead of writeShellScriptBin" && \
          exit 1) || true
 
-NIX_FLAGS="--extra-experimental-features nix-command --extra-experimental-features flakes --extra-experimental-features discard-references"
+NIX_FLAGS=(
+    --extra-experimental-features nix-command
+    --extra-experimental-features flakes
+    --extra-experimental-features discard-references
+)
 
 echo "Evaluate modules derivations"
-nix eval $NIX_FLAGS .#modules --json
+nix eval "${NIX_FLAGS[@]}" .#modules --json
 
-nix develop $NIX_FLAGS
+nix develop "${NIX_FLAGS[@]}"
 
 python scripts/build_changed_modules.py main


### PR DESCRIPTION
Why
===

I'd like a more recent version of `uv` to address https://github.com/replit/upm/issues/244

What changed
============

- Bumping flake lock
- Disabling defunct solargraph patch for now, as it was not actually making solargraph work
- Adding `uv` to python modules
- Adding dart, elixir, and R to the upgrade map
- Deleting now-promoted `discard-references` experimental flag, as indicated in https://github.com/NixOS/nix/blob/master/doc/manual/src/release-notes/rl-2.18.md

Test plan
=========

`which uv` should show at least version 0.3.3

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
