### PR TITLE
bug: Removing debugpy override

### DIFF
--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -32,21 +32,8 @@ let
     destination = "/config.toml";
   };
 
-  debugpy = pypkgs.debugpy.overridePythonAttrs
-    (old: rec {
-      disabled = false;
-      version = "1.8.0";
-      src = pkgs.fetchFromGitHub {
-        owner = "microsoft";
-        repo = "debugpy";
-        rev = "refs/tags/v${version}";
-        hash = "sha256-FW1RDmj4sDBS0q08C82ErUd16ofxJxgVaxfykn/wVBA=";
-      };
-      doCheck = false;
-    });
-
   dapPython = pkgs.callPackage ../../dapPython {
-    inherit pkgs python pypkgs debugpy;
+    inherit pkgs python pypkgs;
   };
 
   debuggerConfig = {


### PR DESCRIPTION
Why
===

Looks like debugpy got bumped upstream to a version whose nixpkgs patches no longer apply to our pinned 1.8.0 version. Looks like https://github.com/replit/nixmodules/pull/87 had pinned due to issues with Python 3.11, but googling around suggests this is no longer an issue.

What changed
============

- Removed debugpy override

Test plan
=========

- Manual testing, adding breakpoints, etc.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
