### PR TITLE
Disable user mode install for pip

### DIFF
--- a/pkgs/modules/python/pip.nix
+++ b/pkgs/modules/python/pip.nix
@@ -22,7 +22,7 @@ let
     name = "pip.conf";
     text = ''
       [global]
-      user = yes
+      user = no
       disable-pip-version-check = yes
       break-system-packages = yes
     '';


### PR DESCRIPTION
Why
===

In some cases, using user install mode for pip will break because with the uv setup we are running in a virtualenv, where user mode will be disabled.

What changed
============

If uv is already rolled out 100% we can consider switching this off. But we may break existing repls that aren't uv. If there's a way to do this only with uv repls, that'll be a better solution.

