### PR TITLE
Poetry security updates

### DIFF
--- a/pkgs/poetry/poetry-py3.10.nix
+++ b/pkgs/poetry/poetry-py3.10.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.4";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.5-python-3.10.14-bundle.tgz;
-  sha256 = "sha256:0sfkj927jxc5qbi3lqnyya9l7hswy7w8ihk5acxivmj3gpxz547i";
+  version = "1.5.6";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.6-python-3.10.16-bundle.tgz;
+  sha256 = "sha256:1bgdqyh7mvbpay47k5wni25vrx7j9f3g15bhcnws33vy2vyqyldc";
   inherit python pypkgs;
 }

--- a/pkgs/poetry/poetry-py3.11.nix
+++ b/pkgs/poetry/poetry-py3.11.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.4";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.5-python-3.11.9-bundle.tgz;
-  sha256 = "sha256:0madgivk9zywddir130rrvfyxg8whah8dgzd1g2m88j1yvdgspnd";
+  version = "1.5.6";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.6-python-3.11.10-bundle.tgz;
+  sha256 = "sha256:139kfql4in5lc519q6bfby27jbfaixm4x1zdj778vm1hdd8ydn6k";
   inherit python pypkgs;
 }

--- a/pkgs/poetry/poetry-py3.12.nix
+++ b/pkgs/poetry/poetry-py3.12.nix
@@ -1,7 +1,7 @@
 { pkgs, python, pypkgs }:
 pkgs.callPackage ./poetry-in-venv.nix {
-  version = "1.5.4";
-  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.5-python-3.12.3-bundle.tgz;
-  sha256 = "sha256:0d5cvh29683mya1lvwnn0r39bh3agm1gfhkrs3cc57rgs6dfp6yg";
+  version = "1.5.6";
+  url = https://storage.googleapis.com/poetry-bundles/poetry-1.5.6-python-3.12.7-bundle.tgz;
+  sha256 = "sha256:1v42fgq3p5g41l5al33fswrx4g335gf1jxadvdf378giy583r309";
   inherit python pypkgs;
 }


### PR DESCRIPTION
Why
===

Get security updates deployed for [poetry](https://github.com/replit/poetry).

What changed
============

Updated bundle URLs and shas.

## Test

1. Create new repl
2. for each of 3.10, 3.11, 3.12:
   a. Install `python-<version>` nix module
   b. `cat $(which poetry)`
   c. go down 3 or 4 layers of poetry wrappers (via cat) to find the directory for poetry-in-venv. Such as: `ls /nix/store/f6cbszjx0r02mw8kdgv8bkla07dc639w-poetry-in-venv/env/lib/python3.10/site-packages/` and verify that: virtualenv >= 20.29, certifi=2025.1.31, urllib3>=1.26.20, etc
Run template tester to see that things still work. 