### PR TITLE
Exposing global "REPLIT_LD_LOADER" property to be picked up by replenv builder

### DIFF
--- a/pkgs/modules/replit/default.nix
+++ b/pkgs/modules/replit/default.nix
@@ -34,10 +34,13 @@ in
     Replit tools. Includes .replit language server.
   '';
 
+  replit.env = {
+    REPLIT_LD_AUDIT = "${pkgs.replit-rtld-loader}/rtld_loader.so";
+  };
+
   replit.dev.languageServers.dotreplit-lsp = {
     name = ".replit LSP";
     language = "dotreplit";
     start = "${taplo}/bin/taplo lsp -c ${taplo-config} stdio";
   };
 }
-


### PR DESCRIPTION
Why
===

For better or worse, `uv` mandates the virtualenv being a "real" virtualenv, including `bin/python` symlinks. This subverts our attempts to manipulate the environment via shell-script wrappers, causing runtime library issues.

By moving the environment shuffling into the replenv builder itself, curating the environment itself instead of the wrapper scripts, we can have both uv as well as tools like rtld-loder.

What changed
============

- Expose `REPLIT_LD_AUDIT`

Test plan
=========

I should be able to `echo $REPLIT_LD_AUDIT` and get the value defined even on an empty Repl.

Rollout
=======

- [x] This is fully backward and forward compatible
