### PR TITLE
chore/fix the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,3 @@ or
 ```
 nix build .#custom-bundle-squashfs
 ```
-
-## Adding modules to historical modules
-
-pkgs/historical-modules/default.nix provides a list of modules that are still active but we no longer maintain and build.
-
-To add a new historical module, you need to pick a commit of the nix modules repo that has that module in it. This commit's src code will be used to build this module.

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1728455642,
-        "narHash": "sha256-abYGwrL6ak5sBRqwPh+V3CPJ6Pa89p378t51b7BO1lE=",
+        "lastModified": 1728282832,
+        "narHash": "sha256-I7AbcwGggf+CHqpyd/9PiAjpIBGTGx5woYHqtwxaV7I=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "3b47535a5c782e4f4ad59cd4bdb23636b6926e03",
+        "rev": "1ec71be1f4b8f3105c5d38da339cb061fefc43f4",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1726716330,
-        "narHash": "sha256-mIuOP4I51eFLquRaxMKx67pHmhatZrcVPjfHL98v/M8=",
+        "lastModified": 1723948777,
+        "narHash": "sha256-rX14joTzvRUiCfmCT0LUMV3Mxi79VJANcKB/kkh7Qys=",
         "owner": "oxalica",
         "repo": "nil",
-        "rev": "c8e8ce72442a164d89d3fdeaae0bcc405f8c015a",
+        "rev": "4f3081d1f10bb61f197b780e67f426e53f818691",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1728409405,
-        "narHash": "sha256-kk530XBUGDpt0DQbyUb3yDpSddPqF9PA5KTo/nsmmg0=",
+        "lastModified": 1725503534,
+        "narHash": "sha256-hd1eRyPtTkRnAPYpnEfzugQwAifVYMmOR3z+MTTSw+g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1366d1af8f58325602280e43ed6233849fb92216",
+        "rev": "fcb54ddcc974cff59bdfb7c1ac9e080299763d2d",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728386838,
-        "narHash": "sha256-Lk64EoJkvp3WMGVJK3CR1TYcNghX0/BqHPLW5zdvmLE=",
+        "lastModified": 1728249780,
+        "narHash": "sha256-J269DvCI5dzBmPrXhAAtj566qt0b22TJtF3TIK+tMsI=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "efaf8bd5de34e2f47bd57425b83e0c7974902176",
+        "rev": "2b750da1a1a2c1d2c70896108d7096089842d877",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726453838,
-        "narHash": "sha256-pupsow4L79SBfNwT6vh/5RAbVZuhngIA0RTCZksXmZY=",
+        "lastModified": 1722824458,
+        "narHash": "sha256-2k3/geD5Yh8JT1nrGaRycje5kB0DkvQA/OUZoel1bIU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ca2e79cd22625d214b8437c2c4080ce79bd9f7d2",
+        "rev": "a8a937c304e62a5098c6276c9cdf65c19a43b1a5",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726178208,
-        "narHash": "sha256-WppAdNVzhB79d4BtkzpqDBruw/XhGtw7Ra6qqHE4vPs=",
+        "lastModified": 1724710535,
+        "narHash": "sha256-iw6I7yhXBbanIUi3VHXIveXDXF9BrakwAflQ76/pxDg=",
         "owner": "replit",
         "repo": "ztoc-rs",
-        "rev": "94a02a9a2e51dff2ecb6791e27f7ad5983ba9a28",
+        "rev": "977661eba22f474a9fddd1ff1fcd63b6acadc902",
         "type": "github"
       },
       "original": {

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -79,15 +79,6 @@ let
       };
     }
     {
-      moduleId = "go-1.21";
-      commit = "00fa9ccbbd30ded08a8ab54259490102f21905b7";
-      overrides = {
-        # /nix/store/vjdwykj1l3hkr5hzjdr4m1m2mq8vxj0i-replit-module-go-1.21
-        # .runners["go-run"].displayVersion = "1.21.13";
-        displayVersion = "1.21";
-      };
-    }
-    {
       moduleId = "haskell-ghc9.0";
       commit = "c48c43c6c698223ed3ce2abc5a2d708735a77d5b";
       overrides = {
@@ -203,16 +194,11 @@ let
   moduleFromHistory = { moduleId, commit, deployment ? false, overrides }:
     let
       flake = getFlake "github:replit/nixmodules/${commit}";
-      flakeMods =
-        if pkgs.lib.hasAttr "activeModules" flake then
-          flake.activeModules
-        else
-          flake.modules;
       module =
         if deployment then
-          (flake.deploymentModules or flakeMods).${moduleId}
+          (flake.deploymentModules or flake.modules).${moduleId}
         else
-          flakeMods.${moduleId};
+          flake.modules.${moduleId};
     in
     pkgs.stdenvNoCC.mkDerivation {
       name = "replit-module-${moduleId}";

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -64,16 +64,9 @@ let
     (import ./nodejs-with-prybar)
 
     (import ./go {
-      go = pkgs.go_1_22;
+      go = pkgs.go_1_21;
       gopls = pkgs.gopls.override {
-        buildGoModule = pkgs.buildGo122Module;
-      };
-    })
-
-    (import ./go {
-      go = pkgs.go_1_23;
-      gopls = pkgs.gopls.override {
-        buildGoModule = pkgs.buildGo123Module;
+        buildGoModule = pkgs.buildGo121Module;
       };
     })
 

--- a/pkgs/modules/docker/default.nix
+++ b/pkgs/modules/docker/default.nix
@@ -4,7 +4,7 @@ let
 
   configFiles = pkgs.copyPathToStore ./etc;
 
-  replit-runc = pkgs.buildGo123Module {
+  replit-runc = pkgs.buildGo121Module {
     pname = "replit-runc";
     version = "1.1.9+replit";
 
@@ -30,7 +30,7 @@ let
     '';
   };
 
-  replit-containerd = pkgs.buildGo123Module {
+  replit-containerd = pkgs.buildGo121Module {
     pname = "replit-containerd";
     version = "1.7.5+replit";
 
@@ -65,7 +65,7 @@ let
     replitShimRunc = replit-containerd;
   };
 
-  replit-buildkit = pkgs.buildGo123Module {
+  replit-buildkit = pkgs.buildGo121Module {
     pname = "replit-buildkit";
     version = "v0.13.0-beta1+replit";
 
@@ -99,9 +99,10 @@ let
     replitShimRunc = replit-containerd;
   };
 
+  mobyGoPackagePath = "github.com/docker/docker";
   mobyVersion = "24.0.7+replit";
 
-  replit-moby = pkgs.buildGoModule {
+  replit-moby = pkgs.buildGoPackage {
     pname = "replit-moby";
     version = mobyVersion;
 
@@ -112,7 +113,7 @@ let
       sha256 = "sha256-VUgsclXkoHHNT+GgYL7qiCV/4V3P9RZrT9BegMVYaRU=";
     };
 
-    vendorHash = null;
+    goPackagePath = mobyGoPackagePath;
 
     nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config pkgs.go pkgs.libtool ];
 
@@ -132,7 +133,7 @@ let
     buildPhase = ''
       export GOCACHE="$TMPDIR/go-cache"
       # build engine
-      cd ./go/src
+      cd ./go/src/${mobyGoPackagePath}
       export AUTO_GOPATH=1
       export DOCKER_GITCOMMIT="v${mobyVersion}"
       export VERSION="${mobyVersion}"
@@ -141,7 +142,7 @@ let
     '';
 
     postInstall = ''
-      cd ./go/src
+      cd ./go/src/${mobyGoPackagePath}
       install -Dm755 ./bundles/dynbinary-daemon/dockerd $out/libexec/docker/replit-dockerd
 
       makeWrapper $out/libexec/docker/replit-dockerd $out/bin/replit-dockerd \

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -32,8 +32,21 @@ let
     destination = "/config.toml";
   };
 
+  debugpy = pypkgs.debugpy.overridePythonAttrs
+    (old: rec {
+      disabled = false;
+      version = "1.8.0";
+      src = pkgs.fetchFromGitHub {
+        owner = "microsoft";
+        repo = "debugpy";
+        rev = "refs/tags/v${version}";
+        hash = "sha256-FW1RDmj4sDBS0q08C82ErUd16ofxJxgVaxfykn/wVBA=";
+      };
+      doCheck = false;
+    });
+
   dapPython = pkgs.callPackage ../../dapPython {
-    inherit pkgs python pypkgs;
+    inherit pkgs python pypkgs debugpy;
   };
 
   debuggerConfig = {


### PR DESCRIPTION
Why
===

Just reverting for now so we can get the pyright-extended upgrade, helping `uv` users. We can try to land this change again next week.

What changed
============

Reverting #405 and #403

Test plan
=========

Does the new nixmodules build?

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
