### PR TITLE
[uv] uv bleeding edge

### DIFF
--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -91,6 +91,18 @@ let
 
   sitecustomize = pkgs.callPackage ./sitecustomize.nix { };
 
+  uv = pkgs.callPackage ./uv {
+    rustPlatform = (
+      let
+        toolchain = pkgs.fenix.latest.toolchain;
+      in
+      pkgs.makeRustPlatform {
+        cargo = toolchain;
+        rustc = toolchain;
+      }
+    );
+  };
+
 in
 {
   id = "python-${pythonVersion}";
@@ -104,7 +116,7 @@ in
     binary-wrapped-python
     pip-wrapper
     poetry-wrapper
-    pkgs.uv
+    uv
   ];
 
   replit.runners.python = {

--- a/pkgs/modules/python/uv/default.nix
+++ b/pkgs/modules/python/uv/default.nix
@@ -13,17 +13,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "uv";
-  version = "0.5.10";
+  version = "0.5.11"; # Technically 8 versions ahead of 0.5.11
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
-    tag = version;
-    hash = "sha256-GE/MgaX6JhzVVwrkz33fr1Vl83QD1WHhlB7vPdJ2W3c=";
+    rev = "ddc290feb4ed2de4740c786af2436cf1f82a3190";
+    hash = "sha256-/hm70Vptk0eg9MMzgbpkOg/x6mNJBTZ/25kfqiYc/7Y=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-jFH+OA2bR4Pq1PWDQCpFFH9AoC3PDLSOKAT0iDvkFWM=";
+  cargoHash = "sha256-k+ABi0xgtpuDwCEgUIqrG7m56iSeYMsDTvtC0YHoCwE=";
 
   nativeBuildInputs = [
     cmake
@@ -32,6 +32,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   dontUseCmakeConfigure = true;
+
+  RUSTFLAGS = "-Z threads=8";
 
   cargoBuildFlags = [
     "--package"

--- a/pkgs/modules/python/uv/default.nix
+++ b/pkgs/modules/python/uv/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, cmake
+, fetchFromGitHub
+, installShellFiles
+, pkg-config
+, rustPlatform
+, versionCheckHook
+, python3Packages
+, nix-update-script
+,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "uv";
+  version = "0.5.10";
+
+  src = fetchFromGitHub {
+    owner = "astral-sh";
+    repo = "uv";
+    tag = version;
+    hash = "sha256-GE/MgaX6JhzVVwrkz33fr1Vl83QD1WHhlB7vPdJ2W3c=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-jFH+OA2bR4Pq1PWDQCpFFH9AoC3PDLSOKAT0iDvkFWM=";
+
+  nativeBuildInputs = [
+    cmake
+    installShellFiles
+    pkg-config
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  cargoBuildFlags = [
+    "--package"
+    "uv"
+  ];
+
+  # Tests require python3
+  doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export HOME=$TMPDIR
+    installShellCompletion --cmd uv \
+      --bash <($out/bin/uv --generate-shell-completion bash) \
+      --fish <($out/bin/uv --generate-shell-completion fish) \
+      --zsh <($out/bin/uv --generate-shell-completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    tests.uv-python = python3Packages.uv;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Extremely fast Python package installer and resolver, written in Rust";
+    homepage = "https://github.com/astral-sh/uv";
+    changelog = "https://github.com/astral-sh/uv/blob/${version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "uv";
+  };
+}


### PR DESCRIPTION
Why
===

Bumping uv to latest HEAD in order to get https://github.com/astral-sh/uv/pull/10046, and open us up to just building the latest tags irrespective of what nixpkgs-unstable is tracking.

What changed
============

- Copy uv definition from https://github.com/NixOS/nixpkgs/tree/staging/pkgs/by-name/uv/uv
- Reformulate to use fenix flake input
- Bump uv to get the latest rev

Test plan
=========

Verified that the following builds: ✅
```
$ nix build --no-eval-cache .#'"python-3.12"' -o result.json
```

Verify that transitively depending on `torch` successfully resolves: ✅ 

See the "complete example" in https://docs.astral.sh/uv/guides/integration/pytorch/#using-a-pytorch-index

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
