### PR TITLE
feat/python module composition

### DIFF
--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -49,6 +49,8 @@ let
     (import ./python-with-prybar)
 
     (import ./pyright-extended)
+    (import ./pyright)
+    (import ./ruff)
 
     (import ./nodejs {
       nodejs = pkgs.nodejs-18_x;

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -34,6 +34,18 @@ let
       python = pkgs.python312Full;
       pypkgs = pkgs.python312Packages;
     })
+    (import ./python-base {
+      python = pkgs.python311Full;
+      pypkgs = pkgs.python311Packages;
+    })
+    (import ./python-base {
+      python = pkgs.python312Full;
+      pypkgs = pkgs.python312Packages;
+    })
+    (import ./python-base {
+      python = pkgs.python313Full;
+      pypkgs = pkgs.python313Packages;
+    })
     (import ./python-with-prybar)
 
     (import ./pyright-extended)

--- a/pkgs/modules/pyright/default.nix
+++ b/pkgs/modules/pyright/default.nix
@@ -1,0 +1,19 @@
+{ pkgs, lib, ... }:
+{
+  id = "pyright";
+  name = "pyright LSP";
+  displayVersion = pkgs.pyright.version;
+  description = ''
+    Pyright is a full-featured, standards-based static type checker for Python. It is designed for high performance and can be used with large Python source bases.
+  '';
+  replit.dev.languageServers.pyright = {
+    name = "pyright";
+    displayVersion = pkgs.pyright.version;
+    language = "python3";
+    start = "${pkgs.pyright}/bin/pyright-langserver --stdio";
+  };
+
+  replit.env = {
+    PATH = "${pkgs.pyright}/bin";
+  };
+}

--- a/pkgs/modules/python-base/default.nix
+++ b/pkgs/modules/python-base/default.nix
@@ -16,6 +16,10 @@ let
 
   sitecustomize = pkgs.callPackage ../python/sitecustomize.nix { };
 
+  binary-wrapped-python = pkgs.callPackage ../../python-wrapped {
+    inherit pkgs python python-ld-library-path;
+  };
+
 in
 {
   id = "python-base-${pythonVersion}";
@@ -28,6 +32,7 @@ in
   '';
 
   replit.packages = [
+    binary-wrapped-python
     pypkgs.pip
     pkgs.poetry
     pkgs.uv

--- a/pkgs/modules/python-base/default.nix
+++ b/pkgs/modules/python-base/default.nix
@@ -1,0 +1,68 @@
+{ python, pypkgs }:
+{ pkgs-unstable, pkgs-23_05, lib, ... }:
+let
+  pythonVersion = lib.versions.majorMinor python.version;
+
+  pkgs = pkgs-unstable;
+
+  pylibs-dir = ".pythonlibs";
+
+  userbase = "$REPL_HOME/${pylibs-dir}";
+
+  pythonUtils = import ../../python-utils {
+    inherit pkgs python pypkgs;
+  };
+  python-ld-library-path = pythonUtils.python-ld-library-path;
+
+  sitecustomize = pkgs.callPackage ../python/sitecustomize.nix { };
+
+in
+{
+  id = "python-base-${pythonVersion}";
+  name = "Python Tools";
+  displayVersion = pythonVersion;
+  description = ''
+    Basic module for Python. Includes the interpreter and basic Replit
+    configuration but nothing else. This may be combined with the
+    pyright-extended module.
+  '';
+
+  replit.packages = [
+    pypkgs.pip
+    pkgs.poetry
+    pkgs.uv
+  ];
+
+  replit.runners.python = {
+    name = "Python ${pythonVersion}";
+    displayVersion = python.version;
+    fileParam = true;
+    language = "python3";
+    start = "${python}/bin/python3 $file";
+    defaultEntrypoints = [ "main.py" "app.py" "run.py" ];
+  };
+
+  replit.dev.packagers.upmPython = {
+    name = "Python packager";
+    language = "python3";
+    ignoredPackages = [ "unit_tests" ];
+    ignoredPaths = [ pylibs-dir ];
+    features = {
+      packageSearch = true;
+      guessImports = true;
+      enabledForHosting = false;
+    };
+  };
+
+  replit.env = {
+    PYTHONUSERBASE = userbase;
+    PYTHONPATH = "${sitecustomize}";
+    REPLIT_PYTHONPATH = "${userbase}/${python.sitePackages}:${pypkgs.setuptools}/${python.sitePackages}";
+    UV_PROJECT_ENVIRONMENT = "$REPL_HOME/.pythonlibs";
+    # Even though it is set-default in the wrapper, add it to the
+    # environment too, so that when someone wants to override it,
+    # they can keep the defaults if they want to.
+    PYTHON_LD_LIBRARY_PATH = python-ld-library-path;
+    PATH = "${userbase}/bin";
+  };
+}

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -139,7 +139,7 @@ in
   };
 
   replit.dev.packagers.upmPython = {
-    name = "Python packager (poetry, pip)";
+    name = "Python packager";
     language = "python3";
     ignoredPackages = [ "unit_tests" ];
     ignoredPaths = [ pylibs-dir ];

--- a/pkgs/modules/ruff/default.nix
+++ b/pkgs/modules/ruff/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, lib, ... }:
+{
+  id = "ruff";
+  name = "ruff LSP";
+  displayVersion = pkgs.ruff.version;
+  description = ''
+    A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code formatter, written in Rust.
+
+    Ruff can be used to replace Flake8 (plus dozens of plugins), Black, isort, pyupgrade, and more, all while executing tens or hundreds of times faster than any individual tool.
+  '';
+  replit.dev.languageServers.ruff = {
+    name = "ruff";
+    displayVersion = pkgs.ruff.version;
+    language = "python3";
+    start = "${pkgs.ruff}/bin/ruff server";
+  };
+
+  replit.env = {
+    PATH = "${pkgs.ruff}/bin";
+  };
+}


### PR DESCRIPTION
Why
===

It's currently very challenging to iterate on python modules, as well as testing replacing `pyright-extended` with pyright+ruff. In support of that, let's just describe these as different modules.

These modules are not intended to be used directly, instead they will be toggled on/off via feature flag during env building in pid1.

What changed
============

- Adding `python-base-*`, `ruff`, and `pyright` modules

Test plan
=========

Compose these modules together and test the workspace. Ensure package installs are detected by pyright/ruff.

Rollout
=======

- [x] This is fully backward and forward compatible
