### PR TITLE
Replace Node 18 with Node 24 in the development bundle

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,9 +10,9 @@ let
   dev-module-ids = [
     "python-3.10"
     "python-3.11"
-    "nodejs-18"
     "nodejs-20"
     "nodejs-22"
+    "nodejs-24"
     "go-1.21"
     "docker"
     "replit"


### PR DESCRIPTION
Why
===

Production repl-runner cells use the full Nixmodules `b024b55` artifact, where Node 24 is available. Goval's reduced local development bundle tops out at Node 22, so agent toolchain resolution behaves differently locally.

What changed
============

Replaces EOL `nodejs-18` with `nodejs-24` in the reduced development bundle. This brings local toolchain selection in line with production without growing the bundle.

Test plan
=========

- `nix build .#bundle-squashfs --print-out-paths --no-link`
- Confirm the generated registry contains `nodejs-24` and no longer contains `nodejs-18`.
- Confirm the artifact contains `nodejs-24.13.0-wrapped/bin/node`.
- The artifact decreased from 1.4 GiB to 1.3 GiB.
- `nix fmt .`

Rollout
=======

This only changes reduced development artifacts. Production full bundles retain every module. Safe to revert.

- [ ] This is fully backward and forward compatible

<!-- zjj-stack:begin -->
#### Stack
- #484 prydonius/include-node-24-in-the-wkmrtuzwyqvm 👈

[Review in PRZerg](https://zerg.zergrush.dev/prs/review/replit/nixmodules/484)
<!-- zjj-stack:end -->

~ written by Zerg :space_invader: ([veteran-vulture-6afc](https://zerg.zergrush.dev/chat?id=veteran-vulture-6afc))
