### PR TITLE
Add Pup CLI Nix module

### DIFF
--- a/pkgs/modules/default.nix
+++ b/pkgs/modules/default.nix
@@ -159,6 +159,7 @@ let
     (import ./replit-rtld-loader)
     (import ./graphite-cli)
     (import ./databricks-cli)
+    (import ./pup)
   ];
 
   activeModules = listToAttrs (

--- a/pkgs/modules/pup/default.nix
+++ b/pkgs/modules/pup/default.nix
@@ -1,0 +1,67 @@
+{ pkgs, lib, ... }:
+
+let
+  version = "0.64.0";
+
+  pup = pkgs.stdenv.mkDerivation (finalAttrs: {
+    pname = "pup";
+    inherit version;
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/DataDog/pup/releases/download/v${finalAttrs.version}/pup_${finalAttrs.version}_Linux_x86_64.tar.gz";
+      hash = "sha256-Qj03X+I6WaYzahcxw3128JwBbSfKhkndraehL5b3iok=";
+    };
+
+    nativeBuildInputs = [
+      pkgs.autoPatchelfHook
+      pkgs.makeWrapper
+    ];
+
+    buildInputs = [ pkgs.stdenv.cc.cc.lib ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontStrip = true;
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 pup "$out/libexec/pup"
+      install -Dm644 ${./pup-wrapper.mjs} "$out/libexec/pup-wrapper.mjs"
+
+      makeWrapper "${pkgs.nodejs_22}/bin/node" "$out/bin/pup" \
+        --add-flags "$out/libexec/pup-wrapper.mjs" \
+        --set PUP_REAL_BINARY "$out/libexec/pup"
+
+      runHook postInstall
+    '';
+
+    doInstallCheck = true;
+
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      HOME="$TMPDIR" "$out/bin/pup" --help >/dev/null
+
+      runHook postInstallCheck
+    '';
+
+    meta = {
+      description = "AI-agent-ready CLI for Datadog";
+      homepage = "https://github.com/DataDog/pup";
+      changelog = "https://github.com/DataDog/pup/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.asl20;
+      mainProgram = "pup";
+      platforms = [ "x86_64-linux" ];
+    };
+  });
+in
+{
+  id = "pup";
+  name = "Pup CLI";
+  displayVersion = version;
+  description = "Pup provides an AI-agent-ready command-line interface to Datadog.";
+
+  replit.packages = [ pup ];
+}

--- a/pkgs/modules/pup/pup-wrapper.mjs
+++ b/pkgs/modules/pup/pup-wrapper.mjs
@@ -1,0 +1,27 @@
+import {spawn} from 'node:child_process'
+
+const realPup = process.env.PUP_REAL_BINARY
+
+if (!realPup) {
+  process.stderr.write('PUP_REAL_BINARY is not set\n')
+  process.exit(1)
+}
+
+const child = spawn(realPup, process.argv.slice(2), {
+  env: process.env,
+  stdio: 'inherit',
+})
+
+child.on('error', (error) => {
+  process.stderr.write(`Failed to start pup: ${error.message}\n`)
+  process.exit(1)
+})
+
+child.on('close', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+
+  process.exit(code ?? 1)
+})


### PR DESCRIPTION
Why
===

We need a reusable `pup` installation before its Datadog CLI wrapper can authenticate through OpenInt. This PR provides that package foundation without adding proxy credentials or environment-specific configuration.

References DEV-1947

What changed
============

Adds Pup CLI v0.64.0 as a reusable Replit Nix module. The module verifies and patches the upstream binary, exposes it through a transparent Node entrypoint, and reserves `libexec/pup` for the untouched executable that the follow-up OpenInt wrapper will launch.

Test plan
=========

- `nix eval .#activeModules --json | jq -e 'has("pup")'`
- `nix eval .#activeDeploymentModules --json | jq -e 'has("pup")'`
- `nix build .#pup`
- `"$(jq -r '.env.PATH' result)/pup" --version` returned `pup 0.64.0`
- `./scripts/ci_check.sh`
- `git diff --cached --check`

Rollout
=======

- [ ] This is fully backward and forward compatible

No rollout action is required. The module is inactive until an environment selects `pup`.

## Stack

Merge bottom-to-top. Each PR is based on the one below it.

- #486 authenticate the wrapper through the OpenInt CLI proxy (2/2)
- #485 add the Pup CLI Nix module (1/2) 👈 this PR

~ written by Zerg :space_invader: ([wp-322d08e4](https://zerg.zergrush.dev/chat?id=wp-322d08e4))

