### PR TITLE
bump replit_rtld_loader

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713277918,
-        "narHash": "sha256-87q8ZaQW0qyCvg6QqTHUuvXeB5OtXHEAwwUWZ5gf0A0=",
+        "lastModified": 1750276858,
+        "narHash": "sha256-rOqpm3ii/k1eJF8FApmz65kNiwfXDmWTyHST2HclwqU=",
         "owner": "replit",
         "repo": "replit_rtld_loader",
-        "rev": "4eba5ae8b825a724ccdfaa12ad637e9a9754629a",
+        "rev": "dffff3d40cf95bcc3dc4302ce3a0f6790139190d",
         "type": "github"
       },
       "original": {

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -3,9 +3,9 @@
 }:
 
 bun.overrideAttrs rec {
-  version = "1.2.12";
+  version = "1.2.16";
   src = fetchurl {
     url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-    hash = "sha256-MzeWT6ox2LzhmfkXCBMHEO8ucLmP80o09ZCxdFiApjM";
+    hash = "sha256-+DEdjXyqDZOMbEzs8KYA5enOTidaQR44oun4x30MEAI=";
   };
 }


### PR DESCRIPTION
Why
===

Bun didn't turn out to be the root of the LD_AUDIT bun/upm crash issue. Seems like replit_rtld_loader was trying to reassign nix binary libraries.

What changed
============
- Reapply bun update that didn't turn out to be the root cause of some issues.
- Bump replit_rtld_loader to include https://github.com/replit/replit_rtld_loader/pull/16

Test plan
=========

- Ensure dynamically linked binaries are still fixed by replit_rtld_loader
- Ensure having `pkgs.glibc` installed in `replit.nix` doesn't break `bun`.

Rollout
=======

- [ ] This is fully backward and forward compatible
