### PR TITLE
set GLIBC_TUNABLES to increase mem reservation

### DIFF
--- a/pkgs/modules/replit-rtld-loader/default.nix
+++ b/pkgs/modules/replit-rtld-loader/default.nix
@@ -8,6 +8,7 @@
 
   replit.env = {
     LD_AUDIT = "${pkgs.replit-rtld-loader}/rtld_loader.so";
+    GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=2500";
   };
 }
 


### PR DESCRIPTION
Why
===

Seeing number of issues related to https://sourceware.org/bugzilla/show_bug.cgi?id=31991, https://github.com/jemalloc/jemalloc/issues/2472, and https://github.com/flox/flox/issues/1341.

In our case this leads to some programs failing with
```
libjemalloc.so.2: cannot allocate memory in static TLS block
```

What changed
============

Set `GLIBC_TUNABLES` to a higher amount to allow these programs to not crash.

Test plan
=========

- Ensure `redis-server`, `bun`, `fd`, and others work as expected.

Rollout
=======

- [ ] This is fully backward and forward compatible
