### PR TITLE
Revert "Update Bunnn"

### DIFF
--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.2.16";
+  version = "1.2.12";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-+DEdjXyqDZOMbEzs8KYA5enOTidaQR44oun4x30MEAI=";
+    hash = "sha256-MzeWT6ox2LzhmfkXCBMHEO8ucLmP80o09ZCxdFiApjM";
   };
 }


### PR DESCRIPTION
This reverts commit b7ef01bbf115a67fd6db0ef99b338f233ac7041f.

Why
===

Causes some issues with `upm`, need to debug before relanding.

What changed
============

Revert bun upgrade

Test plan
=========


Rollout
=======

- [ ] This is fully backward and forward compatible
