### PR TITLE
[rust] set CARGO_HOME to $XDG_DATA_HOME/cargo

### DIFF
--- a/pkgs/modules/rust/default.nix
+++ b/pkgs/modules/rust/default.nix
@@ -74,6 +74,6 @@ in
   };
 
   replit.env = {
-    CARGO_HOME = "$REPL_HOME/.cargo";
+    CARGO_HOME = "$XDG_DATA_HOME/.cargo";
   };
 }


### PR DESCRIPTION
Why
===

this has been bothering me, and i just ran into a scenario where cloning a repo resulted in ~13k untracked files in git

we can't fix that with gitignore since a project's `.cargo` directory may also be checked into git by convention (primarily for project-local configuration, but there's other reasons to do so)

What changed
============

moved the `CARGO_HOME` env var from `$REPL_HOME/.cargo` to `$XDG_DATA_HOME/cargo`

Test plan
=========

before:
1. clone https://github.com/tamasfe/taplo in replit
2. notice several thousand untracked files

after:
1. clone the same repo into a new repl
2. notice no untracked files
3. `stat .local/share/cargo/registry` has exit code 0

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
