### PR TITLE
Update nixpkgs-unstable for latest pnpm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768364046,
-        "narHash": "sha256-PDFfpswLiuG/DcadTBb7dEfO3jX1fcGlCD4ZKSkC0M8=",
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ea30586ee015f37f38783006a9bc9e4aa64d7d61",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
         "type": "github"
       },
       "original": {
@@ -302,7 +302,7 @@
     "replit-rtld-loader": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-25_05"
         ]
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
   inputs.ztoc-rs.url = "github:replit/ztoc-rs";
   inputs.ztoc-rs.inputs.nixpkgs.follows = "nixpkgs";
   inputs.replit-rtld-loader.url = "github:replit/replit_rtld_loader";
-  inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs-25_05";
 
   outputs = { self, nixpkgs, nixpkgs-23_05, nixpkgs-24_11, nixpkgs-25_05, nixpkgs-master, nixpkgs-staging, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
     let

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -30,20 +30,20 @@ let
       pypkgs = pkgs-24_11.python39Packages;
     })
     (import ./python {
-      python = pkgs.python310;
-      pypkgs = pkgs.python310Packages;
+      python = pkgs-25_05.python310;
+      pypkgs = pkgs-25_05.python310Packages;
     })
     (import ./python {
-      python = pkgs.python311;
-      pypkgs = pkgs.python311Packages;
+      python = pkgs-25_05.python311;
+      pypkgs = pkgs-25_05.python311Packages;
     })
     (import ./python {
       python = pkgs.python312;
       pypkgs = pkgs.python312Packages;
     })
     (import ./python-base {
-      python = pkgs.python311;
-      pypkgs = pkgs.python311Packages;
+      python = pkgs-25_05.python311;
+      pypkgs = pkgs-25_05.python311Packages;
     })
     (import ./python-base {
       python = pkgs.python312;

--- a/pkgs/upgrade-map/default.nix
+++ b/pkgs/upgrade-map/default.nix
@@ -20,6 +20,7 @@ let
     "dart-3.4" = "dart-3.5";
     "dart-3.5" = "dart-3.8";
     "dart-3.8" = "dart-3.10";
+    "dart-3.10" = "dart-3.11";
     "elixir-1_16" = "elixir-1_17";
     "elixir-1_17" = "elixir-1_18";
     "go" = "go-1.19";


### PR DESCRIPTION
## Why

We want the latest version of pnpm in packages that include it (nodejs, vue, angular modules). The nixpkgs-unstable input was pinned to Jan 14 and needed updating to get the latest pnpm.

Slack thread: https://slack.com/archives/C0AEE1W8E3X/p1773959062350099

## What changed

- **Updated `nixpkgs-unstable`** input from `ea30586` (2026-01-14) to `f8573b9` (2026-03-16) to get the latest pnpm version available in nixpkgs-unstable.
- **Pinned `python310` and `python311`** to `pkgs-25_05` in `pkgs/modules/default.nix`:
  - `python310` was removed from the latest unstable channel entirely.
  - `python311`'s pip is broken in the latest unstable due to sphinx 9.1.0 not supporting Python 3.11.
  - Affects: `python-3.10` module, `python-3.11` module, and `python-base-3.11` module.
- **Pinned `replit-rtld-loader`** nixpkgs input to follow `nixpkgs-25_05` instead of `nixpkgs` since the loader's flake.nix references `pkgs.python310` which no longer exists in unstable.
- **Added `dart-3.10 -> dart-3.11`** upgrade mapping since dart bumped from 3.10 to 3.11 in the new unstable.

## Test plan

- Ran `nix flake update nixpkgs` to update the unstable input.
- Ran `nix eval .#packages.x86_64-linux --json` and verified full evaluation succeeds with no errors (only deprecation warnings for xorg renames and buildRustPackage).

## Rollout

- [ ] This is fully backward and forward compatible

This should be backward compatible. Existing module IDs are preserved via the upgrade map. Python 3.10 and 3.11 users will still get working modules from `pkgs-25_05`.

~ written by Zerg 👾