### PR TITLE
Correctly set the bun 1.0 display version

### DIFF
--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -14,7 +14,7 @@ let
       overrides = {
         # /nix/store/cvz36f39793v9l361ibfxznjjmk4jpd6-replit-module-bun-1.0
         # .runners["package.json"].displayVersion = "1.0.23";
-        displayVersion = "1.0";
+        displayVersion = "1.0.23";
       };
     }
     {

--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -14,7 +14,7 @@ let
       overrides = {
         # /nix/store/cvz36f39793v9l361ibfxznjjmk4jpd6-replit-module-bun-1.0
         # .runners["package.json"].displayVersion = "1.0.23";
-        displayVersion = "1";
+        displayVersion = "1.0";
       };
     }
     {


### PR DESCRIPTION
Why
===

This is showing up incorrectly in the version picker

<img width="605" alt="image" src="https://github.com/user-attachments/assets/307eba2a-9adf-4781-a94b-9825b4bb0ae2" />

What changed
============

Set the display version to something other than `1`

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
