### PR TITLE
Bumping pyright-extended

### DIFF
--- a/pkgs/pyright-extended/default.nix
+++ b/pkgs/pyright-extended/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, yapf, ... }:
 let
-  version = "2.0.11";
+  version = "2.0.12";
 in
 pkgs.stdenvNoCC.mkDerivation rec {
   pname = "pyright-extended";
@@ -8,7 +8,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
 
   src = pkgs.fetchurl {
     url = "https://registry.npmjs.org/@replit/pyright-extended/-/pyright-extended-${version}.tgz";
-    hash = "sha256-bIHx9dCY8lOBsyoRm3WP7Vxt0VYMkYlO7wUeCTEGY10=";
+    hash = "sha256-IZcw5C1Kbpas3HDHyECdFvI0F8hF/Um3+WtCEyCo5Ik=";
   };
 
   binPath = lib.makeBinPath [


### PR DESCRIPTION
Why
===

- File limit reached when traversing `.cache/uv`

What changed
============

- Ignored that directory

Test plan
=========

Manual testing

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
