### PR TITLE
update nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1742452566,
-        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
+        "lastModified": 1752734526,
+        "narHash": "sha256-OIg7NwrqyYJVpXJdDgaagIzM0dtc4GghdncUrUsCgT8=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
+        "rev": "f1526533e3a59a666dbae99594c9d29b201f302d",
         "type": "github"
       },
       "original": {
@@ -143,7 +143,7 @@
     "java-language-server": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-23_05"
         ]
       },
       "locked": {
@@ -184,6 +184,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1752683762,
+        "narHash": "sha256-CVC4bpthYhKk4Qb4mt00SqfJ7CJ4vfTX06pLN2OHa1c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fa64ec5c1ca6f17746f3defedb988b9248e97616",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23_05": {
+      "locked": {
         "lastModified": 1704290814,
         "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
         "owner": "nixos",
@@ -198,18 +214,18 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-24_11": {
       "locked": {
-        "lastModified": 1734435836,
-        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -261,7 +277,8 @@
         "java-language-server": "java-language-server",
         "nil": "nil",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs-23_05": "nixpkgs-23_05",
+        "nixpkgs-24_11": "nixpkgs-24_11",
         "prybar": "prybar",
         "replit-rtld-loader": "replit-rtld-loader",
         "ztoc-rs": "ztoc-rs"
@@ -270,11 +287,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1742296961,
-        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
+        "lastModified": 1752687976,
+        "narHash": "sha256-juLg/AlXwda5fwewOJq42Q5T49wU131glK55BzKyhvU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
+        "rev": "152087654552a79f85e588da0a8de905436e62d8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "Nix expressions for defining Replit development environments";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
-  inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs-23_05.url = "github:nixos/nixpkgs/nixos-23.05";
+  inputs.nixpkgs-24_11.url = "github:nixos/nixpkgs/nixos-24.11";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.nil.url = "github:oxalica/nil";
@@ -9,13 +10,13 @@
   inputs.prybar.url = "github:replit/prybar";
   inputs.prybar.inputs.nixpkgs.follows = "nixpkgs";
   inputs.java-language-server.url = "github:replit/java-language-server";
-  inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.java-language-server.inputs.nixpkgs.follows = "nixpkgs-23_05";
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
   inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
   inputs.replit-rtld-loader.url = "github:replit/replit_rtld_loader";
   inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
+  outputs = { self, nixpkgs, nixpkgs-23_05, nixpkgs-24_11, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -33,11 +34,12 @@
         ];
       };
 
-      pkgs-23_05 = mkPkgs nixpkgs "x86_64-linux";
+      pkgs-23_05 = mkPkgs nixpkgs-23_05 "x86_64-linux";
+      pkgs-24_11 = mkPkgs nixpkgs-24_11 "x86_64-linux";
 
-      patched-unstable = nixpkgs-unstable.legacyPackages.x86_64-linux.applyPatches {
+      patched-unstable = nixpkgs.legacyPackages.x86_64-linux.applyPatches {
         name = "nixpkgs-unstable-patched";
-        src = nixpkgs-unstable;
+        src = nixpkgs;
         patches = [
           # rexml broke solargraph at some point in the past.
           # Attempting to run:
@@ -114,6 +116,7 @@
       import ./pkgs/modules {
         inherit pkgs;
         inherit pkgs-23_05;
+        inherit pkgs-24_11;
       }
     );
 }

--- a/pkgs/moduleit/entrypoint.nix
+++ b/pkgs/moduleit/entrypoint.nix
@@ -1,5 +1,6 @@
 { pkgs ? import <nixpkgs-unstable> { }
 , pkgs-23_05 ? import <nixpkgs-stable-23_05> { }
+, pkgs-24_11 ? import <nixpkgs-stable-24_11> { }
 , configPath
 , deployment ? false
 }:
@@ -10,7 +11,7 @@ let
       (import ./module-definition.nix)
     ];
     specialArgs = {
-      inherit pkgs pkgs-23_05;
+      inherit pkgs pkgs-23_05 pkgs-24_11;
       pkgs-unstable = pkgs;
       modulesPath = builtins.toString ./.;
     };

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -1,13 +1,13 @@
-{ pkgs, pkgs-23_05 }:
+{ pkgs, pkgs-23_05, pkgs-24_11 }:
 with builtins;
 let
   mkModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-23_05;
+    inherit pkgs-23_05 pkgs-24_11;
   };
   mkDeploymentModule = path: pkgs.callPackage ../moduleit/entrypoint.nix {
     configPath = path;
-    inherit pkgs-23_05;
+    inherit pkgs-23_05 pkgs-24_11;
     deployment = true;
   };
   apply-upgrade-map = import ../upgrade-map;
@@ -15,8 +15,8 @@ let
 
   modulesList = [
     (import ./python {
-      python = pkgs.python39Full;
-      pypkgs = pkgs.python39Packages;
+      python = pkgs-24_11.python39Full;
+      pypkgs = pkgs-24_11.python39Packages;
     })
     (import ./python {
       python = pkgs.python310Full;
@@ -42,14 +42,20 @@ let
       python = pkgs.python313Full;
       pypkgs = pkgs.python313Packages;
     })
+    (import ./python-base {
+      python = pkgs.python314Full;
+      pypkgs = pkgs.python314Packages;
+    })
     (import ./python-with-prybar)
 
-    (import ./pyright-extended)
+    (import ./pyright-extended {
+      nodejs = pkgs-24_11.nodejs-18_x;
+    })
     (import ./pyright)
     (import ./ruff)
 
     (import ./nodejs {
-      nodejs = pkgs.nodejs-18_x;
+      nodejs = pkgs-24_11.nodejs-18_x;
     })
     (import ./nodejs {
       nodejs = pkgs.nodejs_20;
@@ -58,14 +64,25 @@ let
       nodejs = pkgs.nodejs_22;
     })
     (import ./nodejs {
-      nodejs = pkgs.nodejs_23;
+      nodejs = pkgs-24_11.nodejs_23;
     })
-    (import ./nodejs-with-prybar)
+    (import ./nodejs {
+      nodejs = pkgs.nodejs_24;
+    })
+    (import ./nodejs-with-prybar {
+      nodejs = pkgs-24_11.nodejs-18_x;
+    })
 
     (import ./go {
       go = pkgs.go_1_23;
       gopls = pkgs.gopls.override {
-        buildGoModule = pkgs.buildGo123Module;
+        buildGoLatestModule = pkgs.buildGo123Module;
+      };
+    })
+    (import ./go {
+      go = pkgs.go_1_24;
+      gopls = pkgs.gopls.override {
+        buildGoLatestModule = pkgs.buildGo124Module;
       };
     })
 
@@ -125,7 +142,7 @@ let
       nodejs = pkgs.nodejs_20;
     })
     (import ./vue {
-      nodejs = pkgs.nodejs_18;
+      nodejs = pkgs-24_11.nodejs-18_x;
     })
     (import ./web)
     (import ./hermit)

--- a/pkgs/modules/nodejs-with-prybar/default.nix
+++ b/pkgs/modules/nodejs-with-prybar/default.nix
@@ -1,7 +1,6 @@
+{ nodejs }:
 { pkgs, lib, ... }:
 let
-  nodejs = pkgs.nodejs-18_x;
-
   nodeVersion = lib.versions.major nodejs.version;
 
   prybar = pkgs.prybar.prybar-nodejs;

--- a/pkgs/modules/pyright-extended/default.nix
+++ b/pkgs/modules/pyright-extended/default.nix
@@ -1,6 +1,9 @@
+{ nodejs }:
 { pkgs, lib, ... }:
 let
-  pyright-extended = pkgs.callPackage ../../pyright-extended { };
+  pyright-extended = pkgs.callPackage ../../pyright-extended {
+    nodejs = nodejs;
+  };
 in
 {
   id = "pyright-extended";

--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -1,5 +1,5 @@
 { python, pypkgs }:
-{ pkgs-unstable, pkgs-23_05, lib, ... }:
+{ pkgs-unstable, pkgs-24_11, pkgs-23_05, lib, ... }:
 let
   pythonVersion = lib.versions.majorMinor python.version;
 
@@ -86,6 +86,7 @@ let
   };
 
   pyright-extended = pkgs.callPackage ../../pyright-extended {
+    nodejs = pkgs-24_11.nodejs-18_x;
     yapf = pypkgs.yapf;
   };
 

--- a/pkgs/pyright-extended/default.nix
+++ b/pkgs/pyright-extended/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, yapf, ... }:
+{ pkgs, lib, yapf, nodejs, ... }:
 let
   version = "2.0.13";
 in
@@ -14,7 +14,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
   binPath = lib.makeBinPath [
     pkgs.ruff
     yapf
-    pkgs.nodejs_18
+    nodejs
   ];
 
   nativeBuildInputs = [

--- a/pkgs/stderred/default.nix
+++ b/pkgs/stderred/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage {
     name = "stderred";
   };
 
-  cargoSha256 = "sha256-Fc5ZP/ARqcNdwU5t/xarhsEglbYCNo2XVsJjdHT+/DA=";
+  cargoHash = "sha256-Fc5ZP/ARqcNdwU5t/xarhsEglbYCNo2XVsJjdHT+/DA=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/upgrade-map/default.nix
+++ b/pkgs/upgrade-map/default.nix
@@ -15,9 +15,12 @@ let
     "dart-3.2" = "dart-3.3";
     "dart-3.3" = "dart-3.4";
     "dart-3.4" = "dart-3.5";
+    "dart-3.5" = "dart-3.8";
     "elixir-1_16" = "elixir-1_17";
+    "elixir-1_17" = "elixir-1_18";
     "go" = "go-1.19";
     "r-4.3" = "r-4.4";
+    "r-4.4" = "r-4.5";
     "rust" = "rust-1.69";
     "rust-1.69" = "rust-1.70";
     "rust-1.70" = "rust-1.72";


### PR DESCRIPTION
Why
===

In order to keep more of our languages up to date, we should keep the nixpkgs pin up to date

What changed
============

- Updated nixpkgs unstable pin
- Added nixpkgs 24.11 pin for packages removed from latest unstable

Test plan
=========

- Build and ensure all updated languages still work
- Run template tester

Rollout
=======

- [ ] This is fully backward and forward compatible
