### PR TITLE
databricks-cli: switch to replit/databricks-cli fork

### DIFF
--- a/pkgs/modules/databricks-cli/default.nix
+++ b/pkgs/modules/databricks-cli/default.nix
@@ -1,19 +1,25 @@
 { pkgs, lib, ... }:
 
 let
-  version = "0.286.0";
+  # Replit fork of databricks/cli. Adds --concurrency and --retry-timeout
+  # flags to `databricks sync`. Based on upstream v0.290.2, the same release
+  # nixpkgs is on, so the test skip list below stays in sync with nixpkgs'.
+  # Source: https://github.com/replit/databricks-cli (replit-main branch)
+  upstreamVersion = "0.290.2";
+  rev = "4928653c0620fb73b20d57dda4a26a233c2546f1";
+  version = "${upstreamVersion}-replit-${builtins.substring 0 8 rev}";
   databricks-cli = pkgs.buildGoModule {
     pname = "databricks-cli";
     inherit version;
 
     src = pkgs.fetchFromGitHub {
-      owner = "databricks";
-      repo = "cli";
-      rev = "v${version}";
-      hash = "sha256-iCmxHjIYznqed6BMQKtuYHJNFPy+3XrNzSXfhtyzPJk=";
+      owner = "replit";
+      repo = "databricks-cli";
+      inherit rev;
+      hash = "sha256-wTceEtlE2EnOe2noUWTsN0DzMIJxV8yLvyQu2M3Ts8E=";
     };
 
-    vendorHash = "sha256-TNUI2VQVKnxTiKQg9Bj3qDK2w3oOjO0rdrtTlFIhTzA=";
+    vendorHash = "sha256-8PJ2M5L8DkL4ydtUQbw0wKvt+5rVYbOAAGvURkSMm/o=";
 
     excludedPackages = [
       "bundle/internal"
@@ -77,8 +83,8 @@ let
     meta = {
       description = "Databricks CLI";
       mainProgram = "databricks";
-      homepage = "https://github.com/databricks/cli";
-      changelog = "https://github.com/databricks/cli/releases/tag/v${version}";
+      homepage = "https://github.com/replit/databricks-cli";
+      changelog = "https://github.com/databricks/cli/releases/tag/v${upstreamVersion}";
       license = lib.licenses.databricks;
     };
   };


### PR DESCRIPTION
Why
===

Pid2's `databricks.ts` invokes `databricks sync` to upload Repl files to a Databricks Apps workspace. We've been hitting 502s mid-sync that surface as fatal errors because the upstream SDK's retry predicate covers 429/504 but not 502/503. We also want the option to dial in-flight upload concurrency.

The fork at `replit/databricks-cli` adds two flags to `databricks sync` (and `databricks bundle sync`):

- `--retry-timeout` (default 30s) — per-call deadline for retrying transient gateway errors (HTTP 502/503/504), implemented with the SDK's `retries.Poll`.
- `--concurrency` (default 5) — replaces the hardcoded 20 in-flight request limit.

Fork branch: https://github.com/replit/databricks-cli/tree/replit-main
Upstream PR (merged): https://github.com/replit/databricks-cli/pull/1
Slack thread: https://replit.slack.com/archives/C0A2Z9042FR/p1778082184841149

What changed
============

- Repoint `src` from `databricks/cli` v0.286.0 → `replit/databricks-cli` `replit-main` at commit `4928653c`. The branch is upstream `v0.290.2` + the 1 Replit commit. Version string is `0.290.2-replit-4928653c`.
- Update source `hash` and `vendorHash`. Vendor hash is identical to nixpkgs' v0.290.2 entry (the Replit commit doesn't add new Go dependencies).
- Update `meta.homepage` to the fork; keep `meta.changelog` pointing at upstream tags.
- Pin to v0.290.2 (the same release nixpkgs is on at https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/da/databricks-cli/package.nix) so the `checkFlags` skip list stays identical to nixpkgs', mirroring established practice. v0.291+ adds an SDK host-metadata resolver that's awkward to test in the nix sandbox; bumping past it is a separate change.

Test plan
=========

```
$ nix build '.#activeModules.databricks-cli' '.#activeDeploymentModules.databricks-cli'
# both targets build clean, including the upstream test phase

$ databricks --version
Databricks CLI v0.290.2-replit-4928653c

$ databricks sync --help | grep -E "concurrency|retry-timeout"
      --concurrency int          maximum number of concurrent in-flight requests during sync (default 5)
      --retry-timeout duration   per-call deadline for retrying transient gateway errors (HTTP 502/503/504) (default 30s)
```

135 test packages run in the nix sandbox during `nix build`, including `libs/sync` (covers the new retry helper) and `cmd/sync` (covers the new flags). 0 failures. The `checkFlags` skip list is unchanged from the original PR (#477) and mirrors nixpkgs upstream.

Rollout
=======

- [x] This is fully backward and forward compatible

The new flags have sane defaults, so existing callers (pid2's `databricks sync ...` invocation) get the new retry behaviour and concurrency=5 automatically without any pid2 change. To revert, change the pin back to upstream `databricks/cli` v0.286.0 with the original hashes.

Revertibility
=============

Safe to revert. Pure module pin change with no migrations or persistent state.

~ written by Zerg :space_invader: ([wp-7918444a](https://zerg.zergrush.dev/chat?id=wp-7918444a))