### PR TITLE
Bump to latest unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768364046,
-        "narHash": "sha256-PDFfpswLiuG/DcadTBb7dEfO3jX1fcGlCD4ZKSkC0M8=",
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ea30586ee015f37f38783006a9bc9e4aa64d7d61",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
         "type": "github"
       },
       "original": {
@@ -242,6 +242,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-25_11": {
+      "locked": {
+        "lastModified": 1773814637,
+        "narHash": "sha256-GNU+ooRmrHLfjlMsKdn0prEKVa0faVanm0jrgu1J/gY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fea3b367d61c1a6592bc47c72f40a9f3e6a53e96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -328,6 +344,7 @@
         "nixpkgs-23_05": "nixpkgs-23_05",
         "nixpkgs-24_11": "nixpkgs-24_11",
         "nixpkgs-25_05": "nixpkgs-25_05",
+        "nixpkgs-25_11": "nixpkgs-25_11",
         "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-staging": "nixpkgs-staging",
         "prybar": "prybar",

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   inputs.nixpkgs-23_05.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.nixpkgs-24_11.url = "github:nixos/nixpkgs/nixos-24.11";
   inputs.nixpkgs-25_05.url = "github:nixos/nixpkgs/nixos-25.05";
+  inputs.nixpkgs-25_11.url = "github:nixos/nixpkgs/nixos-25.11";
   inputs.nixpkgs-master.url = "github:nixos/nixpkgs/master";
   inputs.nixpkgs-staging.url = "github:nixos/nixpkgs/staging-next";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
@@ -19,7 +20,7 @@
   inputs.replit-rtld-loader.url = "github:replit/replit_rtld_loader";
   inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, nixpkgs-23_05, nixpkgs-24_11, nixpkgs-25_05, nixpkgs-master, nixpkgs-staging, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
+  outputs = { self, nixpkgs, nixpkgs-23_05, nixpkgs-24_11, nixpkgs-25_05, nixpkgs-25_11, nixpkgs-master, nixpkgs-staging, prybar, java-language-server, nil, fenix, replit-rtld-loader, ... }:
     let
       mkPkgs = nixpkgs-spec: system: import nixpkgs-spec {
         inherit system;
@@ -40,6 +41,7 @@
       pkgs-23_05 = mkPkgs nixpkgs-23_05 "x86_64-linux";
       pkgs-24_11 = mkPkgs nixpkgs-24_11 "x86_64-linux";
       pkgs-25_05 = mkPkgs nixpkgs-25_05 "x86_64-linux";
+      pkgs-25_11 = mkPkgs nixpkgs-25_11 "x86_64-linux";
       # TODO: once nodejs update lands in unstable, switch to that
       pkgs-master = mkPkgs nixpkgs-master "x86_64-linux";
       pkgs-staging = mkPkgs nixpkgs-staging "x86_64-linux";
@@ -110,7 +112,7 @@
       };
       devShells.x86_64-linux.default = pkgs.mkShell {
         packages = with pkgs; [
-          python310
+          pkgs-25_11.python310
           pigz
           coreutils
           findutils
@@ -125,6 +127,7 @@
         inherit pkgs-23_05;
         inherit pkgs-24_11;
         inherit pkgs-25_05;
+        inherit pkgs-25_11;
         inherit pkgs-master;
         inherit pkgs-staging;
       }

--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -2,6 +2,7 @@
 , pkgs-23_05
 , pkgs-24_11
 , pkgs-25_05
+, pkgs-25_11
 , pkgs-master
 , pkgs-staging
 , ...
@@ -30,8 +31,8 @@ let
       pypkgs = pkgs-24_11.python39Packages;
     })
     (import ./python {
-      python = pkgs.python310;
-      pypkgs = pkgs.python310Packages;
+      python = pkgs-25_11.python310;
+      pypkgs = pkgs-25_11.python310Packages;
     })
     (import ./python {
       python = pkgs.python311;


### PR DESCRIPTION
Why
===

My main reason was to get the latest version of pnpm, current version we're on has some bugs

What changed
============

- Update flake to latest unstable
- Add pkgs-25_11 in order to pin python310 which is no longer available on unstable

Test plan
=========
modulit

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
