### PR TITLE
add basic postgresql module

### DIFF
--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -90,6 +90,7 @@ let
     (import ./lua)
     (import ./nix)
     (import ./php)
+    (import ./postgresql)
     (import ./qbasic)
     (import ./R)
     (import ./replit)

--- a/pkgs/modules/postgresql/default.nix
+++ b/pkgs/modules/postgresql/default.nix
@@ -1,0 +1,17 @@
+{ pkgs, lib, ... }:
+let
+  postgresql = pkgs.postgresql_16;
+  postgresql-version = lib.versions.major postgresql.version;
+in
+{
+  id = "postgresql-${postgresql-version}";
+  name = "Postgresql Tools";
+  displayVersion = postgresql-version;
+  description = ''
+    Tools for working with Postgresql databases.
+  '';
+
+  replit.packages = [
+    postgresql
+  ];
+}


### PR DESCRIPTION
Why
===

_Describe what prompted you to make this change, link relevant resources_

When using old nix channels, postgres versions can change and cause incompatability with replit's postgres db.

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Make postgres a nixmodule to pin version across different repls.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Test that nixmodule works as intended.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
