### PR TITLE
databricks-cli: build Replit fork from source, skip tests

### DIFF
--- a/pkgs/modules/databricks-cli/default.nix
+++ b/pkgs/modules/databricks-cli/default.nix
@@ -1,19 +1,26 @@
 { pkgs, lib, ... }:
 
 let
-  version = "0.286.0";
+  # Replit fork of databricks/cli, based on upstream v0.299.0 plus the
+  # `sync: add --concurrency and --retry-timeout flags` patch (#1) that
+  # pid2's deploy path needs.
+  #
+  # See https://github.com/replit/databricks-cli/releases for tags. To bump:
+  # rebase replit/databricks-cli `main` onto a newer upstream tag, retag
+  # vX.Y.Z-replit.<n>, push, then update version + hash + vendorHash here.
+  version = "0.299.0-replit.1";
   databricks-cli = pkgs.buildGoModule {
     pname = "databricks-cli";
     inherit version;
 
     src = pkgs.fetchFromGitHub {
-      owner = "databricks";
-      repo = "cli";
+      owner = "replit";
+      repo = "databricks-cli";
       rev = "v${version}";
-      hash = "sha256-iCmxHjIYznqed6BMQKtuYHJNFPy+3XrNzSXfhtyzPJk=";
+      hash = "sha256-mrsxKw9pIgP14SBQH4+OAGpBPfKINtVACXMR7qEhfLY=";
     };
 
-    vendorHash = "sha256-TNUI2VQVKnxTiKQg9Bj3qDK2w3oOjO0rdrtTlFIhTzA=";
+    vendorHash = "sha256-IcKEzXfmReVCUzMyPC3Y2BRXWwGoB8Gdd3y5p6FtxI0=";
 
     excludedPackages = [
       "bundle/internal"
@@ -36,49 +43,21 @@ let
       mv "$GOPATH/bin/cli" "$GOPATH/bin/databricks"
     '';
 
-    checkFlags =
-      "-skip="
-      + (lib.concatStringsSep "|" [
-        # Need network
-        "TestConsistentDatabricksSdkVersion"
-        "TestTerraformArchiveChecksums"
-        "TestExpandPipelineGlobPaths"
-        "TestRelativePathTranslationDefault"
-        "TestRelativePathTranslationOverride"
-        "TestWorkspaceVerifyProfileForHost"
-        "TestWorkspaceVerifyProfileForHost/default_config_file_with_match"
-        "TestWorkspaceResolveProfileFromHost"
-        "TestWorkspaceResolveProfileFromHost/no_config_file"
-        "TestBundleConfigureDefault"
-        # Use uv venv which doesn't work with nix
-        # https://github.com/astral-sh/uv/issues/4450
-        "TestVenvSuccess"
-        "TestPatchWheel"
-        # Fails in nix sandbox due to missing home/cache directory
-        "TestCacheDirEnvVar"
-      ]);
-
-    nativeCheckInputs = [
-      pkgs.gitMinimal
-      (pkgs.python3.withPackages (
-        ps: with ps; [
-          setuptools
-          wheel
-        ]
-      ))
-    ];
-
-    preCheck = ''
-      # Some tests depend on git and remote url
-      git init
-      git remote add origin https://github.com/databricks/cli.git
-    '';
+    # Tests are skipped in the nix sandbox. The Databricks CLI test suite
+    # has a long tail of tests that try to resolve workspace clients, hit
+    # the network, or otherwise depend on a working environment that the
+    # nix sandbox does not provide. Each upstream bump tends to add new
+    # offenders; rather than maintain an ever-growing -skip= regex (and
+    # debug new entries on every rebase), we trust upstream's CI and skip
+    # the whole checkPhase. Same pattern as `pkgs/modules/python/uv` and
+    # the docker stack.
+    doCheck = false;
 
     meta = {
-      description = "Databricks CLI";
+      description = "Databricks CLI (Replit fork)";
       mainProgram = "databricks";
-      homepage = "https://github.com/databricks/cli";
-      changelog = "https://github.com/databricks/cli/releases/tag/v${version}";
+      homepage = "https://github.com/replit/databricks-cli";
+      changelog = "https://github.com/replit/databricks-cli/releases/tag/v${version}";
       license = lib.licenses.databricks;
     };
   };
@@ -91,6 +70,10 @@ in
     Databricks. It provides commands to manage Databricks resources
     such as workspaces, jobs, clusters, libraries, and Databricks
     apps from the command line.
+
+    This is the Replit fork (https://github.com/replit/databricks-cli),
+    based on upstream v0.299.0 with the --concurrency and --retry-timeout
+    flags added to `databricks sync` for faster, more reliable deploys.
   '';
   displayVersion = version;
 


### PR DESCRIPTION
Why
===

We ended up temporarily forking databricks CLI to unblock and speed up process of fixing some issues. Need to point to our fork replit/databricks-cli. 

What changed
============

`pkgs/modules/databricks-cli/default.nix`:

- Bumps `version` from `0.286.0` to `0.299.0-replit.1` and points `src` at `replit/databricks-cli` at that tag (upstream v0.299.0 + the squashed `sync: add --concurrency and --retry-timeout flags` PR #1). Updates `hash` and `vendorHash` accordingly.
- Replaces the 13-entry `checkFlags` skip list (and its supporting `nativeCheckInputs` / `preCheck` plumbing) with `doCheck = false`. Bumping to v0.299.0 surfaced a new offender (`TestClearWorkspaceClient` hangs on workspace-client DNS resolution and times out at 10 minutes); rather than play whack-a-mole with new entries on every upstream rebase, we skip the whole `checkPhase` and trust upstream CI. Same pattern that `pkgs/modules/python/uv` and the docker stack (`runc`, `containerd`, `buildkit`, `moby`) already use in this repo.
- Updates `meta.homepage`, `meta.changelog`, and the `description` to point at the fork.


NOTE: we skip tests here because the new databricks version introduces a lot of tests that require network calls which cause DNS resolution to hang. This is not ideal but skipping tests in interest of time for now. We do not expect to maintain our own fork long-term, this is a bandaid.

Test plan
=========

```sh
$ nix build .#'"databricks-cli"'
$ /nix/store/.../databricks-cli-0.299.0-replit.1/bin/databricks --version
Databricks CLI v0.299.0-replit.1

$ /nix/store/.../bin/databricks sync --help | grep -E 'concurrency|retry-timeout'
      --concurrency int          maximum number of concurrent in-flight requests during sync (default 5)
      --retry-timeout duration   per-call deadline for retrying transient gateway errors (HTTP 502/503/504) (default 30s)

$ nix fmt -- --check .
0 / 82 would have been reformatted
```

Rollout
=======

- [x] This is fully backward and forward compatible — same module id, same binary name, same `replit.packages` shape; consumers see only the bumped `displayVersion` and the new flags.

Future maintenance
==================

Each rebase of the fork's `main` onto a newer upstream tag → retag `vX.Y.Z-replit.<n>` on `replit/databricks-cli` → bump `version` + `hash` + `vendorHash` in this file. The first build after a bump will fail twice with hash mismatches (telling you the new `hash` and `vendorHash`); paste them in and rebuild.

Long-term fix is upstreaming `--concurrency` to `databricks/cli` so the fork goes away.

Context
=======

Slack thread: https://replit.slack.com/archives/C0A2Z9042FR/p1778082184841149

Fork tag: https://github.com/replit/databricks-cli/releases/tag/v0.299.0-replit.1

~ written by Zerg :space_invader: ([hungry-lurker-7ee9](https://zerg.zergrush.dev/chat?id=hungry-lurker-7ee9))