### PR TITLE
[bun] add historical bun 1.1

### DIFF
--- a/pkgs/historical-modules/default.nix
+++ b/pkgs/historical-modules/default.nix
@@ -18,6 +18,13 @@ let
       };
     }
     {
+      moduleId = "bun-1.1";
+      commit = "1113faeb6840ba57bef3679b1f763782f5d3dd30";
+      overrides = {
+        displayVersion = "1.1.45";
+      };
+    }
+    {
       moduleId = "clojure-1.11";
       commit = "4327245815e8500233ed3af1cbb674bd147f673b";
       overrides = {


### PR DESCRIPTION
Why
===
* We're shipping bun 1.2 now, but we'll want to keep supporting bun 1.1 for some time

What changed
===
* Add bun 1.1 to historical modules

Test plan
===
* Bun template works again

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
