### PR TITLE
[chore] Disambiguate

### DIFF
--- a/pkgs/modules/nix/default.nix
+++ b/pkgs/modules/nix/default.nix
@@ -6,7 +6,7 @@
   '';
 
   replit.dev.languageServers.nil = {
-    name = "nil";
+    name = "Nix Language Server (nil)";
     language = "nix";
     start = "${pkgs.nil}/bin/nil";
     extensions = [ ".nix" ];


### PR DESCRIPTION
Why
===

`{} nil` is confusing, some folks may not know the nix language server is called `nil`.

What changed
============

Put more letters in the string.

Test plan
=========

👀 

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
