### PR TITLE
We prefer 3.11 instead of 3.12 atm for python due to some breaking ch…

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,7 +7,7 @@ let
   revstring_long = self.rev or "dirty";
   revstring = builtins.substring 0 7 revstring_long;
 
-  dev-module-ids = [ "python-3.10" "python-3.12" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" "ruby" ];
+  dev-module-ids = [ "python-3.10" "python-3.11" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" "ruby" ];
 
   mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
 


### PR DESCRIPTION
…anges

What changed
============

Changed the included python from 3.12 to 3.11.