### PR TITLE
Updated java-language-server for security update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697466147,
-        "narHash": "sha256-3AhaAwFYglnvtv4Cyeq3/cooQUIVTE+vID+TSZsFAfQ=",
+        "lastModified": 1740003396,
+        "narHash": "sha256-txIMmVTpMf1NEKuNuQguMd2lPIyWwT3k9AkKK9t4n1c=",
         "owner": "replit",
         "repo": "java-language-server",
-        "rev": "ba33f337ad1967f2b1b0990801701c2c531369f6",
+        "rev": "f61c12579d978ec9274b048519449f4c8510de4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Why
===

Update java-language-server for security update.

What changed
============

Updated flack for java-language-server.

Test plan
=========

Add `java-graalvm22.3` nix module and see that java lsp still works.