### PR TITLE
[debugpy] Reflow dap-python to remove override

### DIFF
--- a/pkgs/dapPython/default.nix
+++ b/pkgs/dapPython/default.nix
@@ -1,62 +1,24 @@
 { pkgs, python, pypkgs, debugpy ? pypkgs.debugpy }:
 
-pypkgs.buildPythonPackage rec {
-  pname = "replit-python-dap-wrapper";
+let
+  pythonVersion = pkgs.lib.versions.majorMinor python.version;
+in
+pkgs.stdenv.mkDerivation {
+  name = "dap-python";
   version = debugpy.version;
-
-  src = ./.;
-
   propagatedBuildInputs = [
-    debugpy
+    (python.withPackages (_: [
+      debugpy
+    ]))
   ];
-
-  postInstall = ''
+  dontUnpack = true;
+  installPhase = ''
     mkdir -p $out/bin
-    
-    cat<<EOF > $out/bin/dap-python
-    #!${python}/bin/python3
-    """A small wrapper around debugpy's cli.
-
-    This wrapper is roughly equivalent to:
-
-        python3 -m debugpy --listen localhost:0 --wait-for-client "$@"
-
-    with the added twist that it reports the port used back through fd 3.
-    """
-
-    import os
-    import os.path
-    import sys
-    import runpy
-
-    import debugpy
-    import debugpy.server
-
-
-    def _main() -> None:
-        if len(sys.argv) < 2:
-            print(f'Usage: {sys.argv[0]} <script> [args...]', file=sys.stderr)
-            sys.exit(1)
-        # This process' stdout/stderr are already used to deliver
-        # the debuggee's stdout/stderr. We need to deliver this
-        # information out of band, through fd 3.
-        with os.fdopen(3, 'w') as port_fd:
-            port_fd.write(str(debugpy.listen(('localhost', 0))[1]))
-        debugpy.wait_for_client()
-        # The first argument to this script is this script itself, so we need to
-        # remove it. Otherwise `runpy.run_path` below will change `sys.argv[0]` to
-        # the script being run, which would result in the script name being
-        # duplicate.
-        sys.argv.pop(0)
-        target_as_str = sys.argv[0]
-        dir = os.path.dirname(os.path.abspath(target_as_str))
-        sys.path.insert(0, os.getcwd())
-        runpy.run_path(target_as_str, run_name="__main__")
-
-
-    if __name__ == '__main__':
-        _main()
-    EOF
+    cp ${./wrapper.py} $out/bin/dap-python
     chmod +x $out/bin/dap-python
+
+    substituteInPlace $out/bin/dap-python \
+        --replace "@python-bin@" "${python}/bin/python3" \
+        --replace "@debugpy-path@" "${debugpy.out}/lib/python${pythonVersion}/site-packages"
   '';
 }

--- a/pkgs/dapPython/setup.py
+++ b/pkgs/dapPython/setup.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup(
-        name="replit-python-dap-wrapper"
-    )

--- a/pkgs/dapPython/wrapper.py
+++ b/pkgs/dapPython/wrapper.py
@@ -1,0 +1,46 @@
+#!@python-bin@
+"""A small wrapper around debugpy's cli.
+
+This wrapper is roughly equivalent to:
+
+  python3 -m debugpy --listen localhost:0 --wait-for-client "$@"
+
+with the added twist that it reports the port used back through fd 3.
+"""
+
+import os
+import os.path
+import sys
+import runpy
+
+# Permit interpolated path to be sensibly replaced.
+for idx, path in enumerate("@debugpy-path@".split(":")):
+    sys.path.insert(idx, path)
+
+import debugpy
+import debugpy.server
+
+
+def _main() -> None:
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} <script> [args...]', file=sys.stderr)
+        sys.exit(1)
+    # This process' stdout/stderr are already used to deliver
+    # the debuggee's stdout/stderr. We need to deliver this
+    # information out of band, through fd 3.
+    with os.fdopen(3, 'w') as port_fd:
+        port_fd.write(str(debugpy.listen(('localhost', 0))[1]))
+    debugpy.wait_for_client()
+    # The first argument to this script is this script itself, so we need to
+    # remove it. Otherwise `runpy.run_path` below will change `sys.argv[0]` to
+    # the script being run, which would result in the script name being
+    # duplicate.
+    sys.argv.pop(0)
+    target_as_str = sys.argv[0]
+    dir = os.path.dirname(os.path.abspath(target_as_str))
+    sys.path.insert(0, os.getcwd())
+    runpy.run_path(target_as_str, run_name="__main__")
+
+
+if __name__ == '__main__':
+    _main()

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -32,21 +32,8 @@ let
     destination = "/config.toml";
   };
 
-  debugpy = pypkgs.debugpy.overridePythonAttrs
-    (old: rec {
-      disabled = false;
-      version = "1.8.0";
-      src = pkgs.fetchFromGitHub {
-        owner = "microsoft";
-        repo = "debugpy";
-        rev = "refs/tags/v${version}";
-        hash = "sha256-FW1RDmj4sDBS0q08C82ErUd16ofxJxgVaxfykn/wVBA=";
-      };
-      doCheck = false;
-    });
-
   dapPython = pkgs.callPackage ../../dapPython {
-    inherit pkgs python pypkgs debugpy;
+    inherit pkgs python pypkgs;
   };
 
   debuggerConfig = {


### PR DESCRIPTION
Why
===

We cannot upgrade nixpkgs-unstable.

What changed
============

Removing debugpy override to get us into a position where we can upgrade nixpkgs-unstable without getting patch errors.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
