### PR TITLE
Avoid incorrectly setting LD_LIBRARY_PATH

### DIFF
--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -32,12 +32,8 @@ let
       ldLibraryPathConvertWrapper = pkgs.writeShellApplication {
         inherit name;
         text = ''
-          if test "''${REPLIT_RTLD_LOADER:-}" = "1" && test "''${REPLIT_NIX_CHANNEL:-}" != "legacy"
+          if test "''${REPLIT_NIX_CHANNEL:-}" = "legacy"
           then
-            # activate RTLD loader!
-            export LD_AUDIT="${pkgs.replit-rtld-loader}/rtld_loader.so"
-            export REPLIT_LD_LIBRARY_PATH=${python-ld-library-path}:''${REPLIT_LD_LIBRARY_PATH:-}
-          else
             export LD_LIBRARY_PATH=${python-ld-library-path}
             if [ -n "''${PYTHON_LD_LIBRARY_PATH-}" ]; then
               export LD_LIBRARY_PATH=''${PYTHON_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
@@ -45,6 +41,10 @@ let
             if [ -n "''${REPLIT_LD_LIBRARY_PATH-}" ]; then
               export LD_LIBRARY_PATH=''${REPLIT_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
             fi
+          else
+            # activate RTLD loader!
+            export LD_AUDIT="${pkgs.replit-rtld-loader}/rtld_loader.so"
+            export REPLIT_LD_LIBRARY_PATH=${python-ld-library-path}:''${REPLIT_LD_LIBRARY_PATH:-}
           fi
           exec "${bin}" "$@"
         '';

--- a/pkgs/python-utils/default.nix
+++ b/pkgs/python-utils/default.nix
@@ -32,7 +32,7 @@ let
       ldLibraryPathConvertWrapper = pkgs.writeShellApplication {
         inherit name;
         text = ''
-          if test "''${REPLIT_NIX_CHANNEL:-}" = "legacy"
+          if test "''${REPLIT_NIX_CHANNEL:-}" = "legacy" || test "''${REPLIT_NIX_CHANNEL:-}" = "stable-21_11"
           then
             export LD_LIBRARY_PATH=${python-ld-library-path}
             if [ -n "''${PYTHON_LD_LIBRARY_PATH-}" ]; then

--- a/pkgs/python-wrapped/main.go
+++ b/pkgs/python-wrapped/main.go
@@ -9,12 +9,8 @@ import (
 var PythonExePath string
 var ReplitPythonLdLibraryPath string
 
-func main() {
-	if ldAudit := os.Getenv("REPLIT_LD_AUDIT"); ldAudit != "" {
-		os.Setenv("LD_AUDIT", ldAudit)
-	}
-	os.Unsetenv("PYTHONNOUSERSITE")
-
+// Set up environment for legacy nixpkgs
+func legacy() {
 	ldLibraryPath := []string{}
 	for _, key := range []string{
 		"REPLIT_LD_LIBRARY_PATH",
@@ -30,7 +26,26 @@ func main() {
 	if len(ldLibraryPath) > 0 {
 		os.Setenv("LD_LIBRARY_PATH", strings.Join(ldLibraryPath, ":"))
 	}
+}
 
+// Set up environment for non-legacy nixpkgs
+func modern() {
+	if ldAudit := os.Getenv("REPLIT_LD_AUDIT"); ldAudit != "" {
+		os.Setenv("LD_AUDIT", ldAudit)
+	}
+	if val, ok := os.LookupEnv("REPLIT_LD_LIBRARY_PATH"); ok && val != "" {
+		os.Setenv("REPLIT_LD_LIBRARY_PATH", strings.Join([]string{ReplitPythonLdLibraryPath, val}, ":"))
+	}
+}
+
+func main() {
+	os.Unsetenv("PYTHONNOUSERSITE")
+
+	if val, ok := os.LookupEnv("REPLIT_NIX_CHANNEL"); !ok || val == "legacy" || val == "" {
+		legacy()
+	} else {
+		modern()
+	}
 
 	if err := syscall.Exec(PythonExePath, os.Args, os.Environ()); err != nil {
 		panic(err)

--- a/pkgs/python-wrapped/main.go
+++ b/pkgs/python-wrapped/main.go
@@ -38,13 +38,18 @@ func modern() {
 	}
 }
 
+// returns whether a Nix channel works with RTLD loader
+func channelWorksWithRtldLoader(channel string) bool {
+	return channel != "" && channel != "legacy" && channel != "stable-21_11"
+}
+
 func main() {
 	os.Unsetenv("PYTHONNOUSERSITE")
 
-	if val, ok := os.LookupEnv("REPLIT_NIX_CHANNEL"); !ok || val == "legacy" || val == "" {
-		legacy()
-	} else {
+	if val, ok := os.LookupEnv("REPLIT_NIX_CHANNEL"); ok && channelWorksWithRtldLoader(val) {
 		modern()
+	} else {
+		legacy()
 	}
 
 	if err := syscall.Exec(PythonExePath, os.Args, os.Environ()); err != nil {


### PR DESCRIPTION
Why
===

When I split out the binary Python wrapper, I misread that `LD_LIBRARY_PATH` should be set in all cases, not just the legacy case.

What changed
============

Increasing readability and addressing the underlying bug. Also removed the `REPLIT_RTLD_LOADER = "1"` check as the flag has been rolled out and burned in, and is unlikely to get rolled back.

Test plan
=========

Attempt to fork and run one of the test cases supplied by support.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
