### PR TITLE
Constrain TypeScript language server defaults

### DIFF
--- a/pkgs/modules/typescript-language-server/default.nix
+++ b/pkgs/modules/typescript-language-server/default.nix
@@ -17,6 +17,8 @@ in
     start = "${typescript-language-server}/bin/typescript-language-server --stdio";
 
     initializationOptions = {
+      disableAutomaticTypingAcquisition = true;
+      maxTsServerMemory = 1536;
       tsserver.fallbackPath = "${nodepkgs.typescript}/lib/node_modules/typescript/lib";
     };
 


### PR DESCRIPTION
Why
===

We found microVMs where TypeScript language server subprocesses (`tsserver` and `typingsInstaller`) could consume multiple GiB of memory and contribute to system-side memory pressure. The matching goval PR contains pid1-side cgroup containment; this PR puts TypeScript-specific language-server defaults in the module that owns the language-server config.

What changed
============

- Set `disableAutomaticTypingAcquisition = true` for `typescript-language-server` to avoid automatic `@types/*` discovery/install work by default.
- Set `maxTsServerMemory = 1536` to cap the TypeScript server V8 old-space budget.
- Left the existing `tsserver.fallbackPath` unchanged.

Test plan
=========

- `nix fmt .`
- `nix eval .#activeModules.typescript-language-server --json`
- `nix build .#typescript-language-server --no-link`

Rollout
=======

- [x] This is fully backward and forward compatible

This is safe to revert. Reverting restores the previous TypeScript language-server initialization options.

~ written by Zerg :space_invader: ([elite-medic-8365](https://zerg.zergrush.dev/chat?id=elite-medic-8365))