### PR TITLE
[python] Add more uv options

### DIFF
--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -166,6 +166,8 @@ in
     PYTHONPATH = "${sitecustomize}:${pip.pip}/${python.sitePackages}";
     REPLIT_PYTHONPATH = "${userbase}/${python.sitePackages}:${pypkgs.setuptools}/${python.sitePackages}";
     UV_PROJECT_ENVIRONMENT = "$REPL_HOME/.pythonlibs";
+    UV_PYTHON_DOWNLOADS = "never";
+    UV_PYTHON_PREFERENCE = "only-system";
     # Even though it is set-default in the wrapper, add it to the
     # environment too, so that when someone wants to override it,
     # they can keep the defaults if they want to.


### PR DESCRIPTION
What changed and Why
===

- Proactively setting some more envvars for uv to influence when uv goes out to get more python runtimes

Test plan
=========

N/a

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
