### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will take a while.
 
 ## Building
 
-For each of the following examples, the build result will found be in a file or directory named `result`.
+For each of the following examples, the build result will be found in a file or directory named `result`.
 
 To build all active modules (this will take a while, and a lot of disk space):
 


### PR DESCRIPTION
Correct word order from 'found be' to 'be found' in the 'Building' section.

Why

A typo was discovered in the README under the "Building" section, where "found be" should have been "be found." This correction improves the clarity and professionalism of the documentation.

What changed

The word order in the "Building" section of the README was corrected. Specifically, the phrase "the build result will found be in" was changed to "the build result will be found in." No other changes were made.

Test plan

Since this is a documentation change, no code functionality needs to be tested. The change was reviewed visually in the README to ensure the typo was corrected.

Rollout

This change is fully backward and forward compatible, as it only affects the README file and does not impact any code or systems.

☑️ This is fully backward and forward compatible
