### PR TITLE
[python with prybar] update pkg building stderred

### DIFF
--- a/pkgs/modules/python-with-prybar/default.nix
+++ b/pkgs/modules/python-with-prybar/default.nix
@@ -1,4 +1,8 @@
-{ pkgs, pkgs-23_05, lib, ... }:
+{ pkgs
+, pkgs-23_05
+, lib
+, ...
+}:
 let
   python = pkgs-23_05.python310Full;
 
@@ -15,16 +19,21 @@ let
 
   prybar-python-version = lib.strings.concatStrings (lib.strings.splitString "." pythonVersion);
 
-  stderred = pkgs-23_05.callPackage ../../stderred { };
+  stderred = pkgs.callPackage ../../stderred { };
 
   run-prybar-bin = pkgs-23_05.writeShellApplication {
     name = "run-prybar";
     text = ''
-      ${stderred}/bin/stderred -- ${pkgs.prybar."prybar-python${prybar-python-version}"}/bin/prybar-python${prybar-python-version} -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i "''$1"
+      ${stderred}/bin/stderred -- ${
+        pkgs.prybar."prybar-python${prybar-python-version}"
+      }/bin/prybar-python${prybar-python-version} -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i "''$1"
     '';
   };
 
-  run-prybar = pythonWrapper { bin = "${run-prybar-bin}/bin/run-prybar"; name = "run-prybar"; };
+  run-prybar = pythonWrapper {
+    bin = "${run-prybar-bin}/bin/run-prybar";
+    name = "run-prybar";
+  };
 in
 {
 

--- a/pkgs/stderred/default.nix
+++ b/pkgs/stderred/default.nix
@@ -1,12 +1,19 @@
-{ rustPlatform, stderred, makeWrapper }:
+{ rustPlatform
+, stderred
+, makeWrapper
+,
+}:
 
 rustPlatform.buildRustPackage {
   pname = "stderred";
   version = "0.1.0";
 
-  src = builtins.path { path = ./.; name = "stderred"; };
+  src = builtins.path {
+    path = ./.;
+    name = "stderred";
+  };
 
-  cargoSha256 = "sha256-21RJeoGIS+fj/q7rgy80cz50TnEs9WGb+lLGnHTVG2A=";
+  cargoSha256 = "sha256-Fc5ZP/ARqcNdwU5t/xarhsEglbYCNo2XVsJjdHT+/DA=";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
Why
===
* We were getting:

```
building '/nix/store/hmfp9y0w181bywzy02b9pyvbd5ai0p6s-stderred-0.1.0-vendor.tar.gz.drv'...29:41
error: builder for '/nix/store/hmfp9y0w181bywzy02b9pyvbd5ai0p6s-stderred-0.1.0-vendor.tar.gz.drv' failed with exit code 101;29:41
       last 10 log lines:29:41
       > error: failed to sync29:41
       >29:41
       > Caused by:29:41
       >   failed to load pkg lockfile29:41
       >29:41
       > Caused by:29:41
       >   failed to parse lock file at: /build/stderred/Cargo.lock29:41
       >29:41
       > Caused by:29:41
       >   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?29:41
       For full logs, run 'nix log /nix/store/hmfp9y0w181bywzy02b9pyvbd5ai0p6s-stderred-0.1.0-vendor.tar.gz.drv'.
```

What changed
===
* Update stderrred to build with pkgs instead of pkgs-23_05
* Update cargo hash

Test plan
===
```
nix build '.#"python-with-prybar-3.10"'
```
works

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
