### PR TITLE
bump rtld.optional_static_tls

### DIFF
--- a/pkgs/modules/replit-rtld-loader/default.nix
+++ b/pkgs/modules/replit-rtld-loader/default.nix
@@ -8,7 +8,7 @@
 
   replit.env = {
     LD_AUDIT = "${pkgs.replit-rtld-loader}/rtld_loader.so";
-    GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=2500";
+    GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=10000";
   };
 }
 


### PR DESCRIPTION
Why
===

Latest rustc nightly fails with rtld loader enabled with the current static tls limit.

What changed
============

Bump rtld.optional_static_tls from 2500 -> 10000.

Test plan
=========

`rustc` nightly and other programs still work as expected.

Rollout
=======

- [ ] This is fully backward and forward compatible
