### PR TITLE
add postgresql-16 to dev modules

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,7 +7,7 @@ let
   revstring_long = self.rev or "dirty";
   revstring = builtins.substring 0 7 revstring_long;
 
-  dev-module-ids = [ "python-3.10" "python-3.11" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" "ruby" ];
+  dev-module-ids = [ "python-3.10" "python-3.11" "nodejs-18" "nodejs-20" "docker" "replit" "replit-rtld-loader" "ruby" "postgresql-16" ];
 
   mkPhonyOCI = pkgs.callPackage ./mk-phony-oci { ztoc-rs = self.inputs.ztoc-rs.packages.x86_64-linux.default; };
 


### PR DESCRIPTION
Why
===

needed for a test

What changed
============

add postgresql-16 to dev modules
Test plan
=========

following works:

<img width="720" height="545" alt="image" src="https://github.com/user-attachments/assets/3a34e969-2233-4354-bd6b-48d0a4e805b6" />

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
