### PR TITLE
Bump pyright-extended to 2.0.13

### DIFF
--- a/pkgs/pyright-extended/default.nix
+++ b/pkgs/pyright-extended/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, yapf, ... }:
 let
-  version = "2.0.12";
+  version = "2.0.13";
 in
 pkgs.stdenvNoCC.mkDerivation rec {
   pname = "pyright-extended";
@@ -8,7 +8,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
 
   src = pkgs.fetchurl {
     url = "https://registry.npmjs.org/@replit/pyright-extended/-/pyright-extended-${version}.tgz";
-    hash = "sha256-IZcw5C1Kbpas3HDHyECdFvI0F8hF/Um3+WtCEyCo5Ik=";
+    hash = "sha256-i4AOpkXF7YOLvcO4n5wDUjBSefFHnjFkSydJfRkMOX4=";
   };
 
   binPath = lib.makeBinPath [


### PR DESCRIPTION
Why
===

The latest pyright-extened version is 2.0.13 and it should ignore non-python files so we should see less `ENOSPC: System limit for number of file watchers reached` errors. 

pyright-extended PR: https://github.com/replit/pyright-extended/pull/66

What changed
============

- Bump version to 2.0.13

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
