### PR TITLE
Security updates for java-debug

### DIFF
--- a/pkgs/java-debug/debug-plugin.nix
+++ b/pkgs/java-debug/debug-plugin.nix
@@ -5,13 +5,13 @@
 , callPackage
 }:
 let
-  version = "0.32.0";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "replit";
     repo = "java-debug";
-    rev = "debug-interface";
-    sha256 = "14ada9chynzycnfqc4w9c1w24gyx37by81fyb9y42izdrn46dj2z";
+    rev = "main";
+    sha256 = "RR3Atw2B5ttT+K10wGD+OsDOeMlcNVEqA/7ZTixCXCQ=";
   };
   repository = callPackage ./repo.nix {
     inherit src jdk patches;

--- a/pkgs/java-debug/repo.nix
+++ b/pkgs/java-debug/repo.nix
@@ -25,5 +25,5 @@ stdenv.mkDerivation {
   dontFixup = true;
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "1fc4axfswz9p7sh8pqf1icjypdbmaqbraxy2xn0nr6ykbqn61b3l";
+  outputHash = "eqUv4tMhdBkRWOGmIMbSFpDZl9B1Aq+P3cKAF3m9sZY=";
 }


### PR DESCRIPTION
Why
===

Update java-debug for security update.

What changed
============

Update version to main branch (d66ba60090a1165d94632615deff884e113f8ea5) of https://github.com/replit/java-debug