### PR TITLE
Moving py3.8 over to historical modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,26 +92,6 @@
           };
         };
 
-      } // rec {
-        python38 = pkgs.python310.override {
-          sourceVersion = {
-            major = "3";
-            minor = "8";
-            patch = "18";
-            suffix = "";
-          };
-          hash = "sha256-P/txzTSaMmunsvrcfn34a6V33ZxJF+UqhAGtvadAXj8=";
-        };
-
-
-        python38Full = python38.override {
-          self = python38Full;
-          pythonAttr = "python38Full";
-          bluezSupport = true;
-          x11Support = true;
-        };
-
-        python38Packages = python38Full.pkgs;
       };
       formatter.x86_64-linux = pkgs.nixpkgs-fmt;
       packages.x86_64-linux = import ./pkgs {

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -163,6 +163,13 @@ let
       };
     }
     {
+      moduleId = "python-3.8";
+      commit = "76ae6535d7d60e767fe9d54902400229ca0b9448";
+      overrides = {
+        displayVersion = "3.8";
+      };
+    }
+    {
       moduleId = "r-4.2";
       commit = "1e1bb663068482cdb7c04bf585daed00205c0140";
       overrides = {

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -15,10 +15,6 @@ let
 
   modulesList = [
     (import ./python {
-      python = pkgs.python38Full;
-      pypkgs = pkgs.python38Packages;
-    })
-    (import ./python {
       python = pkgs.python39Full;
       pypkgs = pkgs.python39Packages;
     })

--- a/pkgs/poetry/poetry-py3.8.nix
+++ b/pkgs/poetry/poetry-py3.8.nix
@@ -1,7 +1,0 @@
-{ pkgs, python, pypkgs }:
-pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.5";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.5-python-3.8.18-bundle.tgz;
-  sha256 = "sha256:0iaw6iyj5skbi2vs5sfcbwlncxjfq3i2k1nnfvrdc02ybbmpbl3q";
-  inherit python pypkgs;
-}


### PR DESCRIPTION
Why
===

In preparation for next month's EOL, opening an intent-to-deprecate PR so we can stop building python3.8.

Sphinx [is not supported for python 3.8 and below](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/sphinx/default.nix#L45), and while I cannot find it at this point, there is a long thread of people talking about how it's not worth trying to backport since 3.8 is so close to EOL.

What changed
============

Moving the `python-3.8` module over to historical modules, deleting the module definition.

Test plan
=========

It should be possible to switch from our wrapped pip over to stock pip, which has been blocked by this sphinx issue.

Rollout
=======

- [x] This is fully backward and forward compatible
