### PR TITLE
python: restore formatting for ty-based modules

### DIFF
--- a/pkgs/modules/python/default.nix
+++ b/pkgs/modules/python/default.nix
@@ -58,8 +58,6 @@ let
     inherit pkgs python python-ld-library-path;
   };
 
-  ty = pkgs.callPackage ../../ty { };
-
   sitecustomize = pkgs.callPackage ./sitecustomize.nix { };
 
   uv = pkgs.callPackage ./uv {
@@ -79,8 +77,9 @@ in
   id = "python-${pythonVersion}";
   name = "Python Tools";
   displayVersion = pythonVersion;
+  imports = [ (import ../ty) ];
   description = ''
-    Development tools for Python. Includes Python interpreter, Pip, Poetry, and the ty language server.
+    Development tools for Python. Includes Python interpreter, Pip, Poetry, the ty language server, and Ruff formatting.
   '';
 
   replit.packages = [
@@ -101,13 +100,6 @@ in
       "app.py"
       "run.py"
     ];
-  };
-
-  replit.dev.languageServers.ty = {
-    name = "ty";
-    displayVersion = ty.version;
-    language = "python3";
-    start = "${ty}/bin/ty server";
   };
 
   replit.dev.packagers.upmPython = {

--- a/pkgs/modules/ty/default.nix
+++ b/pkgs/modules/ty/default.nix
@@ -1,12 +1,66 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   ty = pkgs.callPackage ../../ty { };
+
+  formatter = import ../../formatter {
+    inherit pkgs;
+  };
+
+  run-ruff-format = pkgs.writeShellApplication {
+    name = "run-ruff-format";
+    runtimeInputs = [
+      pkgs.bash
+      pkgs.ruff
+    ];
+    extraShellCheckFlags = [ "-x" ];
+    text = ''
+      #!/bin/bash
+
+      # Source the shared options parsing script
+      source ${formatter}/bin/parse-formatter-options "$@"
+
+      if [[ "$apply" == "true" ]]; then
+        if [[ "$stdinMode" == "true" ]]; then
+          ruff format --stdin-filename "$file" - > "$file"
+        else
+          ruff format --quiet "$file"
+        fi
+        exit 0
+      fi
+
+      if [[ "$stdinMode" == "true" ]]; then
+        ruff format --stdin-filename "$file" -
+      else
+        ruff format --stdin-filename "$file" - < "$file"
+      fi
+    '';
+    checkPhase = ''
+      cat > test.py << 'EOF'
+      def greet(  name:str ) ->None:
+          print( f"hello, {name}" )
+      EOF
+
+      $out/bin/run-ruff-format -f test.py > output.py
+      printf 'def greet(name: str) -> None:\n    print(f"hello, {name}")\n' > expected.py
+      if ! diff expected.py output.py; then
+        echo "format output doesn't match expectation"
+        exit 1
+      fi
+
+      cp test.py applied.py
+      $out/bin/run-ruff-format --apply -f applied.py
+      if ! diff expected.py applied.py; then
+        echo "apply format output doesn't match expectation"
+        exit 1
+      fi
+    '';
+  };
 in
 {
-  id = "ty";
-  name = "ty LSP";
-  displayVersion = ty.version;
-  description = ''
+  id = lib.mkDefault "ty";
+  name = lib.mkDefault "ty LSP";
+  displayVersion = lib.mkDefault ty.version;
+  description = lib.mkDefault ''
     Ty is an extremely fast Python type checker from Astral with an integrated language server.
   '';
   replit.dev.languageServers.ty = {
@@ -16,7 +70,18 @@ in
     start = "${ty}/bin/ty server";
   };
 
+  replit.dev.formatters.ruff = {
+    name = "Ruff";
+    displayVersion = pkgs.ruff.version;
+    language = "python3";
+    extensions = [ ".py" ];
+    start = {
+      args = [ "${run-ruff-format}/bin/run-ruff-format" ];
+    };
+    stdin = true;
+  };
+
   replit.env = {
-    PATH = "${ty}/bin";
+    PATH = lib.mkDefault "${ty}/bin";
   };
 }


### PR DESCRIPTION
Why
===

Switching Python modules from pyright-extended to ty removed formatting support in the default Python module experience.

What changed
============

- Added a Ruff formatter to the `ty` module via `replit.dev.formatters.ruff`.
- Added a `run-ruff-format` wrapper that understands our formatter option contract (`--stdin`, `--apply`, and `--file`).
- Updated `python` modules to import `../ty` so ty language-server + formatter behavior is shared in one place.
- Made `ty` module metadata and PATH defaults use `lib.mkDefault` so it can be safely imported into other modules.

Test plan
=========

- `direnv exec /home/developer/replit/nixmodules nix build --no-link --print-out-paths '.#activeModules.\"python-3.11\"' '.#activeModules.ty'`
- Confirmed the build succeeds and emits both module artifacts.
- Confirmed the `run-ruff-format` derivation check phase passes for both stdout formatting and `--apply` mode.

Revertibility
=============

Safe to revert. This change only affects module wiring and formatter configuration and does not modify stateful data or irreversible behavior.

Rollout
=======

- [x] This is fully backward and forward compatible

~ written by Zerg 👾