### PR TITLE
Update to bun 1.2.12 

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.2.5";
+  version = "1.2.12";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-iPZL7e4zD/TWMo4+kMZpvHrFMUknxgT4XjKeoqHRl5s=";
+    hash = "sha256-MzeWT6ox2LzhmfkXCBMHEO8ucLmP80o09ZCxdFiApjM";
   };
 }


### PR DESCRIPTION
We are using `bun` for https://github.com/tscircuit/tscircuit and are trying to add replit compatibility to all repos. One challenge is Bun 1.2.5 has bugs related to lockfiles, this update gives us the latest version of bun for our repls