### PR TITLE
Binary python wrapper

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,5 +1,8 @@
 entrypoint = "pkgs/default.nix"
 modules = []
 
+[env]
+HISTFILE = "$REPL_HOME/.cache/.bash_history"
+
 [nix]
 channel = "stable-23_11"

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -94,7 +94,7 @@ let
 
   poetry-wrapper = pythonWrapper { bin = "${poetry}/bin/poetry"; name = "poetry"; };
 
-  python-wrapped = pkgs.callPackage ../../python-wrapped {
+  binary-wrapped-python = pkgs.callPackage ../../python-wrapped {
     inherit pkgs python python-ld-library-path;
   };
 
@@ -114,7 +114,7 @@ in
   '';
 
   replit.packages = [
-    python-wrapped
+    binary-wrapped-python
     pip-wrapper
     poetry-wrapper
     pkgs.uv

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -165,7 +165,7 @@ in
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.
-    PYTHON_LD_LIBRARY_PATH = python-ld-library-path;
+    REPLIT_PYTHON_LD_LIBRARY_PATH = python-ld-library-path;
     PATH = "${userbase}/bin";
   };
 }

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -94,6 +94,10 @@ let
 
   poetry-wrapper = pythonWrapper { bin = "${poetry}/bin/poetry"; name = "poetry"; };
 
+  python-wrapped = pkgs.callPackage ../../python-wrapped {
+    inherit pkgs python;
+  };
+
   pyright-extended = pkgs.callPackage ../../pyright-extended {
     yapf = pypkgs.yapf;
   };
@@ -110,7 +114,7 @@ in
   '';
 
   replit.packages = [
-    python3-wrapper
+    python-wrapped
     pip-wrapper
     poetry-wrapper
     pkgs.uv

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -95,7 +95,7 @@ let
   poetry-wrapper = pythonWrapper { bin = "${poetry}/bin/poetry"; name = "poetry"; };
 
   python-wrapped = pkgs.callPackage ../../python-wrapped {
-    inherit pkgs python;
+    inherit pkgs python python-ld-library-path;
   };
 
   pyright-extended = pkgs.callPackage ../../pyright-extended {

--- a/pkgs/python-wrapped/default.nix
+++ b/pkgs/python-wrapped/default.nix
@@ -19,14 +19,14 @@ pkgs.buildGoModule rec {
     '';
     homepage = "https://replit.com";
     license = licenses.mit;
-    mainProgram = "python-wrapped";
+    mainProgram = "python";
   };
 
   postInstall = ''
     cd $out/bin
-    mv python-wrapper .python-wrapper
-    ln -s .python-wrapper python
-    ln -s .python-wrapper python${pkgs.lib.versions.major python.version}
-    ln -s .python-wrapper python${pkgs.lib.versions.majorMinor python.version}
+    mv python-wrapper .python-wrapped
+    ln -s .python-wrapped python
+    ln -s .python-wrapped python${pkgs.lib.versions.major python.version}
+    ln -s .python-wrapped python${pkgs.lib.versions.majorMinor python.version}
   '';
 }

--- a/pkgs/python-wrapped/default.nix
+++ b/pkgs/python-wrapped/default.nix
@@ -1,0 +1,31 @@
+{ pkgs, python }:
+pkgs.buildGoModule rec {
+  pname = "python-wrapped";
+  version = "0.1.0";
+
+  src = ./.;
+
+  ldflags = [
+    "-X main.PythonExePath=${python}/bin/python"
+  ];
+
+  vendorHash = null;
+
+  meta = with pkgs.lib; {
+    description = ''
+      A replit proxy to Python which interpolates some critical bits
+      of the environment at runtime
+    '';
+    homepage = "https://replit.com";
+    license = licenses.mit;
+    mainProgram = "python-wrapped";
+  };
+
+  postInstall = ''
+    cd $out/bin
+    mv python-wrapper .python-wrapper
+    ln -s .python-wrapper python
+    ln -s .python-wrapper python${pkgs.lib.versions.major python.version}
+    ln -s .python-wrapper python${pkgs.lib.versions.majorMinor python.version}
+  '';
+}

--- a/pkgs/python-wrapped/default.nix
+++ b/pkgs/python-wrapped/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, python }:
+{ pkgs, python, python-ld-library-path }:
 pkgs.buildGoModule rec {
   pname = "python-wrapped";
   version = "0.1.0";
@@ -6,6 +6,7 @@ pkgs.buildGoModule rec {
   src = ./.;
 
   ldflags = [
+    "-X main.ReplitPythonLdLibraryPath=${python-ld-library-path}"
     "-X main.PythonExePath=${python}/bin/python"
   ];
 

--- a/pkgs/python-wrapped/go.mod
+++ b/pkgs/python-wrapped/go.mod
@@ -1,0 +1,3 @@
+module github.com/replit/python-wrapper
+
+go 1.21.9

--- a/pkgs/python-wrapped/main.go
+++ b/pkgs/python-wrapped/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"syscall"
+)
+
+var PythonExePath string
+
+func main() {
+	if ldAudit := os.Getenv("REPLIT_LD_AUDIT"); ldAudit != "" {
+		os.Setenv("LD_AUDIT", ldAudit)
+	}
+	os.Unsetenv("PYTHONNOUSERSITE")
+
+	ldLibraryPath := []string{}
+	for _, key := range []string{
+		"REPLIT_LD_LIBRARY_PATH",
+		"LD_LIBRARY_PATH",
+		"REPLIT_PYTHON_LD_LIBRARY_PATH",
+	} {
+		if val, ok := os.LookupEnv(key); ok {
+			ldLibraryPath = append(ldLibraryPath, val)
+		}
+	}
+
+	if len(ldLibraryPath) > 0 {
+		os.Setenv("LD_LIBRARY_PATH", strings.Join(ldLibraryPath, ":"))
+	}
+
+
+	if err := syscall.Exec(PythonExePath, os.Args, os.Environ()); err != nil {
+		panic(err)
+	}
+}

--- a/pkgs/python-wrapped/main.go
+++ b/pkgs/python-wrapped/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 var PythonExePath string
+var ReplitPythonLdLibraryPath string
 
 func main() {
 	if ldAudit := os.Getenv("REPLIT_LD_AUDIT"); ldAudit != "" {
@@ -18,12 +19,13 @@ func main() {
 	for _, key := range []string{
 		"REPLIT_LD_LIBRARY_PATH",
 		"LD_LIBRARY_PATH",
-		"REPLIT_PYTHON_LD_LIBRARY_PATH",
 	} {
 		if val, ok := os.LookupEnv(key); ok {
 			ldLibraryPath = append(ldLibraryPath, val)
 		}
 	}
+
+	ldLibraryPath = append(ldLibraryPath, ReplitPythonLdLibraryPath)
 
 	if len(ldLibraryPath) > 0 {
 		os.Setenv("LD_LIBRARY_PATH", strings.Join(ldLibraryPath, ":"))

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,6 @@
+{ pkgs }: {
+  deps = [
+    pkgs.unixtools.xxd
+    pkgs.jq
+  ];
+}


### PR DESCRIPTION
Why
===

`uv` uses some internal tooling (similar to `python -m site`) to determine the python interpreter to use. By using a custom python wrapper, we can get a little more control of that environment and hopefully convince uv to use our wrapper as the canonical python version, bringing in `LD_AUDIT` with a tight scope until https://github.com/jemalloc/jemalloc/issues/2472 has been resolved.

What changed
============

- Add a Go binary, `.python-wrapped`, with relevant symlinks
- Add some miscellaneous quality of life improvements to the Repl environment for this repo

Test plan
=========

`upm -l python3-uv add requests` should create a `.pythonlibs` where `bin/python` points to our `.python-wrapped` binary.

`upm add streamlit`, followed by
`python -c 'import numpy'`
should import cleanly, and
`nix run nixpkgs#python312 -- -c 'import numpy'`
should fail because `LD_AUDIT` was not present.

Rollout
=======

uv is currently blocked, so if there's a need to roll back we should also roll back `flag-agent-uv` if applicable.

- [x] This is fully backward and forward compatible
